### PR TITLE
[PATCH API-NEXT v4] Update Linux crypto implementation to support recent API additions

### DIFF
--- a/example/ipsec/odp_ipsec_cache.c
+++ b/example/ipsec/odp_ipsec_cache.c
@@ -100,6 +100,7 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 		params.auth_alg = auth_sa->alg.u.auth;
 		params.auth_key.data = auth_sa->key.data;
 		params.auth_key.length = auth_sa->key.length;
+		params.auth_digest_len = auth_sa->icv_len;
 		mode = auth_sa->mode;
 	} else {
 		params.auth_alg = ODP_AUTH_ALG_NULL;

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -267,10 +267,8 @@ odp_crypto_alg_err_t aes_gcm_encrypt(odp_crypto_op_param_t *param,
 {
 	uint8_t *data  = odp_packet_data(param->out_pkt);
 	uint32_t plain_len   = param->cipher_range.length;
-	uint8_t *aad_head = data + param->auth_range.offset;
-	uint8_t *aad_tail = data + param->cipher_range.offset +
-		param->cipher_range.length;
-	uint32_t auth_len = param->auth_range.length;
+	const uint8_t *aad_head = param->aad.ptr;
+	uint32_t aad_len = param->aad.length;
 	unsigned char iv_enc[AES_BLOCK_SIZE];
 	void *iv_ptr;
 	uint8_t *tag = data + param->hash_result_offset;
@@ -281,12 +279,6 @@ odp_crypto_alg_err_t aes_gcm_encrypt(odp_crypto_op_param_t *param,
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
-
-	/* All cipher data must be part of the authentication */
-	if (param->auth_range.offset > param->cipher_range.offset ||
-	    param->auth_range.offset + auth_len <
-	    param->cipher_range.offset + plain_len)
-		return ODP_CRYPTO_ALG_ERR_DATA_SIZE;
 
 	/*
 	 * Create a copy of the IV.  The DES library modifies IV
@@ -305,23 +297,16 @@ odp_crypto_alg_err_t aes_gcm_encrypt(odp_crypto_op_param_t *param,
 	EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv_enc);
 
 	/* Authenticate header data (if any) without encrypting them */
-	if (aad_head < plaindata) {
+	if (aad_len > 0)
 		EVP_EncryptUpdate(ctx, NULL, &cipher_len,
-				  aad_head, plaindata - aad_head);
-	}
+				  aad_head, aad_len);
 
 	EVP_EncryptUpdate(ctx, plaindata, &cipher_len,
 			  plaindata, plain_len);
-	cipher_len = plain_len;
-
-	/* Authenticate footer data (if any) without encrypting them */
-	if (aad_head + auth_len > plaindata + plain_len) {
-		EVP_EncryptUpdate(ctx, NULL, NULL, aad_tail,
-				  auth_len - (aad_tail - aad_head));
-	}
 
 	EVP_EncryptFinal_ex(ctx, plaindata + cipher_len, &cipher_len);
-	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, tag);
+	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG,
+			    session->p.auth_digest_len, tag);
 
 	return ODP_CRYPTO_ALG_ERR_NONE;
 }
