### PR TITLE
[PATCH v1] travis: add dependency of autoconf-archive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ addons:
                 packages:
                         - gcc
                         - clang-3.8
-                        - automake autoconf libtool libssl-dev graphviz mscgen doxygen
+                        - automake autoconf autoconf-archive libtool libssl-dev graphviz mscgen doxygen
                         - libpcap-dev
 #        coverity_scan:
 #                project:


### PR DESCRIPTION
autoconf-archive dependency was added with gcc 7 req.
This also need to be in .travis.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>