### PR TITLE
[PATCH v1] linux-generic: crypto: don't leak sessions if creation fails

### DIFF
--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -678,6 +678,7 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 	if (session->p.iv.data) {
 		if (session->p.iv.length > MAX_IV_LEN) {
 			ODP_DBG("Maximum IV length exceeded\n");
+			free_session(session);
 			return -1;
 		}
 
@@ -724,6 +725,7 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 	/* Check result */
 	if (rc) {
 		*status = ODP_CRYPTO_SES_CREATE_ERR_INV_CIPHER;
+		free_session(session);
 		return -1;
 	}
 
@@ -763,6 +765,7 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 	/* Check result */
 	if (rc) {
 		*status = ODP_CRYPTO_SES_CREATE_ERR_INV_AUTH;
+		free_session(session);
 		return -1;
 	}
 


### PR DESCRIPTION
We should free allocated session in odp_crypto_session_create() error
paths, so that the session is not leaked.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>