@@ -332,10 +317,8 @@ odp_crypto_alg_err_t aes_gcm_decrypt(odp_crypto_op_param_t *param,
 {
 	uint8_t *data  = odp_packet_data(param->out_pkt);
 	uint32_t cipher_len   = param->cipher_range.length;
-	uint8_t *aad_head = data + param->auth_range.offset;
-	uint8_t *aad_tail = data + param->cipher_range.offset +
-		param->cipher_range.length;
-	uint32_t auth_len = param->auth_range.length;
+	const uint8_t *aad_head = param->aad.ptr;
+	uint32_t aad_len = param->aad.length;
 	unsigned char iv_enc[AES_BLOCK_SIZE];
 	void *iv_ptr;
 	uint8_t *tag   = data + param->hash_result_offset;
@@ -346,12 +329,6 @@ odp_crypto_alg_err_t aes_gcm_decrypt(odp_crypto_op_param_t *param,
 		iv_ptr = session->cipher.iv_data;
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
-
-	/* All cipher data must be part of the authentication */
-	if (param->auth_range.offset > param->cipher_range.offset ||
-	    param->auth_range.offset + auth_len <
-	    param->cipher_range.offset + cipher_len)
-		return ODP_CRYPTO_ALG_ERR_DATA_SIZE;
 
 	/*
 	 * Create a copy of the IV.  The DES library modifies IV
@@ -368,25 +345,18 @@ odp_crypto_alg_err_t aes_gcm_decrypt(odp_crypto_op_param_t *param,
 
 	EVP_DecryptInit_ex(ctx, NULL, NULL, NULL, iv_enc);
 
-	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, tag);
+	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG,
+			    session->p.auth_digest_len, tag);
 
 	/* Authenticate header data (if any) without encrypting them */
-	if (aad_head < cipherdata) {
+	if (aad_len > 0)
 		EVP_DecryptUpdate(ctx, NULL, &plain_len,
-				  aad_head, cipherdata - aad_head);
-	}
+				  aad_head, aad_len);
 
 	EVP_DecryptUpdate(ctx, cipherdata, &plain_len,
 			  cipherdata, cipher_len);
-	plain_len = cipher_len;
 
-	/* Authenticate footer data (if any) without encrypting them */
-	if (aad_head + auth_len > cipherdata + cipher_len) {
-		EVP_DecryptUpdate(ctx, NULL, NULL, aad_tail,
-				  auth_len - (aad_tail - aad_head));
-	}
-
-	if (EVP_DecryptFinal_ex(ctx, cipherdata + cipher_len, &plain_len) <= 0)
+	if (EVP_DecryptFinal_ex(ctx, cipherdata + plain_len, &plain_len) <= 0)
 		return ODP_CRYPTO_ALG_ERR_ICV_CHECK;
 
 	return ODP_CRYPTO_ALG_ERR_NONE;
@@ -768,12 +738,14 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 	case ODP_AUTH_ALG_AES128_GCM:
 		if (param->cipher_alg == ODP_CIPHER_ALG_AES128_GCM)
 			aes_gcm = 1;
+		session->p.auth_digest_len = 128 / 8;
 		/* Fallthrough */
 #endif
 	case ODP_AUTH_ALG_AES_GCM:
 		/* AES-GCM requires to do both auth and
 		 * cipher at the same time */
-		if (param->cipher_alg == ODP_CIPHER_ALG_AES_GCM || aes_gcm) {
+		if ((param->cipher_alg == ODP_CIPHER_ALG_AES_GCM || aes_gcm) &&
+		    session->p.auth_digest_len == 128 / 8) {
 			session->auth.func = null_crypto_routine;
 			rc = 0;
 		} else {

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -52,10 +52,12 @@ static const odp_crypto_cipher_capability_t cipher_capa_aes_gcm[] = {
  * Keep sorted: first by digest length, then by key length
  */
 static const odp_crypto_auth_capability_t auth_capa_md5_hmac[] = {
-{.digest_len = 12, .key_len = 16, .aad_len = {.min = 0, .max = 0, .inc = 0} } };
+{.digest_len = 12, .key_len = 16, .aad_len = {.min = 0, .max = 0, .inc = 0} },
+{.digest_len = 16, .key_len = 16, .aad_len = {.min = 0, .max = 0, .inc = 0} } };
 
 static const odp_crypto_auth_capability_t auth_capa_sha256_hmac[] = {
-{.digest_len = 16, .key_len = 32, .aad_len = {.min = 0, .max = 0, .inc = 0} } };
+{.digest_len = 16, .key_len = 32, .aad_len = {.min = 0, .max = 0, .inc = 0} },
+{.digest_len = 32, .key_len = 32, .aad_len = {.min = 0, .max = 0, .inc = 0} } };
 
 static const odp_crypto_auth_capability_t auth_capa_aes_gcm[] = {
 {.digest_len = 16, .key_len = 0, .aad_len = {.min = 8, .max = 12, .inc = 4} } };

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -522,7 +522,6 @@ static int process_des_param(odp_crypto_generic_session_t *session)
 }
 
 static int process_auth_param(odp_crypto_generic_session_t *session,
-			      uint32_t bits,
 			      uint32_t key_length,
 			      const EVP_MD *evp_md)
 {
@@ -535,7 +534,9 @@ static int process_auth_param(odp_crypto_generic_session_t *session,
 	session->auth.evp_md = evp_md;
 
 	/* Number of valid bytes */
-	session->auth.bytes = bits / 8;
+	session->auth.bytes = session->p.auth_digest_len;
+	if (session->auth.bytes < (unsigned)EVP_MD_size(evp_md) / 2)
+		return -1;
 
 	/* Convert keys */
 	session->auth.key_length = key_length;
@@ -745,17 +746,21 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 		session->auth.func = null_crypto_routine;
 		rc = 0;
 		break;
-	case ODP_AUTH_ALG_MD5_HMAC:
 #if ODP_DEPRECATED_API
 	case ODP_AUTH_ALG_MD5_96:
+		session->p.auth_digest_len = 96 / 8;
+		/* Fallthrough */
 #endif
-		rc = process_auth_param(session, 96, 16, EVP_md5());
+	case ODP_AUTH_ALG_MD5_HMAC:
+		rc = process_auth_param(session, 16, EVP_md5());
 		break;
-	case ODP_AUTH_ALG_SHA256_HMAC:
 #if ODP_DEPRECATED_API
 	case ODP_AUTH_ALG_SHA256_128:
+		session->p.auth_digest_len = 128 / 8;
+		/* Fallthrough */
 #endif
-		rc = process_auth_param(session, 128, 32, EVP_sha256());
+	case ODP_AUTH_ALG_SHA256_HMAC:
+		rc = process_auth_param(session, 32, EVP_sha256());
 		break;
 #if ODP_DEPRECATED_API
 	case ODP_AUTH_ALG_AES128_GCM:

--- a/test/common_plat/performance/odp_crypto.c
+++ b/test/common_plat/performance/odp_crypto.c
@@ -209,7 +209,8 @@ static crypto_alg_config_t algs_config[] = {
 			.auth_key = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
-			}
+			},
+			.auth_digest_len = 96 / 8,
 		},
 		.hash_adjust = 12
 	},
@@ -221,7 +222,8 @@ static crypto_alg_config_t algs_config[] = {
 			.auth_key = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
-			}
+			},
+			.auth_digest_len = 96 / 8,
 		},
 		.hash_adjust = 12
 	},

