### PR TITLE
[PATCH API-NEXT v1] linux-generic: crypto: adapt HMAC code to OpenSSL 1.1.x

### DIFF
--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -128,20 +128,18 @@ null_crypto_routine(odp_crypto_op_param_t *param ODP_UNUSED,
 }
 
 static
-void packet_hmac(odp_crypto_op_param_t *param,
-		 odp_crypto_generic_session_t *session,
-		 uint8_t *hash)
+void packet_hmac_calculate(HMAC_CTX *ctx,
+			   odp_crypto_op_param_t *param,
+			   odp_crypto_generic_session_t *session,
+			   uint8_t *hash)
 {
 	odp_packet_t pkt = param->out_pkt;
 	uint32_t offset = param->auth_range.offset;
 	uint32_t len   = param->auth_range.length;
-	HMAC_CTX ctx;
 
 	ODP_ASSERT(offset + len <= odp_packet_len(pkt));
 
-	/* Hash it */
-	HMAC_CTX_init(&ctx);
-	HMAC_Init_ex(&ctx,
+	HMAC_Init_ex(ctx,
 		     session->auth.key,
 		     session->auth.key_length,
 		     session->auth.evp_md,
@@ -152,14 +150,41 @@ void packet_hmac(odp_crypto_op_param_t *param,
 		void *mapaddr = odp_packet_offset(pkt, offset, &seglen, NULL);
 		uint32_t maclen = len > seglen ? seglen : len;
 
-		HMAC_Update(&ctx, mapaddr, maclen);
+		HMAC_Update(ctx, mapaddr, maclen);
 		offset  += maclen;
 		len     -= maclen;
 	}
 
-	HMAC_Final(&ctx, hash, NULL);
+	HMAC_Final(ctx, hash, NULL);
+}
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+static
+void packet_hmac(odp_crypto_op_param_t *param,
+		 odp_crypto_generic_session_t *session,
+		 uint8_t *hash)
+{
+	HMAC_CTX ctx;
+
+	/* Hash it */
+	HMAC_CTX_init(&ctx);
+	packet_hmac_calculate(&ctx, param, session, hash);
 	HMAC_CTX_cleanup(&ctx);
 }
+#else
+static
+void packet_hmac(odp_crypto_op_param_t *param,
+		 odp_crypto_generic_session_t *session,
+		 uint8_t *hash)
+{
+	HMAC_CTX *ctx;
+
+	/* Hash it */
+	ctx = HMAC_CTX_new();
+	packet_hmac_calculate(ctx, param, session, hash);
+	HMAC_CTX_free(ctx);
+}
+#endif
 
 static
 odp_crypto_alg_err_t auth_gen(odp_crypto_op_param_t *param,


### PR DESCRIPTION
OpenSSL 1.1.x has changed HMAC API in an incompatible way. Let's adapt
to it by providing version-dependent wrapper around HMAC calculation.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>