### PR TITLE
[PATCH API-NEXT v1] api: crypto: deprecate per-session IV

### DIFF
--- a/example/ipsec/odp_ipsec_cache.c
+++ b/example/ipsec/odp_ipsec_cache.c
@@ -86,13 +86,11 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 		params.cipher_alg  = cipher_sa->alg.u.cipher;
 		params.cipher_key.data  = cipher_sa->key.data;
 		params.cipher_key.length  = cipher_sa->key.length;
-		params.iv.data = entry->state.iv;
-		params.iv.length = cipher_sa->iv_len;
+		params.iv_length = cipher_sa->iv_len;
 		mode = cipher_sa->mode;
 	} else {
 		params.cipher_alg = ODP_CIPHER_ALG_NULL;
-		params.iv.data = NULL;
-		params.iv.length = 0;
+		params.iv_length = 0;
 	}
 
 	/* Auth */
@@ -103,15 +101,6 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 		mode = auth_sa->mode;
 	} else {
 		params.auth_alg = ODP_AUTH_ALG_NULL;
-	}
-
-	/* Generate an IV */
-	if (params.iv.length) {
-		int32_t size = params.iv.length;
-
-		int32_t ret = odp_random_data(params.iv.data, size, 1);
-		if (ret != size)
-			return -1;
 	}
 
 	/* Synchronous session create for now */