--- a/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
@@ -201,6 +201,7 @@ static void alg_test(odp_crypto_op_t op,
 	ses_params.cipher_key = cipher_key;
 	ses_params.iv = ses_iv;
 	ses_params.auth_key = auth_key;
+	ses_params.auth_digest_len = digest_len;
 
 	rc = odp_crypto_session_create(&ses_params, &session, &status);
 	CU_ASSERT_FATAL(!rc);
@@ -620,7 +621,8 @@ void crypto_test_enc_alg_aes128_gcm(void)
 					  cipher_key.length, iv.length))
 			continue;
 		if (!check_auth_options(ODP_AUTH_ALG_AES_GCM,
-					auth_key.length, AES128_GCM_CHECK_LEN))
+					auth_key.length,
+					aes128_gcm_reference_tag_length[i]))
 			continue;
 
 		alg_test(ODP_CRYPTO_OP_ENCODE,
@@ -639,7 +641,7 @@ void crypto_test_enc_alg_aes128_gcm(void)
 			 aes128_gcm_reference_length[i],
 			 aes128_gcm_reference_ciphertext[i] +
 			 aes128_gcm_reference_length[i],
-			 AES128_GCM_CHECK_LEN);
+			 aes128_gcm_reference_tag_length[i]);
 	}
 }
 
