### PR TITLE
[PATCH v1] Add cross compilation checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,15 @@ addons:
         apt:
                 sources:
                         - ubuntu-toolchain-r-test
-                        - llvm-toolchain-precise-3.8
                 packages:
                         - gcc
                         - clang-3.8
                         - automake autoconf autoconf-archive libtool libssl-dev graphviz mscgen doxygen
                         - libpcap-dev
+                        - dpkg-cross equivs
+                        - gcc-aarch64-linux-gnu pkg-config-aarch64-linux-gnu libc6-dev-arm64-cross
+                        - gcc-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf libc6-dev-armhf-cross
+                        - gcc-powerpc-linux-gnu pkg-config-powerpc-linux-gnu libc6-dev-powerpc-cross
 #        coverity_scan:
 #                project:
 #                        name: "$TRAVIS_REPO_SLUG"
@@ -62,6 +65,24 @@ env:
         - CONF="--enable-schedule-sp"
         - CONF="--enable-schedule-iquery"
 
+before_install:
+#       Install cunit for the validation tests because distro version is too old and fails C99 compile
+        - sudo apt-get remove libcunit1-dev libcunit1
+        - export CUNIT_VERSION=2.1-3
+        - curl -sSOL https://github.com/Linaro/libcunit/releases/download/${CUNIT_VERSION}/CUnit-${CUNIT_VERSION}.tar.bz2
+        - tar -jxf *.bz2
+        - pushd CUnit*
+        - libtoolize --force --copy
+        - aclocal
+        - autoheader
+        - automake --add-missing --include-deps --copy
+        - autoconf
+        - ./configure --enable-debug --enable-automated --enable-basic --enable-console --enable-examples --enable-test $CROSS || cat config.log
+        - make
+        - sudo make install
+        - popd
+        - export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+
 install:
         - echo 1000 | sudo tee /proc/sys/vm/nr_hugepages
         - sudo mkdir -p /mnt/huge
