### PR TITLE
test: tm: use script instead of binary when calling traffic manager test

### DIFF
--- a/test/linux-generic/Makefile.am
+++ b/test/linux-generic/Makefile.am
@@ -30,7 +30,7 @@ TESTS = validation/api/pktio/pktio_run.sh \
 	$(ALL_API_VALIDATION_DIR)/thread/thread_main$(EXEEXT) \
 	$(ALL_API_VALIDATION_DIR)/time/time_main$(EXEEXT) \
 	$(ALL_API_VALIDATION_DIR)/timer/timer_main$(EXEEXT) \
-	$(ALL_API_VALIDATION_DIR)/traffic_mngr/traffic_mngr_main$(EXEEXT) \
+	$(ALL_API_VALIDATION_DIR)/traffic_mngr/traffic_mngr.sh \
 	$(ALL_API_VALIDATION_DIR)/shmem/shmem_main$(EXEEXT) \
 	$(ALL_API_VALIDATION_DIR)/system/system_main$(EXEEXT) \
 	ring/ring_main$(EXEEXT)


### PR DESCRIPTION
Since 51e3b8776b78180741fa57a621f9d13b9ae8bbfb tm test received wrapper
script checking if it is run under Travis CI. However linux-generic
testsuite was not updated to call script instead of binary, resulting in
test failures.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>