### PR TITLE
[PATCH API-NEXT v1] linux-gen: fix out-of-tree build

### DIFF
--- a/platform/Makefile.inc
+++ b/platform/Makefile.inc
@@ -29,7 +29,6 @@ odpapispecinclude_HEADERS = \
 		  $(top_srcdir)/include/odp/api/spec/cpumask.h \
 		  $(top_srcdir)/include/odp/api/spec/crypto.h \
 		  $(top_srcdir)/include/odp/api/spec/debug.h \
-		  $(top_srcdir)/include/odp/api/spec/deprecated.h \
 		  $(top_srcdir)/include/odp/api/spec/errno.h \
 		  $(top_srcdir)/include/odp/api/spec/event.h \
 		  $(top_srcdir)/include/odp/api/spec/feature.h \


### PR DESCRIPTION
Drop include/odp/api/spec/deprecated.h from headers list incorrectly
added by merge a5ef33a6f2575cd011cb05c3fb1b06d1c017f879.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>