@@ -664,7 +666,8 @@ void crypto_test_enc_alg_aes128_gcm_ovr_iv(void)
 					  cipher_key.length, iv.length))
 			continue;
 		if (!check_auth_options(ODP_AUTH_ALG_AES_GCM,
-					auth_key.length, AES128_GCM_CHECK_LEN))
+					auth_key.length,
+					aes128_gcm_reference_tag_length[i]))
 			continue;
 
 		alg_test(ODP_CRYPTO_OP_ENCODE,
@@ -683,7 +686,7 @@ void crypto_test_enc_alg_aes128_gcm_ovr_iv(void)
 			 aes128_gcm_reference_length[i],
 			 aes128_gcm_reference_ciphertext[i] +
 			 aes128_gcm_reference_length[i],
-			 AES128_GCM_CHECK_LEN);
+			 aes128_gcm_reference_tag_length[i]);
 	}
 }
 
@@ -714,7 +717,8 @@ void crypto_test_dec_alg_aes128_gcm(void)
 					  cipher_key.length, iv.length))
 			continue;
 		if (!check_auth_options(ODP_AUTH_ALG_AES_GCM,
-					auth_key.length, AES128_GCM_CHECK_LEN))
+					auth_key.length,
+					aes128_gcm_reference_tag_length[i]))
 			continue;
 
 		alg_test(ODP_CRYPTO_OP_DECODE,
@@ -728,12 +732,13 @@ void crypto_test_dec_alg_aes128_gcm(void)
 			 &aes128_gcm_cipher_range[i],
 			 &aes128_gcm_auth_range[i],
 			 aes128_gcm_reference_ciphertext[i],
-			 aes128_gcm_reference_length[i] + AES128_GCM_CHECK_LEN,
+			 aes128_gcm_reference_length[i] +
+			 aes128_gcm_reference_tag_length[i],
 			 aes128_gcm_reference_plaintext[i],
 			 aes128_gcm_reference_length[i],
 			 aes128_gcm_reference_ciphertext[i] +
 			 aes128_gcm_reference_length[i],
-			 AES128_GCM_CHECK_LEN);
+			 aes128_gcm_reference_tag_length[i]);
 
 		alg_test(ODP_CRYPTO_OP_DECODE,
 			 1,
@@ -746,11 +751,12 @@ void crypto_test_dec_alg_aes128_gcm(void)
 			 &aes128_gcm_cipher_range[i],
 			 &aes128_gcm_auth_range[i],
 			 aes128_gcm_reference_ciphertext[i],
-			 aes128_gcm_reference_length[i] + AES128_GCM_CHECK_LEN,
+			 aes128_gcm_reference_length[i] +
+			 aes128_gcm_reference_tag_length[i],
 			 aes128_gcm_reference_plaintext[i],
 			 aes128_gcm_reference_length[i],
 			 wrong_digest,
-			 AES128_GCM_CHECK_LEN);
+			 aes128_gcm_reference_tag_length[i]);
 	}
 }
 
@@ -779,7 +785,8 @@ void crypto_test_dec_alg_aes128_gcm_ovr_iv(void)
 					  cipher_key.length, iv.length))
 			continue;
 		if (!check_auth_options(ODP_AUTH_ALG_AES_GCM,
-					auth_key.length, AES128_GCM_CHECK_LEN))
+					auth_key.length,
+					aes128_gcm_reference_tag_length[i]))
 			continue;
 
 		alg_test(ODP_CRYPTO_OP_DECODE,
@@ -793,12 +800,13 @@ void crypto_test_dec_alg_aes128_gcm_ovr_iv(void)
 			 &aes128_gcm_cipher_range[i],
 			 &aes128_gcm_auth_range[i],
 			 aes128_gcm_reference_ciphertext[i],
-			 aes128_gcm_reference_length[i] + AES128_GCM_CHECK_LEN,
+			 aes128_gcm_reference_length[i] +
+			 aes128_gcm_reference_tag_length[i],
 			 aes128_gcm_reference_plaintext[i],
 			 aes128_gcm_reference_length[i],
 			 aes128_gcm_reference_ciphertext[i] +
 			 aes128_gcm_reference_length[i],
-			 AES128_GCM_CHECK_LEN);
+			 aes128_gcm_reference_tag_length[i]);
 
 		alg_test(ODP_CRYPTO_OP_DECODE,
 			 1,
@@ -811,11 +819,12 @@ void crypto_test_dec_alg_aes128_gcm_ovr_iv(void)
 			 &aes128_gcm_cipher_range[i],
 			 &aes128_gcm_auth_range[i],
 			 aes128_gcm_reference_ciphertext[i],
-			 aes128_gcm_reference_length[i] + AES128_GCM_CHECK_LEN,
+			 aes128_gcm_reference_length[i] +
+			 aes128_gcm_reference_tag_length[i],
 			 aes128_gcm_reference_plaintext[i],
 			 aes128_gcm_reference_length[i],
 			 wrong_digest,
-			 AES128_GCM_CHECK_LEN);
+			 aes128_gcm_reference_tag_length[i]);
 	}
 }
 
