### PR TITLE
[PATCH v1] test: linux-generic: stop dropping other ODP files in pktio_ips test

### DIFF
--- a/test/linux-generic/pktio_ipc/pktio_ipc_run.sh
+++ b/test/linux-generic/pktio_ipc/pktio_ipc_run.sh
@@ -20,9 +20,6 @@ PATH=.:$PATH
 run()
 {
 	local ret=0
-	#if test was interrupted with CTRL+c than files
-	#might remain in shm. Needed cleanely delete them.
-	rm -rf /tmp/odp-* 2>&1 > /dev/null
 
 	echo "==== run pktio_ipc1 then pktio_ipc2 ===="
 	pktio_ipc1${EXEEXT} -t 10 &


### PR DESCRIPTION
Prevent pktio_ipc test from removing sockets and SHM files used by other applications.