### PR TITLE
[PATCH API-NEXT v3] api: ipsec: factor out IP protocol version parameter

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -569,6 +569,18 @@ typedef enum odp_ipsec_pipeline_t {
 } odp_ipsec_pipeline_t;
 
 /**
+ * IPSEC header type
+ */
+typedef enum odp_ipsec_ip_version_t {
+	/** Header is IPv4 */
+	ODP_IPSEC_IPV4 = 4,
+
+	/** Header is IPv6 */
+	ODP_IPSEC_IPV6 = 6
+
+} odp_ipsec_ip_version_t;
+
+/**
  * IPSEC Security Association (SA) parameters
  */
 typedef struct odp_ipsec_sa_param_t {
@@ -613,11 +625,8 @@ typedef struct odp_ipsec_sa_param_t {
 	 *  only in ODP_IPSEC_LOOKUP_DSTADDR_SPI lookup mode. */
 	struct {
 		/** Select IP version
-		 *
-		 *  4:   IPv4
-		 *  6:   IPv6
 		 */
-		uint8_t ip_version;
+		odp_ipsec_ip_version_t ip_version;
 
 		/** IP destination address (NETWORK ENDIAN) */
 		void    *dst_addr;


### PR DESCRIPTION
Both tunnel and lookup parameters refer IP protocol version. Factor that
out as an IPsec enum used in both places.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>