### PR TITLE
[PATCH API-NEXT v5] api: crypto: make odp_crypto_session_create return odp_crypto_session_t

### DIFF
--- a/example/ipsec/odp_ipsec_cache.c
+++ b/example/ipsec/odp_ipsec_cache.c
@@ -114,8 +114,8 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 			return -1;
 	}
 
-	/* Synchronous session create for now */
-	if (odp_crypto_session_create(&params, &session, &ses_create_rc))
+	session = odp_crypto_session_create2(&params, &ses_create_rc);
+	if (ODP_CRYPTO_SESSION_INVALID == session)
 		return -1;
 	if (ODP_CRYPTO_SES_CREATE_ERR_NONE != ses_create_rc)
 		return -1;

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -585,15 +585,34 @@ int odp_crypto_auth_capability(odp_auth_alg_t auth,
  * default values.
  *
  * @param param             Session parameters
- * @param session           Created session else ODP_CRYPTO_SESSION_INVALID
  * @param status            Failure code if unsuccessful
  *
- * @retval 0 on success
- * @retval <0 on failure
+ * @retval created session on success
+ * @retval ODP_CRYPTO_SESSION_INVALID on failure
  */
+odp_crypto_session_t odp_crypto_session_create2(odp_crypto_session_param_t
+						*param,
+						odp_crypto_ses_create_err_t
+						*status);
+
+#if ODP_DEPRECATED_API
+static inline
 int odp_crypto_session_create(odp_crypto_session_param_t *param,
 			      odp_crypto_session_t *session,
-			      odp_crypto_ses_create_err_t *status);
+			      odp_crypto_ses_create_err_t *status)
+{
+	odp_crypto_session_t sess;
+
+	sess = odp_crypto_session_create2(param, status);
+
+	if (ODP_CRYPTO_SESSION_INVALID == sess)
+		return -1;
+
+	*session = sess;
+
+	return 0;
+}
+#endif
 
 /**
  * Crypto session destroy

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -656,10 +656,9 @@ int odp_crypto_auth_capability(odp_auth_alg_t auth,
 	return num;
 }
 
-int
-odp_crypto_session_create(odp_crypto_session_param_t *param,
-			  odp_crypto_session_t *session_out,
-			  odp_crypto_ses_create_err_t *status)
+odp_crypto_session_t
+odp_crypto_session_create2(odp_crypto_session_param_t *param,
+			   odp_crypto_ses_create_err_t *status)
 {
 	int rc;
 	odp_crypto_generic_session_t *session;
@@ -672,7 +671,7 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 	session = alloc_session();
 	if (NULL == session) {
 		*status = ODP_CRYPTO_SES_CREATE_ERR_ENOMEM;
-		return -1;
+		return ODP_CRYPTO_SESSION_INVALID;
 	}
 
 	/* Copy parameters */
@@ -683,7 +682,7 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 		if (session->p.iv.length > MAX_IV_LEN) {
 			ODP_DBG("Maximum IV length exceeded\n");
 			free_session(session);
-			return -1;
+			return ODP_CRYPTO_SESSION_INVALID;
 		}
 
 		memcpy(session->cipher.iv_data, session->p.iv.data,
@@ -734,7 +733,7 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 	if (rc) {
 		*status = ODP_CRYPTO_SES_CREATE_ERR_INV_CIPHER;
 		free_session(session);
-		return -1;
+		return ODP_CRYPTO_SESSION_INVALID;
 	}
 
 	aes_gcm = 0;
@@ -781,12 +780,11 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 	if (rc) {
 		*status = ODP_CRYPTO_SES_CREATE_ERR_INV_AUTH;
 		free_session(session);
-		return -1;
+		return ODP_CRYPTO_SESSION_INVALID;
 	}
 
 	/* We're happy */
-	*session_out = (intptr_t)session;
-	return 0;
+	return (odp_crypto_session_t)(intptr_t)session;
 }
 
 int odp_crypto_session_destroy(odp_crypto_session_t session)

--- a/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
@@ -202,11 +202,9 @@ static void alg_test(odp_crypto_op_t op,
 	ses_params.iv = ses_iv;
 	ses_params.auth_key = auth_key;
 
-	rc = odp_crypto_session_create(&ses_params, &session, &status);
-	CU_ASSERT_FATAL(!rc);
+	session = odp_crypto_session_create2(&ses_params, &status);
+	CU_ASSERT_FATAL(session != ODP_CRYPTO_SESSION_INVALID);
 	CU_ASSERT(status == ODP_CRYPTO_SES_CREATE_ERR_NONE);
-	CU_ASSERT(odp_crypto_session_to_u64(session) !=
-		  odp_crypto_session_to_u64(ODP_CRYPTO_SESSION_INVALID));
 
 	/* Prepare input data */
 	odp_packet_t pkt = odp_packet_alloc(suite_context.pool,


### PR DESCRIPTION
Currently odp_crypto_session_create() (unlike other creation functions)
returns int result with session being returned through pointer argument.
Instead it is simpler to directly return a session (or
ODP_CRYPTO_SESSION_INVALID in case of an error).

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>