### PR TITLE
[PATCH API-NEXT v1] travis: add linking with libconfig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,10 +133,10 @@ script:
         - echo "Checking linking and run from install..."
         - pushd $HOME
         - echo "Dynamic link.."
-        - ${CC} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst -I${HOME}/odp-install/include -L${HOME}/odp-install/lib -lodp-linux -L${OLDPWD}/dpdk/x86_64-native-linuxapp-gcc/lib -lrt -ldpdk -lpthread -lcrypto -lpcap $MY_CF $MY_LDF -ldl
+        - ${CC} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst -I${HOME}/odp-install/include -L${HOME}/odp-install/lib -lodp-linux -L${OLDPWD}/dpdk/x86_64-native-linuxapp-gcc/lib -lrt -ldpdk -lpthread -lcrypto -lpcap -lconfig $MY_CF $MY_LDF -ldl
         - LD_LIBRARY_PATH="${HOME}/odp-install/lib:$LD_LIBRARY_PATH" ./odp_hello_inst
         - echo "Static link.."
-        - ${CC} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst -I${HOME}/odp-install/include -L${HOME}/odp-install/lib -lodp-linux -L${OLDPWD}/dpdk/x86_64-native-linuxapp-gcc/lib -lrt -ldpdk -lpthread -lcrypto -lpcap $MY_CF $MY_LDF -ldl -static
+        - ${CC} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst -I${HOME}/odp-install/include -L${HOME}/odp-install/lib -lodp-linux -L${OLDPWD}/dpdk/x86_64-native-linuxapp-gcc/lib -lrt -ldpdk -lpthread -lcrypto -lpcap -lconfig $MY_CF $MY_LDF -ldl -static
         - ./odp_hello_inst
         - popd
 


### PR DESCRIPTION
libconfig is needed for api-next branch to compile the app.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>

--
Dmitry works to make pktconfig work but that is quick fix for api next to fix linking. After master merge it's needed to add -lconfig to make app compile in api-next branch. This patch is quick and restores travis work back.