--- a/example/ipsec/odp_ipsec_cache.h
+++ b/example/ipsec/odp_ipsec_cache.h
@@ -56,7 +56,6 @@ typedef struct ipsec_cache_entry_s {
 		odp_crypto_session_t session;  /**< Crypto session handle */
 		uint32_t      esp_seq;         /**< ESP TX sequence number */
 		uint32_t      ah_seq;          /**< AH TX sequence number */
-		uint8_t       iv[MAX_IV_LEN];  /**< ESP IV storage */
 		odp_u16be_t    tun_hdr_id;     /**< Tunnel header IP ID */
 	} state;
 } ipsec_cache_entry_t;

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -234,14 +234,14 @@ typedef struct odp_crypto_key {
 /**
  * Crypto API IV structure
  */
-typedef struct odp_crypto_iv {
+typedef struct ODP_DEPRECATE(odp_crypto_iv) {
 	/** IV data */
 	uint8_t *data;
 
 	/** IV length in bytes */
 	uint32_t length;
 
-} odp_crypto_iv_t;
+} ODP_DEPRECATE(odp_crypto_iv_t);
 
 /**
  * Crypto API data range specifier
@@ -285,8 +285,11 @@ typedef struct odp_crypto_session_param_t {
 	 */
 	odp_crypto_key_t cipher_key;
 
-	/** Cipher Initialization Vector (IV) */
-	odp_crypto_iv_t iv;
+	/** @deprecated use iv_length and per-packet IV instead */
+	ODP_DEPRECATE(odp_crypto_iv_t) ODP_DEPRECATE(iv);
+
+	/** Cipher Initialization Vector (IV) length */
+	uint32_t iv_length;
 
 	/** Authentication algorithm
 	 *
@@ -359,8 +362,11 @@ typedef struct odp_crypto_op_param_t {
 	 */
 	odp_packet_t out_pkt;
 
-	/** Override session IV pointer */
-	uint8_t *override_iv_ptr;
+	/** @deprecated use iv_ptr instead */
+	uint8_t *ODP_DEPRECATE(override_iv_ptr);
+
+	/** IV pointer */
+	uint8_t *iv_ptr;
 
 	/** Offset from start of packet for hash result
 	 *

--- a/platform/linux-generic/include/odp_crypto_internal.h
+++ b/platform/linux-generic/include/odp_crypto_internal.h
@@ -7,6 +7,8 @@
 #ifndef ODP_CRYPTO_INTERNAL_H_
 #define ODP_CRYPTO_INTERNAL_H_
 
+#include <odp/api/deprecated.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -40,8 +42,10 @@ struct odp_crypto_generic_session {
 	odp_bool_t do_cipher_first;
 
 	struct {
+#if ODP_DEPRECATED_API
 		/* Copy of session IV data */
 		uint8_t iv_data[MAX_IV_LEN];
+#endif
 
 		union {
 			struct {

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -184,10 +184,14 @@ odp_crypto_alg_err_t aes_encrypt(odp_crypto_op_param_t *param,
 	unsigned char iv_enc[AES_BLOCK_SIZE];
 	void *iv_ptr;
 
-	if (param->override_iv_ptr)
+	if (param->iv_ptr)
+		iv_ptr = param->iv_ptr;
+#if ODP_DEPRECATED_API
+	else if (param->override_iv_ptr)
 		iv_ptr = param->override_iv_ptr;
 	else if (session->p.iv.data)
 		iv_ptr = session->cipher.iv_data;
+#endif
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
 
@@ -216,10 +220,14 @@ odp_crypto_alg_err_t aes_decrypt(odp_crypto_op_param_t *param,
 	unsigned char iv_enc[AES_BLOCK_SIZE];
 	void *iv_ptr;
 
-	if (param->override_iv_ptr)
+	if (param->iv_ptr)
+		iv_ptr = param->iv_ptr;
+#if ODP_DEPRECATED_API
+	else if (param->override_iv_ptr)
 		iv_ptr = param->override_iv_ptr;
 	else if (session->p.iv.data)
 		iv_ptr = session->cipher.iv_data;
+#endif
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
 
@@ -241,9 +249,14 @@ odp_crypto_alg_err_t aes_decrypt(odp_crypto_op_param_t *param,
 
 static int process_aes_param(odp_crypto_generic_session_t *session)
 {
-	/* Verify IV len is either 0 or 16 */
-	if (!((0 == session->p.iv.length) || (16 == session->p.iv.length)))
+	/* Verify IV len is 16 */
+#if ODP_DEPRECATED_API
+	if (!((16 == session->p.iv_length) || (16 == session->p.iv.length)))
 		return -1;
+#else
+	if (16 != session->p.iv_length)
+		return -1;
+#endif
 
 	/* Set function */
 	if (ODP_CRYPTO_OP_ENCODE == session->p.op) {
@@ -273,10 +286,14 @@ odp_crypto_alg_err_t aes_gcm_encrypt(odp_crypto_op_param_t *param,
 	void *iv_ptr;
 	uint8_t *tag = data + param->hash_result_offset;
 
-	if (param->override_iv_ptr)
+	if (param->iv_ptr)
+		iv_ptr = param->iv_ptr;
+#if ODP_DEPRECATED_API
+	else if (param->override_iv_ptr)
 		iv_ptr = param->override_iv_ptr;
 	else if (session->p.iv.data)
 		iv_ptr = session->cipher.iv_data;
+#endif
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
 
@@ -338,10 +355,14 @@ odp_crypto_alg_err_t aes_gcm_decrypt(odp_crypto_op_param_t *param,
 	void *iv_ptr;
 	uint8_t *tag   = data + param->hash_result_offset;
 
-	if (param->override_iv_ptr)
+	if (param->iv_ptr)
+		iv_ptr = param->iv_ptr;
+#if ODP_DEPRECATED_API
+	else if (param->override_iv_ptr)
 		iv_ptr = param->override_iv_ptr;
 	else if (session->p.iv.data)
 		iv_ptr = session->cipher.iv_data;
+#endif
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
 
@@ -392,6 +413,13 @@ odp_crypto_alg_err_t aes_gcm_decrypt(odp_crypto_op_param_t *param,
 
 static int process_aes_gcm_param(odp_crypto_generic_session_t *session)
 {
+	uint32_t iv_length = session->p.iv_length;
+
+#if ODP_DEPRECATED_API
+	if (0 != session->p.iv.length)
+		iv_length = session->p.iv.length;
+#endif
+
 	/* Verify Key len is 16 */
 	if (session->p.cipher_key.length != 16)
 		return -1;
@@ -409,7 +437,7 @@ static int process_aes_gcm_param(odp_crypto_generic_session_t *session)
 	}
 
 	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN,
-			    session->p.iv.length, NULL);
+			    iv_length, NULL);
 	if (ODP_CRYPTO_OP_ENCODE == session->p.op) {
 		EVP_EncryptInit_ex(ctx, NULL, NULL,
 				   session->p.cipher_key.data, NULL);
@@ -430,10 +458,14 @@ odp_crypto_alg_err_t des_encrypt(odp_crypto_op_param_t *param,
 	DES_cblock iv;
 	void *iv_ptr;
 
-	if (param->override_iv_ptr)
+	if (param->iv_ptr)
+		iv_ptr = param->iv_ptr;
+#if ODP_DEPRECATED_API
+	else if (param->override_iv_ptr)
 		iv_ptr = param->override_iv_ptr;
 	else if (session->p.iv.data)
 		iv_ptr = session->cipher.iv_data;
+#endif
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
 
@@ -468,10 +500,14 @@ odp_crypto_alg_err_t des_decrypt(odp_crypto_op_param_t *param,
 	DES_cblock iv;
 	void *iv_ptr;
 
-	if (param->override_iv_ptr)
+	if (param->iv_ptr)
+		iv_ptr = param->iv_ptr;
+#if ODP_DEPRECATED_API
+	else if (param->override_iv_ptr)
 		iv_ptr = param->override_iv_ptr;
 	else if (session->p.iv.data)
 		iv_ptr = session->cipher.iv_data;
+#endif
 	else
 		return ODP_CRYPTO_ALG_ERR_IV_INVALID;
 
@@ -500,9 +536,14 @@ odp_crypto_alg_err_t des_decrypt(odp_crypto_op_param_t *param,
 
 static int process_des_param(odp_crypto_generic_session_t *session)
 {
-	/* Verify IV len is either 0 or 8 */
-	if (!((0 == session->p.iv.length) || (8 == session->p.iv.length)))
+	/* Verify IV len is 8 */
+#if ODP_DEPRECATED_API
+	if (!((8 == session->p.iv_length) || (8 == session->p.iv.length)))
 		return -1;
+#else
+	if (8 != session->p.iv_length)
+		return -1;
+#endif
 
 	/* Set function */
 	if (ODP_CRYPTO_OP_ENCODE == session->p.op)
@@ -679,6 +720,7 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 	session->p = *param;
 
 	/* Copy IV data */
+#if ODP_DEPRECATED_API
 	if (session->p.iv.data) {
 		if (session->p.iv.length > MAX_IV_LEN) {
 			ODP_DBG("Maximum IV length exceeded\n");
@@ -689,6 +731,7 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 		memcpy(session->cipher.iv_data, session->p.iv.data,
 		       session->p.iv.length);
 	}
+#endif
 
 	/* Derive order */
 	if (ODP_CRYPTO_OP_ENCODE == param->op)

--- a/test/common_plat/performance/odp_crypto.c
+++ b/test/common_plat/performance/odp_crypto.c
@@ -186,10 +186,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key24,
 				.length = sizeof(test_key24)
 			},
-			.iv = {
-				.data = test_iv,
-				.length = 8,
-			},
+			.iv_length = 8,
 			.auth_alg = ODP_AUTH_ALG_NULL
 		},
 	},
@@ -201,10 +198,7 @@ static crypto_alg_config_t algs_config[] = {
 				.data = test_key24,
 				.length = sizeof(test_key24)
 			},
-			.iv = {
-				.data = test_iv,
-				.length = 8,
-			},
+			.iv_length = 8,
 			.auth_alg = ODP_AUTH_ALG_MD5_HMAC,
 			.auth_key = {
 				.data = test_key16,
@@ -552,6 +546,7 @@ run_measure_one(crypto_args_t *cargs,
 				}
 				mem = odp_packet_data(newpkt);
 				memset(mem, 1, payload_length);
+				params.iv_ptr = test_iv;
 				params.pkt = newpkt;
 				params.out_pkt = cargs->in_place ? newpkt :
 						 ODP_PACKET_INVALID;


### PR DESCRIPTION
Per-session IV (in it's current form) are static IVs used (possibly) for
several packets, and so they degradate security of genrated packets.
Instead of modifying semantics of IV wrt processed packets, etc. let's
deprecate (and in future remove) this IV altogether and enforce
applications to always specify correct IV in the per-packet operation
params.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>