### PR TITLE
[PATCH v4] Rework the way ODP links with other libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,10 +124,10 @@ script:
         - echo "Checking linking and run from install..."
         - pushd $HOME
         - echo "Dynamic link.."
-        - ${CC} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst -I${HOME}/odp-install/include -L${HOME}/odp-install/lib -lodp-linux -L${OLDPWD}/dpdk/x86_64-native-linuxapp-gcc/lib -lrt -ldpdk -lpthread -lcrypto -lpcap -ldl
+        - ${CC} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst `PKG_CONFIG_PATH=${HOME}/odp-install/lib/pkgconfig pkg-config --cflags --libs libodp-linux`
         - LD_LIBRARY_PATH="${HOME}/odp-install/lib:$LD_LIBRARY_PATH" ./odp_hello_inst
         - echo "Static link.."
-        - ${CC} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst -I${HOME}/odp-install/include -L${HOME}/odp-install/lib -lodp-linux -L${OLDPWD}/dpdk/x86_64-native-linuxapp-gcc/lib -lrt -ldpdk -lpthread -lcrypto -lpcap -ldl -static
+        - ${CC} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst `PKG_CONFIG_PATH=${HOME}/odp-install/lib/pkgconfig pkg-config --cflags --libs libodp-linux --static` -static
         - ./odp_hello_inst
 
 jobs:

--- a/configure.ac
+++ b/configure.ac
@@ -210,7 +210,6 @@ AC_SUBST([testdir])
 # Set conditionals as computed within platform specific files
 ##########################################################################
 AM_CONDITIONAL([netmap_support], [test x$netmap_support = xyes ])
-AM_CONDITIONAL([PKTIO_DPDK], [test x$pktio_dpdk_support = xyes ])
 AM_CONDITIONAL([HAVE_PCAP], [test $have_pcap = yes])
 AM_CONDITIONAL([SDK_INSTALL_PATH_], [test "x${SDK_INSTALL_PATH_}" = "x1"])
 AM_CONDITIONAL([test_installdir], [test "$testdir" != ""])

--- a/configure.ac
+++ b/configure.ac
@@ -209,7 +209,6 @@ AC_SUBST([testdir])
 ##########################################################################
 # Set conditionals as computed within platform specific files
 ##########################################################################
-AM_CONDITIONAL([netmap_support], [test x$netmap_support = xyes ])
 AM_CONDITIONAL([SDK_INSTALL_PATH_], [test "x${SDK_INSTALL_PATH_}" = "x1"])
 AM_CONDITIONAL([test_installdir], [test "$testdir" != ""])
 AM_CONDITIONAL([cunit_support], [test x$cunit_support = xyes ])

--- a/configure.ac
+++ b/configure.ac
@@ -210,7 +210,6 @@ AC_SUBST([testdir])
 # Set conditionals as computed within platform specific files
 ##########################################################################
 AM_CONDITIONAL([netmap_support], [test x$netmap_support = xyes ])
-AM_CONDITIONAL([HAVE_PCAP], [test $have_pcap = yes])
 AM_CONDITIONAL([SDK_INSTALL_PATH_], [test "x${SDK_INSTALL_PATH_}" = "x1"])
 AM_CONDITIONAL([test_installdir], [test "$testdir" != ""])
 AM_CONDITIONAL([cunit_support], [test x$cunit_support = xyes ])

--- a/configure.ac
+++ b/configure.ac
@@ -363,8 +363,6 @@ AC_CONFIG_FILES([Makefile
 		 pkgconfig/libodphelper.pc
 		 ])
 
-AC_SEARCH_LIBS([timer_create],[rt posix4])
-
 ##########################################################################
 # distribute the changed variables among the Makefiles
 

--- a/pkgconfig/libodp-linux.pc.in
+++ b/pkgconfig/libodp-linux.pc.in
@@ -7,5 +7,5 @@ Name: libodp-linux
 Description: The ODP packet processing engine
 Version: @PKGCONFIG_VERSION@
 Libs: -L${libdir} -lodp-linux @DPDK_LIBS@