@@ -72,19 +93,6 @@ install:
         - sudo pip install coverage
         - gem install asciidoctor
         - PATH=${PATH//:\.\/node_modules\/\.bin/}
-
-#       Install cunit for the validation tests because distro version is too old and fails C99 compile
-        - sudo apt-get remove libcunit1-dev libcunit1
-        - export CUNIT_VERSION=2.1-3
-        - curl -sSOL https://github.com/Linaro/libcunit/releases/download/${CUNIT_VERSION}/CUnit-${CUNIT_VERSION}.tar.bz2
-        - tar -jxf *.bz2
-        - pushd CUnit*
-        - ./bootstrap
-        - ./configure --enable-debug --enable-automated --enable-basic --enable-console --enable-examples --enable-test
-        - make
-        - sudo make install
-        - popd
-        - export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 
 #	DPDK pktio
         - TARGET=${TARGET:-"x86_64-native-linuxapp-gcc"}
@@ -125,6 +133,69 @@ script:
 jobs:
         include:
                 - stage: test
+                  compiler: aarch64-linux-gnu-gcc
+                  env: TEST="aarch64-linux-gnu" CROSS="--host=aarch64-linux-gnu --prefix=/usr/aarch64-linux-gnu"
+                  install: true
+                  script:
+                          - mkdir cross
+                          - pushd cross
+                            # one can not include colon in the command or bad things will happen, so mimic it
+                          - env echo -e 'Provides\x3a multiarch-support, debconf, debconf-2.0' > dummy
+                          - equivs-build -a arm64 dummy
+                          - wget
+                            http://ports.ubuntu.com/pool/main/o/openssl/libssl-dev_1.0.1f-1ubuntu2.22_arm64.deb
+                            http://ports.ubuntu.com/pool/main/o/openssl/libssl1.0.0_1.0.1f-1ubuntu2.22_arm64.deb
+                            http://ports.ubuntu.com/pool/main/z/zlib/zlib1g-dev_1.2.8.dfsg-1ubuntu1_arm64.deb
+                            http://ports.ubuntu.com/pool/main/z/zlib/zlib1g_1.2.8.dfsg-1ubuntu1_arm64.deb
+                          - sudo dpkg-cross -i -M -A -a arm64 *.deb
+                          - popd
+                          - ./bootstrap
+                          - ./configure --prefix=$HOME/odp-install $CROSS
+                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example
+                          - make -j $(nproc)
+                - stage: test
+                  compiler: arm-linux-gnueabihf-gcc
+                  env: TEST="arm-linux-gnueabihf" CROSS="--host=arm-linux-gnueabihf --prefix=/usr/arm-linux-gnueabihf"
+                  install: true
+                  script:
+                          - mkdir cross
+                          - pushd cross
+                            # one can not include colon in the command or bad things will happen, so mimic it
+                          - env echo -e 'Provides\x3a multiarch-support, debconf, debconf-2.0' > dummy
+                          - equivs-build -a armhf dummy
+                          - wget
+                            http://ports.ubuntu.com/pool/main/o/openssl/libssl-dev_1.0.1f-1ubuntu2.22_armhf.deb
+                            http://ports.ubuntu.com/pool/main/o/openssl/libssl1.0.0_1.0.1f-1ubuntu2.22_armhf.deb
+                            http://ports.ubuntu.com/pool/main/z/zlib/zlib1g-dev_1.2.8.dfsg-1ubuntu1_armhf.deb
+                            http://ports.ubuntu.com/pool/main/z/zlib/zlib1g_1.2.8.dfsg-1ubuntu1_armhf.deb
+                          - sudo dpkg-cross -i -M -A -a armhf *.deb
+                          - popd
+                          - ./bootstrap
+                          - ./configure --prefix=$HOME/odp-install $CROSS
+                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example
+                          - make -j $(nproc)
+                - stage: test
+                  compiler: powerpc-linux-gnu-gcc
+                  env: TEST="powerpc-linux-gnu" CROSS="--host=powerpc-linux-gnu --prefix=/usr/powerpc-linux-gnu"
+                  install: true
+                  script:
+                          - mkdir cross
+                          - pushd cross
+                            # one can not include colon in the command or bad things will happen, so mimic it
+                          - env echo -e 'Provides\x3a multiarch-support, debconf, debconf-2.0' > dummy
+                          - equivs-build -a powerpc dummy
+                          - wget
+                            http://ports.ubuntu.com/pool/main/o/openssl/libssl-dev_1.0.1f-1ubuntu2.22_powerpc.deb
+                            http://ports.ubuntu.com/pool/main/o/openssl/libssl1.0.0_1.0.1f-1ubuntu2.22_powerpc.deb
+                            http://ports.ubuntu.com/pool/main/z/zlib/zlib1g-dev_1.2.8.dfsg-1ubuntu1_powerpc.deb
+                            http://ports.ubuntu.com/pool/main/z/zlib/zlib1g_1.2.8.dfsg-1ubuntu1_powerpc.deb
+                          - sudo dpkg-cross -i -M -A -a powerpc *.deb
+                          - popd
+                          - ./bootstrap
+                          - ./configure --prefix=$HOME/odp-install $CROSS
+                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example
+                          - make -j $(nproc)
+                - stage: test
                   env: TEST=coverage
                   compiler: gcc
                   script:
@@ -158,4 +229,5 @@ jobs:
                           - ./scripts/ci-checkpatches.sh ${ODP_PATCHES};
 
 after_failure:
+  - cat config.log
   - find . -name 'test-suite.log' -execdir grep -il "FAILED" {} \; -exec echo {} \; -exec cat {} \;

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -34,11 +34,12 @@ use_libatomic=no
 AC_MSG_CHECKING(whether -latomic is needed for 64-bit atomic built-ins)
 AC_LINK_IFELSE(
   [AC_LANG_SOURCE([[
-    static int loc;
+    #include <stdint.h>
+    static uint64_t loc;
     int main(void)
     {
-        int prev = __atomic_exchange_n(&loc, 7, __ATOMIC_RELAXED);
-        return 0;
+        uint64_t prev = __atomic_exchange_n(&loc, 7, __ATOMIC_RELAXED);
+        return prev & 0xff;
     }
     ]])],
   [AC_MSG_RESULT(no)],
@@ -57,6 +58,8 @@ AC_LINK_IFELSE(
     {
         __int128 prev;
         prev = __atomic_exchange_n(&loc, 7, __ATOMIC_RELAXED);
+        // Do not optimize away prev
+        __asm__ volatile("" : : "g"(&prev) : "memory");
         return 0;
     }
     ]])],


### PR DESCRIPTION
Add cross compilation checks. Compile using gcc for ARM-HF, ARM64 and PowerPC. MIPS64 is left away, because Trusty doesn't provide necessary packets.