@@ -1004,7 +1013,7 @@ void crypto_test_gen_alg_hmac_md5(void)
 		auth_key.length = sizeof(hmac_md5_reference_key[i]);
 
 		if (!check_auth_options(ODP_AUTH_ALG_MD5_HMAC, auth_key.length,
-					HMAC_MD5_96_CHECK_LEN))
+					hmac_md5_reference_digest_length[i]))
 			continue;
 
 		alg_test(ODP_CRYPTO_OP_ENCODE,
@@ -1020,7 +1029,7 @@ void crypto_test_gen_alg_hmac_md5(void)
 			 hmac_md5_reference_length[i],
 			 NULL, 0,
 			 hmac_md5_reference_digest[i],
-			 HMAC_MD5_96_CHECK_LEN);
+			 hmac_md5_reference_digest_length[i]);
 	}
 }
 
@@ -1042,7 +1051,7 @@ void crypto_test_check_alg_hmac_md5(void)
 		auth_key.length = sizeof(hmac_md5_reference_key[i]);
 
 		if (!check_auth_options(ODP_AUTH_ALG_MD5_HMAC, auth_key.length,
-					HMAC_MD5_96_CHECK_LEN))
+					hmac_md5_reference_digest_length[i]))
 			continue;
 
 		alg_test(ODP_CRYPTO_OP_DECODE,
@@ -1058,7 +1067,7 @@ void crypto_test_check_alg_hmac_md5(void)
 			 hmac_md5_reference_length[i],
 			 NULL, 0,
 			 hmac_md5_reference_digest[i],
-			 HMAC_MD5_96_CHECK_LEN);
+			 hmac_md5_reference_digest_length[i]);
 
 		alg_test(ODP_CRYPTO_OP_DECODE,
 			 1,
@@ -1073,7 +1082,7 @@ void crypto_test_check_alg_hmac_md5(void)
 			 hmac_md5_reference_length[i],
 			 NULL, 0,
 			 wrong_digest,
-			 HMAC_MD5_96_CHECK_LEN);
+			 hmac_md5_reference_digest_length[i]);
 	}
 }
 
@@ -1106,7 +1115,7 @@ void crypto_test_gen_alg_hmac_sha256(void)
 
 		if (!check_auth_options(ODP_AUTH_ALG_SHA256_HMAC,
 					auth_key.length,
-					HMAC_SHA256_128_CHECK_LEN))
+					hmac_sha256_reference_digest_length[i]))
 			continue;
 
 		alg_test(ODP_CRYPTO_OP_ENCODE,
@@ -1122,7 +1131,7 @@ void crypto_test_gen_alg_hmac_sha256(void)
 			 hmac_sha256_reference_length[i],
 			 NULL, 0,
 			 hmac_sha256_reference_digest[i],
-			 HMAC_SHA256_128_CHECK_LEN);
+			 hmac_sha256_reference_digest_length[i]);
 	}
 }
 