-Libs.private: @OPENSSL_STATIC_LIBS@ @DPDK_PMDS@ @DPDK_LIBS@ -lpcap @PTHREAD_LIBS@ -lrt -lpthread @ATOMIC_LIBS@
+Libs.private: @OPENSSL_STATIC_LIBS@ @DPDK_PMDS@ @DPDK_LIBS@ @PCAP_LIBS@ @PTHREAD_LIBS@ -lrt -lpthread @ATOMIC_LIBS@
 Cflags: -I${includedir}

--- a/pkgconfig/libodp-linux.pc.in
+++ b/pkgconfig/libodp-linux.pc.in
@@ -7,5 +7,5 @@ Name: libodp-linux
 Description: The ODP packet processing engine
 Version: @PKGCONFIG_VERSION@
 Libs: -L${libdir} -lodp-linux
-Libs.private: @ATOMIC_LIBS@
+Libs.private: -lcrypto -ldl -lpcap @PTHREAD_LIBS@ -lrt -lpthread @ATOMIC_LIBS@
 Cflags: -I${includedir}

--- a/pkgconfig/libodp-linux.pc.in
+++ b/pkgconfig/libodp-linux.pc.in
@@ -7,5 +7,5 @@ Name: libodp-linux
 Description: The ODP packet processing engine
 Version: @PKGCONFIG_VERSION@
 Libs: -L${libdir} -lodp-linux
-Libs.private: -lcrypto -ldl -lpcap @PTHREAD_LIBS@ -lrt -lpthread @ATOMIC_LIBS@
+Libs.private: @OPENSSL_STATIC_LIBS@ -lpcap @PTHREAD_LIBS@ -lrt -lpthread @ATOMIC_LIBS@
 Cflags: -I${includedir}

--- a/pkgconfig/libodp-linux.pc.in
+++ b/pkgconfig/libodp-linux.pc.in
@@ -7,5 +7,5 @@ Name: libodp-linux
 Description: The ODP packet processing engine
 Version: @PKGCONFIG_VERSION@
 Libs: -L${libdir} -lodp-linux @DPDK_LIBS@
-Libs.private: @OPENSSL_STATIC_LIBS@ @DPDK_PMDS@ @DPDK_LIBS@ @PCAP_LIBS@ @PTHREAD_LIBS@ -lrt -lpthread @ATOMIC_LIBS@
+Libs.private: @OPENSSL_STATIC_LIBS@ @DPDK_PMDS@ @DPDK_LIBS@ @PCAP_LIBS@ @PTHREAD_LIBS@ @TIMER_LIBS@ -lpthread @ATOMIC_LIBS@
 Cflags: -I${includedir}

--- a/pkgconfig/libodp-linux.pc.in
+++ b/pkgconfig/libodp-linux.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: libodp-linux
 Description: The ODP packet processing engine
 Version: @PKGCONFIG_VERSION@
-Libs: -L${libdir} -lodp-linux
-Libs.private: @OPENSSL_STATIC_LIBS@ -lpcap @PTHREAD_LIBS@ -lrt -lpthread @ATOMIC_LIBS@
+Libs: -L${libdir} -lodp-linux @DPDK_LIBS@
+Libs.private: @OPENSSL_STATIC_LIBS@ @DPDK_PMDS@ @DPDK_LIBS@ -lpcap @PTHREAD_LIBS@ -lrt -lpthread @ATOMIC_LIBS@
 Cflags: -I${includedir}

--- a/platform/Makefile.inc
+++ b/platform/Makefile.inc
@@ -16,6 +16,8 @@ AM_CFLAGS += $(VISIBILITY_CFLAGS)
 #The implementation will need to retain the deprecated implementation
 AM_CFLAGS += -Wno-deprecated-declarations
 
+AM_CFLAGS += @PTHREAD_CFLAGS@
+
 odpapispecincludedir= $(includedir)/odp/api/spec
 odpapispecinclude_HEADERS = \
 		  $(top_srcdir)/include/odp/api/spec/align.h \

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -13,6 +13,7 @@ AM_CFLAGS +=  -D_ODP_PKTIO_IPC
 
 AM_CPPFLAGS +=  $(OPENSSL_CPPFLAGS)
 AM_CPPFLAGS +=  $(DPDK_CPPFLAGS)
