### PR TITLE
[PATCH v1] configure.ac: do not trap if libatomic is not found

### DIFF
--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -65,7 +65,7 @@ AC_LINK_IFELSE(
    AC_CHECK_LIB(
      [atomic], [__atomic_exchange_16],
      [use_libatomic=yes],
-     [AC_MSG_FAILURE([cannot detect support for 128-bit atomics])])
+     [AC_MSG_CHECKING([cannot detect support for 128-bit atomics])])
   ])
 
 if test "x$use_libatomic" = "xyes"; then


### PR DESCRIPTION
Idea if check was to detect if libatomic is needed or not,
not trap configure on not case
Fixes Linaro CI compilation for:
gcc-linaro-5.3-2016.02-x86_64_arm-linux-gnueabih

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>