### PR TITLE
[PATCH v1] test: time: do not fail under gcov

### DIFF
--- a/test/common_plat/validation/api/time/Makefile.am
+++ b/test/common_plat/validation/api/time/Makefile.am
@@ -1,5 +1,12 @@
 include ../Makefile.inc
 
+TESTS_ENVIRONMENT += TEST_DIR=${builddir}
+
+TESTSCRIPTS = time.sh
+TEST_EXTENSIONS = .sh
+
+TESTS = $(TESTSCRIPTS)
+
 noinst_LTLIBRARIES = libtesttime.la
 libtesttime_la_SOURCES = time.c
 
@@ -7,4 +14,5 @@ test_PROGRAMS = time_main$(EXEEXT)
 dist_time_main_SOURCES = time_main.c
 time_main_LDADD = libtesttime.la $(LIBCUNIT_COMMON) $(LIBODP)
 
-EXTRA_DIST = time.h
+EXTRA_DIST = time.h $(TESTSCRIPTS)
+dist_check_SCRIPTS = $(TESTSCRIPTS)

--- a/test/common_plat/validation/api/time/time.sh
+++ b/test/common_plat/validation/api/time/time.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Copyright (c) 2017, Linaro Limited
+# All rights reserved.
+#
+# SPDX-License-Identifier:	BSD-3-Clause
+#
+
+# directories where time_main binary can be found:
+# -in the validation dir when running make check (intree or out of tree)
+# -in the script directory, when running after 'make install', or
+# -in the validation when running standalone (./time) intree.
+# -in the current directory.
+# running stand alone out of tree requires setting PATH
+PATH=${TEST_DIR}/api/time:$PATH
+PATH=$(dirname $0)/../../../../common_plat/validation/api/time:$PATH
+PATH=$(dirname $0):$PATH
+PATH=`pwd`:$PATH
+
+time_main_path=$(which time_main${EXEEXT})
+if [ -x "$time_main_path" ] ; then
+	echo "running with time_main: $time_run_path"
+else
+	echo "cannot find time_main: please set you PATH for it."
+	exit 1
+fi
+
+# exit codes expected by automake for skipped tests
+TEST_SKIPPED=77
+
+time_main${EXEEXT}
+ret=$?
+
+SIGSEGV=139
+
+if [ "${TRAVIS}" = "true" ] && [ $ret -ne 0 ] &&
+   [ ${TEST} = "coverage" ] && [ $ret -ne ${SIGSEGV} ]; then
+	echo "SKIP: skip due significant slowdown under code coverage"
+	exit ${TEST_SKIPPED}
+fi
+
+exit $ret

--- a/test/linux-generic/Makefile.am
+++ b/test/linux-generic/Makefile.am
@@ -28,7 +28,7 @@ TESTS = validation/api/pktio/pktio_run.sh \
 	$(ALL_API_VALIDATION_DIR)/scheduler/scheduler_main$(EXEEXT) \
 	$(ALL_API_VALIDATION_DIR)/std_clib/std_clib_main$(EXEEXT) \
 	$(ALL_API_VALIDATION_DIR)/thread/thread_main$(EXEEXT) \
-	$(ALL_API_VALIDATION_DIR)/time/time_main$(EXEEXT) \
+	$(ALL_API_VALIDATION_DIR)/time/time.sh \
 	$(ALL_API_VALIDATION_DIR)/timer/timer_main$(EXEEXT) \
 	$(ALL_API_VALIDATION_DIR)/traffic_mngr/traffic_mngr.sh \
 	$(ALL_API_VALIDATION_DIR)/shmem/shmem_main$(EXEEXT) \


### PR DESCRIPTION
code coverage gcov make test very slow and it does not pass
accepted boundaries. Test if env TEST=coverage variable is set
and do no generate fail result if some boundaries are missing.
https://bugs.linaro.org/show_bug.cgi?id=3017

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>