@@ -1146,7 +1155,7 @@ void crypto_test_check_alg_hmac_sha256(void)
 
 		if (!check_auth_options(ODP_AUTH_ALG_SHA256_HMAC,
 					auth_key.length,
-					HMAC_SHA256_128_CHECK_LEN))
+					hmac_sha256_reference_digest_length[i]))
 			continue;
 
 		alg_test(ODP_CRYPTO_OP_DECODE,
@@ -1162,7 +1171,7 @@ void crypto_test_check_alg_hmac_sha256(void)
 			 hmac_sha256_reference_length[i],
 			 NULL, 0,
 			 hmac_sha256_reference_digest[i],
-			 HMAC_SHA256_128_CHECK_LEN);
+			 hmac_sha256_reference_digest_length[i]);
 
 		alg_test(ODP_CRYPTO_OP_DECODE,
 			 1,
@@ -1177,7 +1186,7 @@ void crypto_test_check_alg_hmac_sha256(void)
 			 hmac_sha256_reference_length[i],
 			 NULL, 0,
 			 wrong_digest,
-			 HMAC_SHA256_128_CHECK_LEN);
+			 hmac_sha256_reference_digest_length[i]);
 	}
 }
 

--- a/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
@@ -74,6 +74,8 @@ static void alg_test(odp_crypto_op_t op,
 		     odp_crypto_key_t auth_key,
 		     odp_packet_data_range_t *cipher_range,
 		     odp_packet_data_range_t *auth_range,
+		     uint8_t *aad,
+		     uint32_t aad_len,
 		     const uint8_t *plaintext,
 		     unsigned int plaintext_len,
 		     const uint8_t *ciphertext,
@@ -239,6 +241,9 @@ static void alg_test(odp_crypto_op_t op,
 	}
 	if (op_iv_ptr)
 		op_params.override_iv_ptr = op_iv_ptr;
+
+	op_params.aad.ptr = aad;
+	op_params.aad.length = aad_len;
 
 	op_params.hash_result_offset = plaintext_len;
 	if (0 != digest_len) {
@@ -472,6 +477,7 @@ void crypto_test_enc_alg_3des_cbc(void)
 			 ODP_AUTH_ALG_NULL,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 tdes_cbc_reference_plaintext[i],
 			 tdes_cbc_reference_length[i],
 			 tdes_cbc_reference_ciphertext[i],
@@ -508,6 +514,7 @@ void crypto_test_enc_alg_3des_cbc_ovr_iv(void)
 			 ODP_AUTH_ALG_NULL,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 tdes_cbc_reference_plaintext[i],
 			 tdes_cbc_reference_length[i],
 			 tdes_cbc_reference_ciphertext[i],
@@ -548,6 +555,7 @@ void crypto_test_dec_alg_3des_cbc(void)
 			 ODP_AUTH_ALG_NULL,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 tdes_cbc_reference_ciphertext[i],
 			 tdes_cbc_reference_length[i],
 			 tdes_cbc_reference_plaintext[i],
@@ -586,6 +594,7 @@ void crypto_test_dec_alg_3des_cbc_ovr_iv(void)
 			 ODP_AUTH_ALG_NULL,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 tdes_cbc_reference_ciphertext[i],
 			 tdes_cbc_reference_length[i],
 			 tdes_cbc_reference_plaintext[i],
@@ -636,6 +645,9 @@ void crypto_test_enc_alg_aes128_gcm(void)
 			 &aes128_gcm_cipher_range[i],
 			 &aes128_gcm_auth_range[i],
 			 aes128_gcm_reference_plaintext[i],
+			 aes128_gcm_cipher_range[i].offset -
+			 aes128_gcm_auth_range[i].offset,
+			 aes128_gcm_reference_plaintext[i],
 			 aes128_gcm_reference_length[i],
 			 aes128_gcm_reference_ciphertext[i],
 			 aes128_gcm_reference_length[i],
@@ -680,6 +692,9 @@ void crypto_test_enc_alg_aes128_gcm_ovr_iv(void)
 			 auth_key,
 			 &aes128_gcm_cipher_range[i],
 			 &aes128_gcm_auth_range[i],
+			 aes128_gcm_reference_plaintext[i],
+			 aes128_gcm_cipher_range[i].offset -
+			 aes128_gcm_auth_range[i].offset,
 			 aes128_gcm_reference_plaintext[i],
 			 aes128_gcm_reference_length[i],
 			 aes128_gcm_reference_ciphertext[i],
@@ -731,6 +746,9 @@ void crypto_test_dec_alg_aes128_gcm(void)
 			 auth_key,
 			 &aes128_gcm_cipher_range[i],
 			 &aes128_gcm_auth_range[i],
+			 aes128_gcm_reference_plaintext[i],
+			 aes128_gcm_cipher_range[i].offset -
+			 aes128_gcm_auth_range[i].offset,
 			 aes128_gcm_reference_ciphertext[i],
 			 aes128_gcm_reference_length[i] +
 			 aes128_gcm_reference_tag_length[i],
@@ -750,6 +768,9 @@ void crypto_test_dec_alg_aes128_gcm(void)
 			 auth_key,
 			 &aes128_gcm_cipher_range[i],
 			 &aes128_gcm_auth_range[i],
+			 aes128_gcm_reference_plaintext[i],
+			 aes128_gcm_cipher_range[i].offset -
+			 aes128_gcm_auth_range[i].offset,
 			 aes128_gcm_reference_ciphertext[i],
 			 aes128_gcm_reference_length[i] +
 			 aes128_gcm_reference_tag_length[i],
@@ -799,6 +820,9 @@ void crypto_test_dec_alg_aes128_gcm_ovr_iv(void)
 			 auth_key,
 			 &aes128_gcm_cipher_range[i],
 			 &aes128_gcm_auth_range[i],
+			 aes128_gcm_reference_plaintext[i],
+			 aes128_gcm_cipher_range[i].offset -
+			 aes128_gcm_auth_range[i].offset,
 			 aes128_gcm_reference_ciphertext[i],
 			 aes128_gcm_reference_length[i] +
 			 aes128_gcm_reference_tag_length[i],
@@ -818,6 +842,9 @@ void crypto_test_dec_alg_aes128_gcm_ovr_iv(void)
 			 auth_key,
 			 &aes128_gcm_cipher_range[i],
 			 &aes128_gcm_auth_range[i],
+			 aes128_gcm_reference_plaintext[i],
+			 aes128_gcm_cipher_range[i].offset -
+			 aes128_gcm_auth_range[i].offset,
 			 aes128_gcm_reference_ciphertext[i],
 			 aes128_gcm_reference_length[i] +
 			 aes128_gcm_reference_tag_length[i],
@@ -865,6 +892,7 @@ void crypto_test_enc_alg_aes128_cbc(void)
 			 ODP_AUTH_ALG_NULL,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 aes128_cbc_reference_plaintext[i],
 			 aes128_cbc_reference_length[i],
 			 aes128_cbc_reference_ciphertext[i],
@@ -901,6 +929,7 @@ void crypto_test_enc_alg_aes128_cbc_ovr_iv(void)
 			 ODP_AUTH_ALG_NULL,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 aes128_cbc_reference_plaintext[i],
 			 aes128_cbc_reference_length[i],
 			 aes128_cbc_reference_ciphertext[i],
@@ -941,6 +970,7 @@ void crypto_test_dec_alg_aes128_cbc(void)
 			 ODP_AUTH_ALG_NULL,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 aes128_cbc_reference_ciphertext[i],
 			 aes128_cbc_reference_length[i],
 			 aes128_cbc_reference_plaintext[i],
@@ -979,6 +1009,7 @@ void crypto_test_dec_alg_aes128_cbc_ovr_iv(void)
 			 ODP_AUTH_ALG_NULL,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 aes128_cbc_reference_ciphertext[i],
 			 aes128_cbc_reference_length[i],
 			 aes128_cbc_reference_plaintext[i],
@@ -1025,6 +1056,7 @@ void crypto_test_gen_alg_hmac_md5(void)
 			 ODP_AUTH_ALG_MD5_HMAC,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 hmac_md5_reference_plaintext[i],
 			 hmac_md5_reference_length[i],
 			 NULL, 0,
@@ -1063,6 +1095,7 @@ void crypto_test_check_alg_hmac_md5(void)
 			 ODP_AUTH_ALG_MD5_HMAC,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 hmac_md5_reference_plaintext[i],
 			 hmac_md5_reference_length[i],
 			 NULL, 0,
@@ -1078,6 +1111,7 @@ void crypto_test_check_alg_hmac_md5(void)
 			 ODP_AUTH_ALG_MD5_HMAC,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 hmac_md5_reference_plaintext[i],
 			 hmac_md5_reference_length[i],
 			 NULL, 0,
@@ -1127,6 +1161,7 @@ void crypto_test_gen_alg_hmac_sha256(void)
 			 ODP_AUTH_ALG_SHA256_HMAC,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 hmac_sha256_reference_plaintext[i],
 			 hmac_sha256_reference_length[i],
 			 NULL, 0,
@@ -1167,6 +1202,7 @@ void crypto_test_check_alg_hmac_sha256(void)
 			 ODP_AUTH_ALG_SHA256_HMAC,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 hmac_sha256_reference_plaintext[i],
 			 hmac_sha256_reference_length[i],
 			 NULL, 0,
@@ -1182,6 +1218,7 @@ void crypto_test_check_alg_hmac_sha256(void)
 			 ODP_AUTH_ALG_SHA256_HMAC,
 			 auth_key,
 			 NULL, NULL,
+			 NULL, 0,
 			 hmac_sha256_reference_plaintext[i],
 			 hmac_sha256_reference_length[i],
 			 NULL, 0,

--- a/test/common_plat/validation/api/crypto/test_vectors.h
+++ b/test/common_plat/validation/api/crypto/test_vectors.h
@@ -139,6 +139,8 @@ static uint8_t aes128_gcm_reference_iv[][AES128_GCM_IV_LEN] = {
 
 static uint32_t aes128_gcm_reference_length[] = { 84, 72, 72, 40};
 
+static uint32_t aes128_gcm_reference_tag_length[] = { 16, 16, 16, 16};
+
 static odp_packet_data_range_t aes128_gcm_cipher_range[] = {
 	{ .offset = 12, .length = 72 },
 	{ .offset = 8, .length = 64 },
@@ -306,6 +308,10 @@ static uint8_t hmac_md5_reference_digest[][HMAC_MD5_DIGEST_LEN] = {
 	  0xdb, 0xb8, 0xc7, 0x33, 0xf0, 0xe8, 0xb3, 0xf6 }
 };
 
+static uint32_t hmac_md5_reference_digest_length[] = {
+	12, 12, 12
+};
+
 static uint8_t hmac_sha256_reference_key[][HMAC_SHA256_KEY_LEN] = {
 	{ 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
 	  0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
@@ -348,6 +354,10 @@ static uint8_t hmac_sha256_reference_digest[][HMAC_SHA256_DIGEST_LEN] = {
 
 	{ 0x77, 0x3e, 0xa9, 0x1e, 0x36, 0x80, 0x0e, 0x46,
 	  0x85, 0x4d, 0xb8, 0xeb, 0xd0, 0x91, 0x81, 0xa7 }
+};
+
+static uint32_t hmac_sha256_reference_digest_length[] = {
+	16, 16, 16
 };
 
 #endif

--- a/test/common_plat/validation/api/crypto/test_vectors_len.h
+++ b/test/common_plat/validation/api/crypto/test_vectors_len.h
@@ -21,18 +21,15 @@
 #define AES128_GCM_IV_LEN         12
 #define AES128_GCM_MAX_DATA_LEN   106
 #define AES128_GCM_DIGEST_LEN     16
-#define AES128_GCM_CHECK_LEN      16
 
 /* HMAC-MD5 */
 #define HMAC_MD5_KEY_LEN        16
 #define HMAC_MD5_MAX_DATA_LEN   128
 #define HMAC_MD5_DIGEST_LEN     16
-#define HMAC_MD5_96_CHECK_LEN   12
 
 /* HMAC-SHA256 */
 #define HMAC_SHA256_KEY_LEN        32
 #define HMAC_SHA256_MAX_DATA_LEN   128
 #define HMAC_SHA256_DIGEST_LEN     32
-#define HMAC_SHA256_128_CHECK_LEN  16
 
 #endif


### PR DESCRIPTION
Support recently added auth_digest_length and aad parameters.

This depends on #23 (included as first two patches) and should be rebased after #23 gets merged into main and further into api-next.