### PR TITLE
[PATCH v4] test: fix distcheck failures when configured ODP with tests enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,7 @@ jobs:
                   compiler: gcc
                   script:
                           - ./bootstrap
-                          - ./configure
+                          - ./configure --prefix=$HOME/odp-install --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example
                           - sudo LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" make distcheck
                 - stage: test
                   env: TEST=doxygen

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,11 @@
 ACLOCAL_AMFLAGS=-I m4
 AUTOMAKE_OPTIONS = foreign
-AM_DISTCHECK_CONFIGURE_FLAGS = --enable-test-cpp \
-			       --enable-test-perf \
-			       --enable-test-vald \
+AM_DISTCHECK_CONFIGURE_FLAGS = --enable-test-cpp	\
+			       --enable-test-example	\
+			       --enable-test-helper	\
+			       --enable-test-perf	\
+			       --enable-test-perf-proc	\
+			       --enable-test-vald	\
 			       --with-testdir
 
 #@with_platform@ works alone in subdir but not as part of a path???

--- a/test/common_plat/validation/api/time/Makefile.am
+++ b/test/common_plat/validation/api/time/Makefile.am
@@ -16,3 +16,4 @@ time_main_LDADD = libtesttime.la $(LIBCUNIT_COMMON) $(LIBODP)
 
 EXTRA_DIST = time_test.h $(TESTSCRIPTS)
 dist_check_SCRIPTS = $(TESTSCRIPTS)
+test_SCRIPTS = $(dist_check_SCRIPTS)

--- a/test/common_plat/validation/api/traffic_mngr/Makefile.am
+++ b/test/common_plat/validation/api/traffic_mngr/Makefile.am
@@ -10,9 +10,10 @@ TESTS = $(TESTSCRIPTS)
 noinst_LTLIBRARIES = libtesttraffic_mngr.la
 libtesttraffic_mngr_la_SOURCES = traffic_mngr.c
 
-bin_PROGRAMS = traffic_mngr_main$(EXEEXT)
+test_PROGRAMS = traffic_mngr_main$(EXEEXT)
 dist_traffic_mngr_main_SOURCES = traffic_mngr_main.c
 traffic_mngr_main_LDADD = libtesttraffic_mngr.la -lm $(LIBCUNIT_COMMON) $(LIBODP)
 
 EXTRA_DIST = traffic_mngr.h $(TESTSCRIPTS)
 dist_check_SCRIPTS = $(TESTSCRIPTS)
+test_SCRIPTS = $(dist_check_SCRIPTS)


### PR DESCRIPTION
v4
travis changes in separate commit.
do alphabetical order in AM_DISTCHECK_CONFIGURE_FLAGS.
verified does configure; make distcheck without options still work.

Signed-off-by: Yi He <yi.he@linaro.org>