+AM_CPPFLAGS +=  $(NETMAP_CPPFLAGS)
 
 include_HEADERS = \
 		  $(top_srcdir)/include/odp.h \

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -260,6 +260,10 @@ __LIB__libodp_linux_la_LIBADD = $(ATOMIC_LIBS)
 __LIB__libodp_linux_la_LIBADD += $(OPENSSL_LIBS)
 __LIB__libodp_linux_la_LIBADD += $(DPDK_LIBS) $(DPDK_PMDS)
 
+if HAVE_PCAP
+__LIB__libodp_linux_la_LIBADD += $(PCAP_LIBS)
+endif
+
 # Create symlink for ABI header files. Application does not need to use the arch
 # specific include path for installed files.
 install-data-hook:

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -259,6 +259,7 @@ endif
 __LIB__libodp_linux_la_LIBADD = $(ATOMIC_LIBS)
 __LIB__libodp_linux_la_LIBADD += $(OPENSSL_LIBS)
 __LIB__libodp_linux_la_LIBADD += $(DPDK_LIBS) $(DPDK_PMDS)
+__LIB__libodp_linux_la_LIBADD += $(PTHREAD_LIBS)
 
 if HAVE_PCAP
 __LIB__libodp_linux_la_LIBADD += $(PCAP_LIBS)

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -11,6 +11,8 @@ AM_CFLAGS +=  -I$(top_builddir)/include
 AM_CFLAGS +=  -Iinclude
 AM_CFLAGS +=  -D_ODP_PKTIO_IPC
 
+AM_CPPFLAGS +=  $(OPENSSL_CPPFLAGS)
+
 include_HEADERS = \
 		  $(top_srcdir)/include/odp.h \
 		  $(top_srcdir)/include/odp_api.h
@@ -254,6 +256,7 @@ __LIB__libodp_linux_la_SOURCES += pktio/pcap.c
 endif
 
 __LIB__libodp_linux_la_LIBADD = $(ATOMIC_LIBS)
+__LIB__libodp_linux_la_LIBADD += $(OPENSSL_LIBS)
 
 # Create symlink for ABI header files. Application does not need to use the arch
 # specific include path for installed files.

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -12,6 +12,7 @@ AM_CFLAGS +=  -Iinclude
 AM_CFLAGS +=  -D_ODP_PKTIO_IPC
 
 AM_CPPFLAGS +=  $(OPENSSL_CPPFLAGS)
+AM_CPPFLAGS +=  $(DPDK_CPPFLAGS)
 
 include_HEADERS = \
 		  $(top_srcdir)/include/odp.h \
@@ -257,6 +258,7 @@ endif
 
 __LIB__libodp_linux_la_LIBADD = $(ATOMIC_LIBS)
 __LIB__libodp_linux_la_LIBADD += $(OPENSSL_LIBS)
+__LIB__libodp_linux_la_LIBADD += $(DPDK_LIBS) $(DPDK_PMDS)
 
 # Create symlink for ABI header files. Application does not need to use the arch
 # specific include path for installed files.

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -260,6 +260,7 @@ __LIB__libodp_linux_la_LIBADD = $(ATOMIC_LIBS)
 __LIB__libodp_linux_la_LIBADD += $(OPENSSL_LIBS)
 __LIB__libodp_linux_la_LIBADD += $(DPDK_LIBS) $(DPDK_PMDS)
 __LIB__libodp_linux_la_LIBADD += $(PTHREAD_LIBS)
+__LIB__libodp_linux_la_LIBADD += $(TIMER_LIBS)
 
 if HAVE_PCAP
 __LIB__libodp_linux_la_LIBADD += $(PCAP_LIBS)

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -75,6 +75,7 @@ fi
 AC_SUBST([ATOMIC_LIBS])
 
 m4_include([platform/linux-generic/m4/odp_pthread.m4])
