### PR TITLE
linux-generic: debug: enable helper use from c++ programs

### DIFF
--- a/platform/linux-generic/include/odp/api/debug.h
+++ b/platform/linux-generic/include/odp/api/debug.h
@@ -19,17 +19,36 @@ extern "C" {
 
 #include <odp/api/spec/debug.h>
 
-#if defined(__GNUC__) && !defined(__clang__)
-
-#if __GNUC__ < 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ < 6))
-
 /**
- * @internal _Static_assert was only added in GCC 4.6. Provide a weak replacement
- * for previous versions.
+ * @internal _Static_assert was only added in GCC 4.6 and the C++ version
+ * static_assert for g++ 6 and above.  Provide a weak replacement for previous
+ * versions.
  */
-#define _Static_assert(e, s) (extern int (*static_assert_checker(void)) \
-	[sizeof(struct { unsigned int error_if_negative:(e) ? 1 : -1; })])
+#define _odp_merge(a, b) a##b
+#define _odp_label(a) _odp_merge(_ODP_SASSERT_, a)
+#define _ODP_SASSERT _odp_label(__COUNTER__)
+#define _ODP_SASSERT_ENUM(e) { _ODP_SASSERT = 1 / !!(e) }
+#define _odp_static_assert(e, s) enum _ODP_SASSERT_ENUM(e)
 
+#if defined(__clang__)
+#if defined(__cplusplus)
+#if !__has_feature(cxx_static_assert) && !defined(static_assert)
+#define	static_assert(e, s) _odp_static_assert(e, s)
+#endif
+#elif !__has_feature(c_static_assert) && !defined(_Static_assert)
+#define _Static_assert(e, s) _odp_static_assert(e, s)
+#endif
+
+#elif defined(__GNUC__)
+#if __GNUC__ < 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ < 6)) ||	\
+	(__GNUC__ < 6 && defined(__cplusplus))
+#if defined(__cplusplus)
+#if !defined(static_assert)
+#define	static_assert(e, s) _odp_static_assert(e, s)
+#endif
+#elif !defined(_Static_assert)
+#define _Static_assert(e, s) _odp_static_assert(e, s)
+#endif
 #endif
 
 #endif
@@ -39,9 +58,11 @@ extern "C" {
  * if condition 'cond' is false. Macro definition is empty when compiler is not
  * supported or the compiler does not support static assertion.
  */
-#define ODP_STATIC_ASSERT(cond, msg)  _Static_assert(cond, msg)
+#ifndef __cplusplus
+#define ODP_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
 
-#ifdef __cplusplus
+#else
+#define ODP_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
 }
 #endif
 

--- a/test/common_plat/miscellaneous/odp_api_from_cpp.cpp
+++ b/test/common_plat/miscellaneous/odp_api_from_cpp.cpp
@@ -1,10 +1,9 @@
 #include <cstdio>
 #include <odp_api.h>
-#include <odp/helper/threads.h>
+#include <odp/helper/odph_api.h>
 
 int main(int argc ODP_UNUSED, const char *argv[] ODP_UNUSED)
 {
-
 	printf("\tODP API version: %s\n", odp_version_api_str());
 	printf("\tODP implementation version: %s\n", odp_version_impl_str());
 


### PR DESCRIPTION
The ODP_STATIC_ASSERT() macro expands to _Static_assert(), however when
used in C++ programs this needs to expand to static_assert().

This resolves Bug https://bugs.linaro.org/show_bug.cgi?id=2852

Reported-by: Moshe Tubul <moshe.tubul@firmitas-cs.com>
Signed-off-by: Bill Fischofer <bill.fischofer@linaro.org>