### PR TITLE
[PATCH v1] configure.ac: fix mcx16 vs clang check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -306,7 +306,8 @@ ODP_CFLAGS="$ODP_CFLAGS $ODP_CFLAGS_EXTRA"
 ##########################################################################
 # Check if compiler supports cmpxchng16 on x86-based architectures
 ##########################################################################
-if "${host}" == i?86* -o "${host}" == x86*; then
+case "${host}" in
+  i?86? | x86*)
   if test "${CC}" != "gcc" -o ${CC_VERSION_MAJOR} -ge 5; then
      my_save_cflags="$CFLAGS"
 
@@ -319,7 +320,8 @@ if "${host}" == i?86* -o "${host}" == x86*; then
   	    )
      CFLAGS="$my_save_cflags"
   fi
-fi
+  ;;
+esac
 
 ##########################################################################
 # Default include setup


### PR DESCRIPTION
Currently configure script outputs the following error on my sistem,
because the syntax is far from being standard. Use standard case/esac
instead.

./configure: line 23507: x86_64-pc-linux-gnu: command not found

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>