+m4_include([platform/linux-generic/m4/odp_timer.m4])
 m4_include([platform/linux-generic/m4/odp_openssl.m4])
 m4_include([platform/linux-generic/m4/odp_pcap.m4])
 m4_include([platform/linux-generic/m4/odp_netmap.m4])

--- a/platform/linux-generic/m4/odp_dpdk.m4
+++ b/platform/linux-generic/m4/odp_dpdk.m4
@@ -4,15 +4,15 @@
 pktio_dpdk_support=no
 AC_ARG_WITH([dpdk-path],
 AC_HELP_STRING([--with-dpdk-path=DIR   path to dpdk build directory]),
-    [DPDK_PATH=$withval
-    AM_CPPFLAGS="$AM_CPPFLAGS -msse4.2 -isystem $DPDK_PATH/include"
+    [DPDK_PATH="$withval"
+    DPDK_CPPFLAGS="-msse4.2 -isystem $DPDK_PATH/include"
     pktio_dpdk_support=yes],[])
 
 ##########################################################################
 # Save and set temporary compilation flags
 ##########################################################################
-OLD_CPPFLAGS=$CPPFLAGS
-CPPFLAGS="$AM_CPPFLAGS $CPPFLAGS"
+OLD_CPPFLAGS="$CPPFLAGS"
+CPPFLAGS="$DPDK_CPPFLAGS $CPPFLAGS"
 
 ##########################################################################
 # Check for DPDK availability
@@ -25,22 +25,23 @@ then
     AC_CHECK_HEADERS([rte_config.h], [],
         [AC_MSG_FAILURE(["can't find DPDK header"])])
 
-    DPDK_PMD=--whole-archive,
-    for filename in $with_dpdk_path/lib/*.a; do
-        cur_driver=`echo $(basename "$filename" .a) | \
-            sed -n 's/^\(librte_pmd_\)/-lrte_pmd_/p' | sed -n 's/$/,/p'`
+    AS_VAR_SET([DPDK_PMDS], [-Wl,--whole-archive,])
+    for filename in "$DPDK_PATH"/lib/librte_pmd_*.a; do
+        cur_driver=`basename "$filename" .a | sed -e 's/^lib//'`
         # rte_pmd_nfp has external dependencies which break linking
-        if test "$cur_driver" = "-lrte_pmd_nfp,"; then
+        if test "$cur_driver" = "rte_pmd_nfp"; then
             echo "skip linking rte_pmd_nfp"
         else
-            DPDK_PMD+=$cur_driver
+            AS_VAR_APPEND([DPDK_PMDS], [-l$cur_driver,])
         fi
     done
-    DPDK_PMD+=--no-whole-archive
+    AS_VAR_APPEND([DPDK_PMDS], [--no-whole-archive])
 
     ODP_CFLAGS="$ODP_CFLAGS -DODP_PKTIO_DPDK"
-    AM_LDFLAGS="$AM_LDFLAGS -L$DPDK_PATH/lib -Wl,$DPDK_PMD"
-    LIBS="$LIBS -ldpdk -ldl -lpcap"
+    DPDK_LIBS="-L$DPDK_PATH/lib -ldpdk -lpthread -ldl -lpcap"
+    AC_SUBST([DPDK_CPPFLAGS])
+    AC_SUBST([DPDK_LIBS])
+    AC_SUBST([DPDK_PMDS])
 else
     pktio_dpdk_support=no
 fi
@@ -49,3 +50,5 @@ fi
 # Restore old saved variables
 ##########################################################################
 CPPFLAGS=$OLD_CPPFLAGS
+
+AM_CONDITIONAL([PKTIO_DPDK], [test x$pktio_dpdk_support = xyes ])

--- a/platform/linux-generic/m4/odp_netmap.m4
+++ b/platform/linux-generic/m4/odp_netmap.m4
@@ -15,14 +15,14 @@ AC_ARG_WITH([netmap-path],
 AC_HELP_STRING([--with-netmap-path=DIR   path to netmap root directory],
                [(or in the default path if not specified).]),
     [NETMAP_PATH=$withval
-    AM_CPPFLAGS="$AM_CPPFLAGS -isystem $NETMAP_PATH/sys"
+    NETMAP_CPPFLAGS="-isystem $NETMAP_PATH/sys"
     netmap_support=yes],[])
 
 ##########################################################################
 # Save and set temporary compilation flags
 ##########################################################################
 OLD_CPPFLAGS=$CPPFLAGS
-CPPFLAGS="$AM_CPPFLAGS $CPPFLAGS"
+CPPFLAGS="$NETMAP_CPPFLAGS $CPPFLAGS"
 
 ##########################################################################
 # Check for netmap availability
@@ -32,6 +32,7 @@ then
     AC_CHECK_HEADERS([net/netmap_user.h], [],
         [AC_MSG_FAILURE(["can't find netmap header"])])
     ODP_CFLAGS="$ODP_CFLAGS -DODP_NETMAP"
+    AC_SUBST([NETMAP_CPPFLAGS])
 else
     netmap_support=no
 fi
@@ -40,3 +41,5 @@ fi
 # Restore old saved variables
 ##########################################################################
 CPPFLAGS=$OLD_CPPFLAGS
+
+AM_CONDITIONAL([netmap_support], [test x$netmap_support = xyes ])

--- a/platform/linux-generic/m4/odp_openssl.m4
+++ b/platform/linux-generic/m4/odp_openssl.m4
@@ -5,8 +5,8 @@ AC_ARG_WITH([openssl-path],
 AC_HELP_STRING([--with-openssl-path=DIR path to openssl libs and headers],
                [(or in the default path if not specified).]),
     [OPENSSL_PATH=$withval
-    AM_CPPFLAGS="$AM_CPPFLAGS -I$OPENSSL_PATH/include"
-    AM_LDFLAGS="$AM_LDFLAGS -L$OPENSSL_PATH/lib"
+    OPENSSL_CPPFLAGS="-I$OPENSSL_PATH/include"
+    OPENSSL_LIBS="-L$OPENSSL_PATH/lib"
     ],[])
 
 ##########################################################################
@@ -14,19 +14,24 @@ AC_HELP_STRING([--with-openssl-path=DIR path to openssl libs and headers],
 ##########################################################################
 OLD_LDFLAGS=$LDFLAGS
 OLD_CPPFLAGS=$CPPFLAGS
-LDFLAGS="$AM_LDFLAGS $LDFLAGS"
-CPPFLAGS="$AM_CPPFLAGS $CPPFLAGS"
+LIBS="$OPENSSL_LIBS $LIBS"
+CPPFLAGS="$OPENSSL_CPPFLAGS $CPPFLAGS"
 
 ##########################################################################
 # Check for OpenSSL availability
 ##########################################################################
-AC_CHECK_LIB([crypto], [EVP_EncryptInit], [],
+AC_CHECK_LIB([crypto], [EVP_EncryptInit], [OPENSSL_LIBS="$OPENSSL_LIBS -lcrypto"
+					   OPENSSL_STATIC_LIBS="$OPENSSL_LIBS -ldl"],
              [AC_MSG_FAILURE([OpenSSL libraries required])])
 AC_CHECK_HEADERS([openssl/des.h openssl/rand.h openssl/hmac.h openssl/evp.h], [],
              [AC_MSG_ERROR([OpenSSL headers required])])
 
+AC_SUBST([OPENSSL_CPPFLAGS])
+AC_SUBST([OPENSSL_LIBS])
+AC_SUBST([OPENSSL_STATIC_LIBS])
+
 ##########################################################################
 # Restore old saved variables
 ##########################################################################
-LDFLAGS=$OLD_LDFLAGS
+LIBS=$OLD_LIBS
 CPPFLAGS=$OLD_CPPFLAGS

--- a/platform/linux-generic/m4/odp_pcap.m4
+++ b/platform/linux-generic/m4/odp_pcap.m4
@@ -9,6 +9,10 @@ AC_CHECK_HEADER(pcap/pcap.h,
 [])
 
 if test $have_pcap == yes; then
-    AM_CFLAGS="$AM_CFLAGS -DHAVE_PCAP"
-    LIBS="$LIBS -lpcap"
+    ODP_CFLAGS="$AM_CFLAGS -DHAVE_PCAP"
+    PCAP_LIBS="-lpcap"
 fi
+
+AC_SUBST([PCAP_LIBS])
+
+AM_CONDITIONAL([HAVE_PCAP], [test $have_pcap = yes])

--- a/platform/linux-generic/m4/odp_pthread.m4
+++ b/platform/linux-generic/m4/odp_pthread.m4
@@ -6,8 +6,3 @@ AX_PTHREAD([CC="$PTHREAD_CC"], [
     echo "Error! We require pthreads to be available"
     exit -1
     ])
-LIBS="$PTHREAD_LIBS $LIBS"
-AM_CFLAGS="$AM_CFLAGS $PTHREAD_CFLAGS"
-AM_LDFLAGS="$AM_LDFLAGS $PTHREAD_LDFLAGS"
-
-AM_LDFLAGS="$AM_LDFLAGS -pthread -lrt"

--- a/platform/linux-generic/m4/odp_timer.m4
+++ b/platform/linux-generic/m4/odp_timer.m4
@@ -1,0 +1,8 @@
+##########################################################################
+# Check for POSIX timer functions
+##########################################################################
+
+AC_CHECK_LIB([rt], [timer_create], [TIMER_LIBS="-lrt"],
+	     [AC_CHECK_LIB([posix4], [timer_create], [TIMER_LIBS="-lposix4"],
+			   [AC_MSG_FAILURE([timer_create not found])])])
+AC_SUBST([TIMER_LIBS])

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -4,7 +4,7 @@ LIB   = $(top_builddir)/lib
 #in the following line, the libs using the symbols should come before
 #the libs containing them! The includer is given a chance to add things
 #before libodp by setting PRE_LDADD before the inclusion.
-LDADD = $(PRE_LDADD) $(LIB)/libodphelper.la $(LIB)/libodp-linux.la
+LDADD = $(PRE_LDADD) $(LIB)/libodphelper.la $(LIB)/libodp-linux.la $(DPDK_PMDS)
 
 INCFLAGS = \
 	-I$(top_builddir)/platform/@with_platform@/include \

--- a/test/common_plat/common/Makefile.am
+++ b/test/common_plat/common/Makefile.am
@@ -4,6 +4,7 @@ include $(top_srcdir)/test/Makefile.inc
 noinst_LTLIBRARIES = libcunit_common.la libcpumask_common.la libthrmask_common.la
 
 libcunit_common_la_SOURCES = odp_cunit_common.c
+libcunit_common_la_LIBADD = $(CUNIT_LIBS)
 
 libcpumask_common_la_SOURCES = mask_common.c
 

--- a/test/common_plat/m4/validation.m4
+++ b/test/common_plat/m4/validation.m4
@@ -26,24 +26,24 @@ AC_ARG_WITH([cunit-path],
 AC_HELP_STRING([--with-cunit-path=DIR   path to CUnit libs and headers],
                [(or in the default path if not specified).]),
     [CUNIT_PATH=$withval
-    AM_CPPFLAGS="$AM_CPPFLAGS -I$CUNIT_PATH/include"
-    AM_LDFLAGS="$AM_LDFLAGS -L$CUNIT_PATH/lib"
-    cunit_support=yes],[])
+     CUNIT_CPPFLAGS="-I$CUNIT_PATH/include"
+     CUNIT_LIBS="-L$CUNIT_PATH/lib"
+     cunit_support=yes],[])
 
 ##########################################################################
 # Save and set temporary compilation flags
 ##########################################################################
-OLD_LDFLAGS=$LDFLAGS
+OLD_LIBS=$LIBS
 OLD_CPPFLAGS=$CPPFLAGS
-LDFLAGS="$AM_LDFLAGS $LDFLAGS"
-CPPFLAGS="$AM_CPPFLAGS $CPPFLAGS"
+LIBS="$CUNIT_LIBS $LIBS"
+CPPFLAGS="$CUNIT_CPPFLAGS $CPPFLAGS"
 
 ##########################################################################
 # Check for CUnit availability
 ##########################################################################
 if test x$cunit_support = xyes
 then
-    AC_CHECK_LIB([cunit],[CU_get_error], [],
+    AC_CHECK_LIB([cunit],[CU_get_error], [CUNIT_LIBS="$CUNIT_LIBS -lcunit"],
         [AC_MSG_ERROR([CUnit libraries required])])
     AC_CHECK_HEADERS([CUnit/Basic.h], [],
         [AC_MSG_FAILURE(["can't find cunit headers"])])
@@ -51,8 +51,11 @@ else
     cunit_support=no
 fi
 
+AC_SUBST([CUNIT_CPPFLAGS])
+AC_SUBST([CUNIT_LIBS])
+
 ##########################################################################
 # Restore old saved variables
 ##########################################################################
-LDFLAGS=$OLD_LDFLAGS
+LIBS=$OLD_LIBS
 CPPFLAGS=$OLD_CPPFLAGS

--- a/test/common_plat/validation/api/Makefile.inc
+++ b/test/common_plat/validation/api/Makefile.inc
@@ -9,6 +9,7 @@ AUTOMAKE_OPTIONS = nostdinc
 
 AM_CFLAGS += -I$(top_srcdir)/test/common_plat/common
 AM_LDFLAGS += -static
+AM_LDFLAGS += $(DPDK_PMDS)
 
 LIBCUNIT_COMMON = $(COMMON_DIR)/libcunit_common.la
 LIBCPUMASK_COMMON = $(COMMON_DIR)/libcpumask_common.la

--- a/test/common_plat/validation/api/Makefile.inc
+++ b/test/common_plat/validation/api/Makefile.inc
@@ -11,6 +11,8 @@ AM_CFLAGS += -I$(top_srcdir)/test/common_plat/common
 AM_LDFLAGS += -static
 AM_LDFLAGS += $(DPDK_PMDS)
 
+AM_CPPFLAGS += $(CUNIT_CPPFLAGS)
+
 LIBCUNIT_COMMON = $(COMMON_DIR)/libcunit_common.la
 LIBCPUMASK_COMMON = $(COMMON_DIR)/libcpumask_common.la
 LIBTHRMASK_COMMON = $(COMMON_DIR)/libthrmask_common.la

--- a/test/linux-generic/Makefile.inc
+++ b/test/linux-generic/Makefile.inc
@@ -6,7 +6,7 @@ AM_LDFLAGS += -static
 
 LIBCUNIT_COMMON = $(top_builddir)/test/common_plat/common/libcunit_common.la
 LIB   = $(top_builddir)/lib
-LIBODP = $(LIB)/libodphelper.la $(LIB)/libodp-linux.la
+LIBODP = $(LIB)/libodphelper.la $(LIB)/libodp-linux.la $(DPDK_PMDS)
 
 INCCUNIT_COMMON = -I$(top_srcdir)/test/common_plat/common
 INCODP =  \

--- a/test/linux-generic/Makefile.inc
+++ b/test/linux-generic/Makefile.inc
@@ -4,6 +4,8 @@
 
 AM_LDFLAGS += -static
 
+AM_CPPFLAGS += $(CUNIT_CPPFLAGS)
+
 LIBCUNIT_COMMON = $(top_builddir)/test/common_plat/common/libcunit_common.la
 LIB   = $(top_builddir)/lib
 LIBODP = $(LIB)/libodphelper.la $(LIB)/libodp-linux.la $(DPDK_PMDS)


### PR DESCRIPTION
Currently configure tests add all libraries to AM_LDFLAGS or LIBS, thus making all libraries link against everything. For example libodp-linux ends up depending on libcunit. Implement fine-grained control of what gets linked against which libraries. As a side effect, this allows us to introduce proper linking flags to libod-linux.pc, enabling other users to use it properly.