### PR TITLE
[PATCH API-NEXT v1] api: ipsec: more capabilities

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -241,8 +241,17 @@ typedef struct odp_ipsec_capability_t {
 	 */
 	odp_support_t op_mode_async;
 
-	/** Inline IPSEC operation mode (ODP_IPSEC_OP_MODE_INLINE) support */
-	odp_support_t op_mode_inline;
+	/**
+	 * Inline inbound IPSEC operation mode (ODP_IPSEC_OP_MODE_INLINE)
+	 * support
+	 */
+	odp_support_t op_mode_inline_in;
+
+	/**
+	 * Inline outgoing IPSEC operation mode (ODP_IPSEC_OP_MODE_INLINE)
+	 * support
+	 */
+	odp_support_t op_mode_inline_out;
 
 	/** IP Authenticated Header (ODP_IPSEC_AH) support */
 	odp_support_t proto_ah;

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -244,6 +244,9 @@ typedef struct odp_ipsec_capability_t {
 	/** Inline IPSEC operation mode (ODP_IPSEC_OP_MODE_INLINE) support */
 	odp_support_t op_mode_inline;
 
+	/** IP Authenticated Header (ODP_IPSEC_AH) support */
+	odp_support_t proto_ah;
+
 	/**
 	 * Support of pipelined classification (ODP_IPSEC_PIPELINE_CLS) of
 	 *  resulting inbound packets


### PR DESCRIPTION
- Add AH support capability (as AH is optional in RFC 4301).
- Split INLINE capability into pair of in and out caps.