### PR TITLE
[PATCH API-NEXT v9] Crypto API rework

### DIFF
--- a/example/ipsec/odp_ipsec.c
+++ b/example/ipsec/odp_ipsec.c
@@ -393,9 +393,7 @@ void ipsec_init_post(crypto_api_mode_e api_mode)
 						     auth_sa,
 						     tun,
 						     api_mode,
-						     entry->input,
-						     completionq,
-						     out_pool)) {
+						     entry->input)) {
 				EXAMPLE_ERR("Error: IPSec cache entry failed.\n"
 						);
 				exit(EXIT_FAILURE);
@@ -662,7 +660,6 @@ pkt_disposition_e do_ipsec_in_classify(odp_packet_t pkt,
 
 	/* Initialize parameters block */
 	memset(&params, 0, sizeof(params));
-	params.ctx = ctx;
 	params.session = entry->state.session;
 	params.pkt = pkt;
 	params.out_pkt = entry->in_place ? pkt : ODP_PACKET_INVALID;
@@ -843,7 +840,6 @@ pkt_disposition_e do_ipsec_out_classify(odp_packet_t pkt,
 	/* Initialize parameters block */
 	memset(&params, 0, sizeof(params));
 	params.session = entry->state.session;
-	params.ctx = ctx;
 	params.pkt = pkt;
 	params.out_pkt = entry->in_place ? pkt : ODP_PACKET_INVALID;
 
@@ -1085,14 +1081,6 @@ int pktio_thread(void *arg EXAMPLE_UNUSED)
 				}
 				ctx->state = PKT_STATE_INPUT_VERIFY;
 			}
-		} else if (ODP_EVENT_CRYPTO_COMPL == odp_event_type(ev)) {
-			odp_crypto_compl_t compl;
-
-			compl = odp_crypto_compl_from_event(ev);
-			odp_crypto_compl_result(compl, &result);
-			odp_crypto_compl_free(compl);
-			pkt = result.pkt;
-			ctx = result.ctx;
 		} else {
 			abort();
 		}

--- a/example/ipsec/odp_ipsec.c
+++ b/example/ipsec/odp_ipsec.c
@@ -724,9 +724,9 @@ pkt_disposition_e do_ipsec_in_finish(odp_packet_t pkt,
 
 	/* Check crypto result */
 	if (!result->ok) {
-		if (!is_crypto_compl_status_ok(&result->cipher_status))
+		if (!is_crypto_op_status_ok(&result->cipher_status))
 			return PKT_DROP;
-		if (!is_crypto_compl_status_ok(&result->auth_status))
+		if (!is_crypto_op_status_ok(&result->auth_status))
 			return PKT_DROP;
 	}
 	ip = (odph_ipv4hdr_t *)odp_packet_l3_ptr(pkt, NULL);
@@ -1011,9 +1011,9 @@ pkt_disposition_e do_ipsec_out_finish(odp_packet_t pkt,
 
 	/* Check crypto result */
 	if (!result->ok) {
-		if (!is_crypto_compl_status_ok(&result->cipher_status))
+		if (!is_crypto_op_status_ok(&result->cipher_status))
 			return PKT_DROP;
-		if (!is_crypto_compl_status_ok(&result->auth_status))
+		if (!is_crypto_op_status_ok(&result->auth_status))
 			return PKT_DROP;
 	}
 	ip = (odph_ipv4hdr_t *)odp_packet_l3_ptr(pkt, NULL);

--- a/example/ipsec/odp_ipsec_cache.c
+++ b/example/ipsec/odp_ipsec_cache.c
@@ -40,9 +40,7 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 			     sa_db_entry_t *auth_sa,
 			     tun_db_entry_t *tun,
 			     crypto_api_mode_e api_mode,
-			     odp_bool_t in,
-			     odp_queue_t completionq,
-			     odp_pool_t out_pool)
+			     odp_bool_t in)
 {
 	odp_crypto_session_param_t params;
 	ipsec_cache_entry_t *entry;
@@ -65,15 +63,8 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 	/* Setup parameters and call crypto library to create session */
 	params.op = (in) ? ODP_CRYPTO_OP_DECODE : ODP_CRYPTO_OP_ENCODE;
 	params.auth_cipher_text = TRUE;
-	if (CRYPTO_API_SYNC == api_mode) {
-		params.pref_mode   = ODP_CRYPTO_SYNC;
-		params.compl_queue = ODP_QUEUE_INVALID;
-		params.output_pool = ODP_POOL_INVALID;
-	} else {
-		params.pref_mode   = ODP_CRYPTO_ASYNC;
-		params.compl_queue = completionq;
-		params.output_pool = out_pool;
-	}
+	params.compl_queue = ODP_QUEUE_INVALID;
+	params.output_pool = ODP_POOL_INVALID;
 
 	if (CRYPTO_API_ASYNC_NEW_BUFFER == api_mode)
 		entry->in_place = FALSE;

--- a/example/ipsec/odp_ipsec_cache.h
+++ b/example/ipsec/odp_ipsec_cache.h
@@ -32,6 +32,7 @@ typedef enum {
 typedef struct ipsec_cache_entry_s {
 	struct ipsec_cache_entry_s  *next;        /**< Next entry on list */
 	odp_bool_t                   in_place;    /**< Crypto API mode */
+	odp_bool_t                   async;       /**< ASYNC or SYNC mode */
 	uint32_t                     src_ip;      /**< Source v4 address */
 	uint32_t                     dst_ip;      /**< Destination v4 address */
 	sa_mode_t		     mode;        /**< SA mode - transport/tun */
@@ -85,6 +86,8 @@ void init_ipsec_cache(void);
  * @param tun         Tunnel DB entry pointer
  * @param api_mode    Crypto API mode for testing
  * @param in          Direction (input versus output)
+ * @param completionq Completion queue
+ * @param out_pool    Output buffer pool
  *
  * @return 0 if successful else -1
  */
@@ -92,7 +95,9 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 			     sa_db_entry_t *auth_sa,
 			     tun_db_entry_t *tun,
 			     crypto_api_mode_e api_mode,
-			     odp_bool_t in);
+			     odp_bool_t in,
+			     odp_queue_t completionq,
+			     odp_pool_t out_pool);
 
 /**
  * Find a matching IPsec cache entry for input packet

--- a/example/ipsec/odp_ipsec_cache.h
+++ b/example/ipsec/odp_ipsec_cache.h
@@ -85,8 +85,6 @@ void init_ipsec_cache(void);
  * @param tun         Tunnel DB entry pointer
  * @param api_mode    Crypto API mode for testing
  * @param in          Direction (input versus output)
- * @param completionq Completion queue
- * @param out_pool    Output buffer pool
  *
  * @return 0 if successful else -1
  */
@@ -94,9 +92,7 @@ int create_ipsec_cache_entry(sa_db_entry_t *cipher_sa,
 			     sa_db_entry_t *auth_sa,
 			     tun_db_entry_t *tun,
 			     crypto_api_mode_e api_mode,
-			     odp_bool_t in,
-			     odp_queue_t completionq,
-			     odp_pool_t out_pool);
+			     odp_bool_t in);
 
 /**
  * Find a matching IPsec cache entry for input packet

--- a/example/ipsec/odp_ipsec_misc.h
+++ b/example/ipsec/odp_ipsec_misc.h
@@ -321,12 +321,12 @@ void ipv4_adjust_len(odph_ipv4hdr_t *ip, int adj)
 /**
  * Verify crypto operation completed successfully
  *
- * @param status  Pointer to cryto completion structure
+ * @param status  Pointer to crypto op status structure
  *
  * @return TRUE if all OK else FALSE
  */
 static inline
-odp_bool_t is_crypto_compl_status_ok(odp_crypto_compl_status_t *status)
+odp_bool_t is_crypto_op_status_ok(odp_crypto_op_status_t *status)
 {
 	if (status->alg_err != ODP_CRYPTO_ALG_ERR_NONE)
 		return FALSE;

--- a/example/ipsec/odp_ipsec_misc.h
+++ b/example/ipsec/odp_ipsec_misc.h
@@ -321,7 +321,7 @@ void ipv4_adjust_len(odph_ipv4hdr_t *ip, int adj)
 /**
  * Verify crypto operation completed successfully
  *
- * @param status  Pointer to crypto op status structure
+ * @param status  Pointer to cryto completion structure
  *
  * @return TRUE if all OK else FALSE
  */

--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -270,8 +270,11 @@ typedef struct odp_crypto_session_param_t {
 	 */
 	odp_bool_t auth_cipher_text;
 
-	/** Preferred sync vs. async */
-	odp_crypto_op_mode_t pref_mode;
+	/** Preferred sync vs. async
+	 *
+	 * @deprecated no-op now, odp_crypto_operation() will always process
+	 * data in non-posted mode */
+	odp_crypto_op_mode_t ODP_DEPRECATE(pref_mode);
 
 	/** Cipher algorithm
 	 *
@@ -334,8 +337,11 @@ typedef struct odp_crypto_op_param_t {
 	/** Session handle from creation */
 	odp_crypto_session_t session;
 
-	/** User context */
-	void *ctx;
+	/** User context
+	 *
+	 * @deprecated No need to pass context around sync calls
+	 * */
+	void *ODP_DEPRECATE(ctx);
 
 	/** Input packet
 	 *
@@ -618,7 +624,8 @@ int odp_crypto_session_destroy(odp_crypto_session_t session);
  *
  * @return crypto completion handle
  */
-odp_crypto_compl_t odp_crypto_compl_from_event(odp_event_t ev);
+ODP_DEPRECATE(odp_crypto_compl_t) ODP_DEPRECATE(odp_crypto_compl_from_event)(
+						odp_event_t ev);
 
 /**
  * Convert crypto completion handle to event handle
@@ -627,14 +634,16 @@ odp_crypto_compl_t odp_crypto_compl_from_event(odp_event_t ev);
  *
  * @return Event handle
  */
-odp_event_t odp_crypto_compl_to_event(odp_crypto_compl_t completion_event);
+odp_event_t ODP_DEPRECATE(odp_crypto_compl_to_event)(
+			  ODP_DEPRECATE(odp_crypto_compl_t) completion_event);
 
 /**
  * Release crypto completion event
  *
  * @param completion_event  Completion event we are done accessing
  */
-void odp_crypto_compl_free(odp_crypto_compl_t completion_event);
+void ODP_DEPRECATE(odp_crypto_compl_free)(
+		   ODP_DEPRECATE(odp_crypto_compl_t) completion_event);
 
 /**
  * Crypto per packet operation
@@ -662,8 +671,9 @@ int odp_crypto_operation(odp_crypto_op_param_t *param,
  * @param completion_event  Event containing operation results
  * @param result            Pointer to result structure
  */
-void odp_crypto_compl_result(odp_crypto_compl_t completion_event,
-			     odp_crypto_op_result_t *result);
+void ODP_DEPRECATE(odp_crypto_compl_result)(
+		   ODP_DEPRECATE(odp_crypto_compl_t) completion_event,
+		   odp_crypto_op_result_t *result);
 
 /**
  * Get printable value for an odp_crypto_session_t
@@ -689,7 +699,8 @@ uint64_t odp_crypto_session_to_u64(odp_crypto_session_t hdl);
  * to enable applications to generate a printable value that represents
  * an odp_crypto_compl_t handle.
  */
-uint64_t odp_crypto_compl_to_u64(odp_crypto_compl_t hdl);
+uint64_t ODP_DEPRECATE(odp_crypto_compl_to_u64)(
+		       ODP_DEPRECATE(odp_crypto_compl_t) hdl);
 
 /**
  * Initialize crypto session parameters

--- a/include/odp/arch/default/api/abi/crypto.h
+++ b/include/odp/arch/default/api/abi/crypto.h
@@ -11,6 +11,8 @@
 extern "C" {
 #endif
 
+#include <odp/api/deprecated.h>
+
 #include <stdint.h>
 
 /** @internal Dummy type for strong typing */
@@ -23,7 +25,7 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_crypto_compl_t;
 #define ODP_CRYPTO_SESSION_INVALID (0xffffffffffffffffULL)
 
 typedef uint64_t  odp_crypto_session_t;
-typedef _odp_abi_crypto_compl_t *odp_crypto_compl_t;
+typedef _odp_abi_crypto_compl_t *ODP_DEPRECATE(odp_crypto_compl_t);
 
 /**
  * @}

--- a/include/odp/arch/default/api/abi/event.h
+++ b/include/odp/arch/default/api/abi/event.h
@@ -11,6 +11,8 @@
 extern "C" {
 #endif
 
+#include <odp/api/deprecated.h>
+
 #include <stdint.h>
 
 /** @internal Dummy type for strong typing */
@@ -28,7 +30,7 @@ typedef enum odp_event_type_t {
 	ODP_EVENT_BUFFER       = 1,
 	ODP_EVENT_PACKET       = 2,
 	ODP_EVENT_TIMEOUT      = 3,
-	ODP_EVENT_CRYPTO_COMPL = 4,
+	ODP_DEPRECATE(ODP_EVENT_CRYPTO_COMPL) = 4,
 	ODP_EVENT_IPSEC_STATUS = 5
 } odp_event_type_t;
 

--- a/include/odp/arch/default/api/abi/event.h
+++ b/include/odp/arch/default/api/abi/event.h
@@ -37,7 +37,8 @@ typedef enum odp_event_type_t {
 typedef enum odp_event_subtype_t {
 	ODP_EVENT_NO_SUBTYPE   = 0,
 	ODP_EVENT_PACKET_BASIC = 1,
-	ODP_EVENT_PACKET_IPSEC = 2
+	ODP_EVENT_PACKET_CRYPTO = 2,
+	ODP_EVENT_PACKET_IPSEC = 3
 } odp_event_subtype_t;
 
 /**

--- a/platform/linux-generic/include/odp/api/plat/crypto_types.h
+++ b/platform/linux-generic/include/odp/api/plat/crypto_types.h
@@ -22,6 +22,7 @@ extern "C" {
 #if ODP_ABI_COMPAT == 1
 #include <odp/api/abi/crypto.h>
 #else
+#include <odp/api/deprecated.h>
 
 /** @ingroup odp_crypto
  *  @{
@@ -30,7 +31,7 @@ extern "C" {
 #define ODP_CRYPTO_SESSION_INVALID (0xffffffffffffffffULL)
 
 typedef uint64_t odp_crypto_session_t;
-typedef ODP_HANDLE_T(odp_crypto_compl_t);
+typedef ODP_HANDLE_T(ODP_DEPRECATE(odp_crypto_compl_t));
 
 /**
  * @}

--- a/platform/linux-generic/include/odp/api/plat/event_types.h
+++ b/platform/linux-generic/include/odp/api/plat/event_types.h
@@ -23,6 +23,7 @@ extern "C" {
 #include <odp/api/abi/event.h>
 #else
 
+#include <odp/api/deprecated.h>
 #include <odp/api/std_types.h>
 #include <odp/api/plat/strong_types.h>
 
@@ -38,7 +39,7 @@ typedef enum odp_event_type_t {
 	ODP_EVENT_BUFFER       = 1,
 	ODP_EVENT_PACKET       = 2,
 	ODP_EVENT_TIMEOUT      = 3,
-	ODP_EVENT_CRYPTO_COMPL = 4,
+	ODP_DEPRECATE(ODP_EVENT_CRYPTO_COMPL) = 4,
 	ODP_EVENT_IPSEC_STATUS = 5
 } odp_event_type_t;
 

--- a/platform/linux-generic/include/odp/api/plat/event_types.h
+++ b/platform/linux-generic/include/odp/api/plat/event_types.h
@@ -46,7 +46,8 @@ typedef enum odp_event_type_t {
 typedef enum odp_event_subtype_t {
 	ODP_EVENT_NO_SUBTYPE   = 0,
 	ODP_EVENT_PACKET_BASIC = 1,
-	ODP_EVENT_PACKET_IPSEC = 2
+	ODP_EVENT_PACKET_CRYPTO = 2,
+	ODP_EVENT_PACKET_IPSEC = 3
 } odp_event_subtype_t;
 
 /**

--- a/platform/linux-generic/include/odp/api/plat/strong_types.h
+++ b/platform/linux-generic/include/odp/api/plat/strong_types.h
@@ -17,7 +17,9 @@
 
 /** Use strong typing for ODP types */
 #ifdef __cplusplus
-#define ODP_HANDLE_T(type) struct _##type { uint8_t unused_dummy_var; } *type
+/* Allow type to be expanded before concatenation with underscore */
+#define _ODP_HANDLE_T(type) struct _##type { uint8_t unused_dummy_var; } *type
+#define ODP_HANDLE_T(type) _ODP_HANDLE_T(type)
 #else
 #define odp_handle_t struct { uint8_t unused_dummy_var; } *
 /** C/C++ helper macro for strong typing */

--- a/platform/linux-generic/include/odp_buffer_inlines.h
+++ b/platform/linux-generic/include/odp_buffer_inlines.h
@@ -21,6 +21,8 @@ extern "C" {
 
 odp_event_type_t _odp_buffer_event_type(odp_buffer_t buf);
 void _odp_buffer_event_type_set(odp_buffer_t buf, int ev);
+odp_event_subtype_t _odp_buffer_event_subtype(odp_buffer_t buf);
+void _odp_buffer_event_subtype_set(odp_buffer_t buf, int ev);
 int odp_buffer_snprint(char *str, uint32_t n, odp_buffer_t buf);
 
 static inline odp_buffer_t odp_hdr_to_buf(odp_buffer_hdr_t *hdr)

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -96,6 +96,9 @@ struct odp_buffer_hdr_t {
 	/* Event type. Maybe different than pool type (crypto compl event) */
 	int8_t    event_type;
 
+	/* Event subtype. Should be ODP_EVENT_NO_SUBTYPE except packets. */
+	int8_t    event_subtype;
+
 	/* Burst table */
 	struct odp_buffer_hdr_t *burst[BUFFER_BURST_SIZE];
 

--- a/platform/linux-generic/include/odp_crypto_internal.h
+++ b/platform/linux-generic/include/odp_crypto_internal.h
@@ -56,14 +56,6 @@ struct odp_crypto_generic_session {
 };
 
 /**
- * Per packet operation result
- */
-typedef struct odp_crypto_generic_op_result {
-	uint32_t magic;
-	odp_crypto_op_result_t result;
-} odp_crypto_generic_op_result_t;
-
-/**
  * Per session creation operation result
  */
 typedef struct odp_crypto_generic_session_result {

--- a/platform/linux-generic/include/odp_crypto_internal.h
+++ b/platform/linux-generic/include/odp_crypto_internal.h
@@ -23,7 +23,8 @@ typedef struct odp_crypto_generic_session odp_crypto_generic_session_t;
  * Algorithm handler function prototype
  */
 typedef
-odp_crypto_alg_err_t (*crypto_func_t)(odp_crypto_op_param_t *param,
+odp_crypto_alg_err_t (*crypto_func_t)(odp_packet_t pkt,
+				      const odp_crypto_packet_op_param_t *param,
 				      odp_crypto_generic_session_t *session);
 
 /**

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -128,6 +128,9 @@ typedef struct {
 	/* Classifier destination queue */
 	odp_queue_t dst_queue;
 
+	/* Result for crypto packet op */
+	odp_crypto_packet_result_t crypto_op_result;
+
 	/* Packet data storage */
 	uint8_t data[0];
 } odp_packet_hdr_t;

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -128,9 +128,6 @@ typedef struct {
 	/* Classifier destination queue */
 	odp_queue_t dst_queue;
 
-	/* Result for crypto */
-	odp_crypto_generic_op_result_t op_result;
-
 	/* Packet data storage */
 	uint8_t data[0];
 } odp_packet_hdr_t;
@@ -171,7 +168,6 @@ static inline void copy_packet_cls_metadata(odp_packet_hdr_t *src_hdr,
 	dst_hdr->dst_queue = src_hdr->dst_queue;
 	dst_hdr->flow_hash = src_hdr->flow_hash;
 	dst_hdr->timestamp = src_hdr->timestamp;
-	dst_hdr->op_result = src_hdr->op_result;
 }
 
 static inline void pull_tail(odp_packet_hdr_t *pkt_hdr, uint32_t len)

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -113,7 +113,8 @@ void free_session(odp_crypto_generic_session_t *session)
 }
 
 static odp_crypto_alg_err_t
-null_crypto_routine(odp_crypto_op_param_t *param ODP_UNUSED,
+null_crypto_routine(odp_packet_t pkt ODP_UNUSED,
+		    const odp_crypto_packet_op_param_t *param ODP_UNUSED,
 		    odp_crypto_generic_session_t *session ODP_UNUSED)
 {
 	return ODP_CRYPTO_ALG_ERR_NONE;
@@ -121,11 +122,11 @@ null_crypto_routine(odp_crypto_op_param_t *param ODP_UNUSED,
 
 static
 void packet_hmac_calculate(HMAC_CTX *ctx,
-			   odp_crypto_op_param_t *param,
+			   odp_packet_t pkt,
+			   const odp_crypto_packet_op_param_t *param,
 			   odp_crypto_generic_session_t *session,
 			   uint8_t *hash)
 {
-	odp_packet_t pkt = param->out_pkt;
 	uint32_t offset = param->auth_range.offset;
 	uint32_t len   = param->auth_range.length;
 
@@ -152,7 +153,8 @@ void packet_hmac_calculate(HMAC_CTX *ctx,
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 static
-void packet_hmac(odp_crypto_op_param_t *param,
+void packet_hmac(odp_packet_t pkt,
+		 const odp_crypto_packet_op_param_t *param,
 		 odp_crypto_generic_session_t *session,
 		 uint8_t *hash)
 {
@@ -160,12 +162,13 @@ void packet_hmac(odp_crypto_op_param_t *param,
 
 	/* Hash it */
 	HMAC_CTX_init(&ctx);
-	packet_hmac_calculate(&ctx, param, session, hash);
+	packet_hmac_calculate(&ctx, pkt, param, session, hash);
 	HMAC_CTX_cleanup(&ctx);
 }
 #else
 static
-void packet_hmac(odp_crypto_op_param_t *param,
+void packet_hmac(odp_packet_t pkt,
+		 const odp_crypto_packet_op_param_t *param,
 		 odp_crypto_generic_session_t *session,
 		 uint8_t *hash)
 {
@@ -173,22 +176,23 @@ void packet_hmac(odp_crypto_op_param_t *param,
 
 	/* Hash it */
 	ctx = HMAC_CTX_new();
-	packet_hmac_calculate(ctx, param, session, hash);
+	packet_hmac_calculate(ctx, pkt, param, session, hash);
 	HMAC_CTX_free(ctx);
 }
 #endif
 
 static
-odp_crypto_alg_err_t auth_gen(odp_crypto_op_param_t *param,
+odp_crypto_alg_err_t auth_gen(odp_packet_t pkt,
+			      const odp_crypto_packet_op_param_t *param,
 			      odp_crypto_generic_session_t *session)
 {
 	uint8_t  hash[EVP_MAX_MD_SIZE];
 
 	/* Hash it */
-	packet_hmac(param, session, hash);
+	packet_hmac(pkt, param, session, hash);
 
 	/* Copy to the output location */
-	odp_packet_copy_from_mem(param->out_pkt,
+	odp_packet_copy_from_mem(pkt,
 				 param->hash_result_offset,
 				 session->auth.bytes,
 				 hash);
@@ -197,7 +201,8 @@ odp_crypto_alg_err_t auth_gen(odp_crypto_op_param_t *param,
 }
 
 static
-odp_crypto_alg_err_t auth_check(odp_crypto_op_param_t *param,
+odp_crypto_alg_err_t auth_check(odp_packet_t pkt,
+				const odp_crypto_packet_op_param_t *param,
 				odp_crypto_generic_session_t *session)
 {
 	uint32_t bytes = session->auth.bytes;
@@ -205,14 +210,14 @@ odp_crypto_alg_err_t auth_check(odp_crypto_op_param_t *param,
 	uint8_t  hash_out[EVP_MAX_MD_SIZE];
 
 	/* Copy current value out and clear it before authentication */
-	odp_packet_copy_to_mem(param->out_pkt, param->hash_result_offset,
+	odp_packet_copy_to_mem(pkt, param->hash_result_offset,
 			       bytes, hash_in);
 
-	_odp_packet_set_data(param->out_pkt, param->hash_result_offset,
+	_odp_packet_set_data(pkt, param->hash_result_offset,
 			     0, bytes);
 
 	/* Hash it */
-	packet_hmac(param, session, hash_out);
+	packet_hmac(pkt, param, session, hash_out);
 
 	/* Verify match */
 	if (0 != memcmp(hash_in, hash_out, bytes))
@@ -223,9 +228,10 @@ odp_crypto_alg_err_t auth_check(odp_crypto_op_param_t *param,
 }
 
 static
-int internal_encrypt(EVP_CIPHER_CTX *ctx, odp_crypto_op_param_t *param)
+int internal_encrypt(EVP_CIPHER_CTX *ctx,
+		     odp_packet_t pkt,
+		     const odp_crypto_packet_op_param_t *param)
 {
-	odp_packet_t pkt = param->out_pkt;
 	unsigned in_pos = param->cipher_range.offset;
 	unsigned out_pos = param->cipher_range.offset;
 	unsigned in_len = param->cipher_range.length;
@@ -278,9 +284,10 @@ int internal_encrypt(EVP_CIPHER_CTX *ctx, odp_crypto_op_param_t *param)
 }
 
 static
-int internal_decrypt(EVP_CIPHER_CTX *ctx, odp_crypto_op_param_t *param)
+int internal_decrypt(EVP_CIPHER_CTX *ctx,
+		     odp_packet_t pkt,
+		     const odp_crypto_packet_op_param_t *param)
 {
-	odp_packet_t pkt = param->out_pkt;
 	unsigned in_pos = param->cipher_range.offset;
 	unsigned out_pos = param->cipher_range.offset;
 	unsigned in_len = param->cipher_range.length;
@@ -333,7 +340,8 @@ int internal_decrypt(EVP_CIPHER_CTX *ctx, odp_crypto_op_param_t *param)
 }
 
 static
-odp_crypto_alg_err_t cipher_encrypt(odp_crypto_op_param_t *param,
+odp_crypto_alg_err_t cipher_encrypt(odp_packet_t pkt,
+				    const odp_crypto_packet_op_param_t *param,
 				    odp_crypto_generic_session_t *session)
 {
 	EVP_CIPHER_CTX *ctx;
@@ -354,7 +362,7 @@ odp_crypto_alg_err_t cipher_encrypt(odp_crypto_op_param_t *param,
 	EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 	EVP_CIPHER_CTX_set_padding(ctx, 0);
 
-	ret = internal_encrypt(ctx, param);
+	ret = internal_encrypt(ctx, pkt, param);
 
 	EVP_CIPHER_CTX_free(ctx);
 
@@ -363,7 +371,8 @@ odp_crypto_alg_err_t cipher_encrypt(odp_crypto_op_param_t *param,
 }
 
 static
-odp_crypto_alg_err_t cipher_decrypt(odp_crypto_op_param_t *param,
+odp_crypto_alg_err_t cipher_decrypt(odp_packet_t pkt,
+				    const odp_crypto_packet_op_param_t *param,
 				    odp_crypto_generic_session_t *session)
 {
 	EVP_CIPHER_CTX *ctx;
@@ -384,7 +393,7 @@ odp_crypto_alg_err_t cipher_decrypt(odp_crypto_op_param_t *param,
 	EVP_DecryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 	EVP_CIPHER_CTX_set_padding(ctx, 0);
 
-	ret = internal_decrypt(ctx, param);
+	ret = internal_decrypt(ctx, pkt, param);
 
 	EVP_CIPHER_CTX_free(ctx);
 
@@ -420,7 +429,8 @@ static int process_cipher_param(odp_crypto_generic_session_t *session,
 }
 
 static
-odp_crypto_alg_err_t aes_gcm_encrypt(odp_crypto_op_param_t *param,
+odp_crypto_alg_err_t aes_gcm_encrypt(odp_packet_t pkt,
+				     const odp_crypto_packet_op_param_t *param,
 				     odp_crypto_generic_session_t *session)
 {
 	EVP_CIPHER_CTX *ctx;
@@ -452,11 +462,11 @@ odp_crypto_alg_err_t aes_gcm_encrypt(odp_crypto_op_param_t *param,
 		EVP_EncryptUpdate(ctx, NULL, &dummy_len,
 				  aad_head, aad_len);
 
-	ret = internal_encrypt(ctx, param);
+	ret = internal_encrypt(ctx, pkt, param);
 
 	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG,
 			    session->p.auth_digest_len, block);
-	odp_packet_copy_from_mem(param->out_pkt, param->hash_result_offset,
+	odp_packet_copy_from_mem(pkt, param->hash_result_offset,
 				 session->p.auth_digest_len, block);
 
 	EVP_CIPHER_CTX_free(ctx);
@@ -466,7 +476,8 @@ odp_crypto_alg_err_t aes_gcm_encrypt(odp_crypto_op_param_t *param,
 }
 
 static
-odp_crypto_alg_err_t aes_gcm_decrypt(odp_crypto_op_param_t *param,
+odp_crypto_alg_err_t aes_gcm_decrypt(odp_packet_t pkt,
+				     const odp_crypto_packet_op_param_t *param,
 				     odp_crypto_generic_session_t *session)
 {
 	EVP_CIPHER_CTX *ctx;
@@ -493,7 +504,7 @@ odp_crypto_alg_err_t aes_gcm_decrypt(odp_crypto_op_param_t *param,
 	EVP_DecryptInit_ex(ctx, NULL, NULL, NULL, iv_ptr);
 	EVP_CIPHER_CTX_set_padding(ctx, 0);
 
-	odp_packet_copy_to_mem(param->out_pkt, param->hash_result_offset,
+	odp_packet_copy_to_mem(pkt, param->hash_result_offset,
 			       session->p.auth_digest_len, block);
 	EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG,
 			    session->p.auth_digest_len, block);
@@ -503,7 +514,7 @@ odp_crypto_alg_err_t aes_gcm_decrypt(odp_crypto_op_param_t *param,
 		EVP_DecryptUpdate(ctx, NULL, &dummy_len,
 				  aad_head, aad_len);
 
-	ret = internal_decrypt(ctx, param);
+	ret = internal_decrypt(ctx, pkt, param);
 
 	EVP_CIPHER_CTX_free(ctx);
 
@@ -833,87 +844,59 @@ int odp_crypto_session_destroy(odp_crypto_session_t session)
 	return 0;
 }
 
+/*
+ * Shim function around packet operation, can be used by other implementations.
+ */
 int
 odp_crypto_operation(odp_crypto_op_param_t *param,
 		     odp_bool_t *posted,
 		     odp_crypto_op_result_t *result)
 {
-	odp_crypto_alg_err_t rc_cipher = ODP_CRYPTO_ALG_ERR_NONE;
-	odp_crypto_alg_err_t rc_auth = ODP_CRYPTO_ALG_ERR_NONE;
-	odp_crypto_generic_session_t *session;
+	odp_crypto_packet_op_param_t packet_param;
+	odp_packet_t out_pkt = param->out_pkt;
+	odp_crypto_packet_result_t packet_result;
 	odp_crypto_op_result_t local_result;
-	odp_bool_t allocated = false;
+	int rc;
 
-	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
+	packet_param.session = param->session;
+	packet_param.override_iv_ptr = param->override_iv_ptr;
+	packet_param.hash_result_offset = param->hash_result_offset;
+	packet_param.aad.ptr = param->aad.ptr;
+	packet_param.aad.length = param->aad.length;
+	packet_param.cipher_range = param->cipher_range;
+	packet_param.auth_range = param->auth_range;
 
-	/* Resolve output buffer */
-	if (ODP_PACKET_INVALID == param->out_pkt &&
-	    ODP_POOL_INVALID != session->p.output_pool) {
-		param->out_pkt = odp_packet_alloc(session->p.output_pool,
-				odp_packet_len(param->pkt));
-		allocated = true;
-	}
+	rc = odp_crypto_packet_op(&param->pkt, &out_pkt, &packet_param, 1);
+	if (rc < 0)
+		return rc;
 
-	if (odp_unlikely(ODP_PACKET_INVALID == param->out_pkt)) {
-		ODP_DBG("Alloc failed.\n");
-		return -1;
-	}
+	rc = odp_crypto_packet_result(&packet_result, out_pkt);
+	if (rc < 0)
+		return rc;
 
-	if (param->pkt != param->out_pkt) {
-		int ret;
+	/* Indicate to caller operation was sync */
+	*posted = 0;
 
-		ret = odp_packet_copy_from_pkt(param->out_pkt,
-					       0,
-					       param->pkt,
-					       0,
-					       odp_packet_len(param->pkt));
-		if (odp_unlikely(ret < 0))
-			goto err;
-
-		_odp_packet_copy_md_to_packet(param->pkt, param->out_pkt);
-		odp_packet_free(param->pkt);
-		param->pkt = ODP_PACKET_INVALID;
-	}
-
-	/* Invoke the functions */
-	if (session->do_cipher_first) {
-		rc_cipher = session->cipher.func(param, session);
-		rc_auth = session->auth.func(param, session);
-	} else {
-		rc_auth = session->auth.func(param, session);
-		rc_cipher = session->cipher.func(param, session);
-	}
+	_odp_buffer_event_subtype_set(_odp_packet_to_buffer(out_pkt),
+				      ODP_EVENT_PACKET_BASIC);
 
 	/* Fill in result */
 #if ODP_DEPRECATED_API
 	local_result.ctx = param->ctx;
 #endif
-	local_result.pkt = param->out_pkt;
-	local_result.cipher_status.alg_err = rc_cipher;
-	local_result.cipher_status.hw_err = ODP_CRYPTO_HW_ERR_NONE;
-	local_result.auth_status.alg_err = rc_auth;
-	local_result.auth_status.hw_err = ODP_CRYPTO_HW_ERR_NONE;
-	local_result.ok =
-		(rc_cipher == ODP_CRYPTO_ALG_ERR_NONE) &&
-		(rc_auth == ODP_CRYPTO_ALG_ERR_NONE);
+	local_result.pkt = out_pkt;
+	local_result.cipher_status = packet_result.cipher_status;
+	local_result.auth_status = packet_result.auth_status;
+	local_result.ok = packet_result.ok;
 
-	/* Synchronous, simply return results */
-	if (!result)
-		goto err;
+	/*
+	 * Be bug-to-bug compatible. Return output packet also through params.
+	 */
+	param->out_pkt = out_pkt;
+
 	*result = local_result;
 
-	/* Indicate to caller operation was sync */
-	*posted = 0;
-
 	return 0;
-
-err:
-	if (allocated) {
-		odp_packet_free(param->out_pkt);
-		param->out_pkt = ODP_PACKET_INVALID;
-	}
-
-	return -1;
 }
 
 static void ODP_UNUSED openssl_thread_id(CRYPTO_THREADID ODP_UNUSED *id)
@@ -1094,4 +1077,172 @@ void odp_crypto_session_param_init(odp_crypto_session_param_t *param)
 uint64_t odp_crypto_session_to_u64(odp_crypto_session_t hdl)
 {
 	return (uint64_t)hdl;
+}
+
+odp_packet_t odp_crypto_packet_from_event(odp_event_t ev)
+{
+	/* This check not mandated by the API specification */
+	ODP_ASSERT(odp_event_type(ev) == ODP_EVENT_PACKET);
+	ODP_ASSERT(odp_event_subtype(ev) == ODP_EVENT_PACKET_CRYPTO);
+
+	return odp_packet_from_event(ev);
+}
+
+odp_event_t odp_crypto_packet_to_event(odp_packet_t pkt)
+{
+	return odp_packet_to_event(pkt);
+}
+
+static
+odp_crypto_packet_result_t *get_op_result_from_packet(odp_packet_t pkt)
+{
+	odp_packet_hdr_t *hdr = odp_packet_hdr(pkt);
+
+	return &hdr->crypto_op_result;
+}
+
+int odp_crypto_packet_result(odp_crypto_packet_result_t *result,
+			     odp_packet_t packet)
+{
+	odp_crypto_packet_result_t *op_result;
+
+	ODP_ASSERT(odp_event_subtype(odp_packet_to_event(packet)) ==
+		   ODP_EVENT_PACKET_CRYPTO);
+
+	op_result = get_op_result_from_packet(packet);
+
+	memcpy(result, op_result, sizeof(*result));
+
+	return 0;
+}
+
+static
+int odp_crypto_op(odp_packet_t pkt_in,
+		  odp_packet_t *pkt_out,
+		  const odp_crypto_packet_op_param_t *param)
+{
+	odp_crypto_alg_err_t rc_cipher = ODP_CRYPTO_ALG_ERR_NONE;
+	odp_crypto_alg_err_t rc_auth = ODP_CRYPTO_ALG_ERR_NONE;
+	odp_crypto_generic_session_t *session;
+	odp_crypto_packet_result_t local_result;
+	odp_bool_t allocated = false;
+	odp_packet_t out_pkt = *pkt_out;
+	odp_crypto_packet_result_t *op_result;
+
+	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
+
+	/* Resolve output buffer */
+	if (ODP_PACKET_INVALID == out_pkt &&
+	    ODP_POOL_INVALID != session->p.output_pool) {
+		out_pkt = odp_packet_alloc(session->p.output_pool,
+					   odp_packet_len(pkt_in));
+		allocated = true;
+	}
+
+	if (odp_unlikely(ODP_PACKET_INVALID == out_pkt)) {
+		ODP_DBG("Alloc failed.\n");
+		return -1;
+	}
+
+	if (pkt_in != out_pkt) {
+		int ret;
+
+		ret = odp_packet_copy_from_pkt(out_pkt,
+					       0,
+					       pkt_in,
+					       0,
+					       odp_packet_len(pkt_in));
+		if (odp_unlikely(ret < 0))
+			goto err;
+
+		_odp_packet_copy_md_to_packet(pkt_in, out_pkt);
+		odp_packet_free(pkt_in);
+		pkt_in = ODP_PACKET_INVALID;
+	}
+
+	/* Invoke the functions */
+	if (session->do_cipher_first) {
+		rc_cipher = session->cipher.func(out_pkt, param, session);
+		rc_auth = session->auth.func(out_pkt, param, session);
+	} else {
+		rc_auth = session->auth.func(out_pkt, param, session);
+		rc_cipher = session->cipher.func(out_pkt, param, session);
+	}
+
+	/* Fill in result */
+	local_result.cipher_status.alg_err = rc_cipher;
+	local_result.cipher_status.hw_err = ODP_CRYPTO_HW_ERR_NONE;
+	local_result.auth_status.alg_err = rc_auth;
+	local_result.auth_status.hw_err = ODP_CRYPTO_HW_ERR_NONE;
+	local_result.ok =
+		(rc_cipher == ODP_CRYPTO_ALG_ERR_NONE) &&
+		(rc_auth == ODP_CRYPTO_ALG_ERR_NONE);
+
+	_odp_buffer_event_subtype_set(_odp_packet_to_buffer(out_pkt),
+				      ODP_EVENT_PACKET_CRYPTO);
+	op_result = get_op_result_from_packet(out_pkt);
+	*op_result = local_result;
+
+	/* Synchronous, simply return results */
+	*pkt_out = out_pkt;
+
+	return 0;
+
+err:
+	if (allocated) {
+		odp_packet_free(out_pkt);
+		out_pkt = ODP_PACKET_INVALID;
+	}
+
+	return -1;
+}
+
+int odp_crypto_packet_op(const odp_packet_t pkt_in[],
+			 odp_packet_t pkt_out[],
+			 const odp_crypto_packet_op_param_t param[],
+			 int num_pkt)
+{
+	int i, rc;
+	odp_crypto_generic_session_t *session;
+
+	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
+	ODP_ASSERT(ODP_CRYPTO_SYNC == session->p.packet_op_mode);
+
+	for (i = 0; i < num_pkt; i++) {
+		rc = odp_crypto_op(pkt_in[i], &pkt_out[i], &param[i]);
+		if (rc < 0)
+			break;
+	}
+
+	return i;
+}
+
+int odp_crypto_packet_op_enq(const odp_packet_t pkt_in[],
+			     const odp_packet_t pkt_out[],
+			     const odp_crypto_packet_op_param_t param[],
+			     int num_pkt)
+{
+	odp_packet_t pkt;
+	odp_event_t event;
+	odp_crypto_generic_session_t *session;
+	int i, rc;
+
+	session = (odp_crypto_generic_session_t *)(intptr_t)param->session;
+	ODP_ASSERT(ODP_CRYPTO_ASYNC == session->p.packet_op_mode);
+	ODP_ASSERT(ODP_QUEUE_INVALID != session->p.compl_queue);
+
+	for (i = 0; i < num_pkt; i++) {
+		pkt = pkt_out[i];
+		rc = odp_crypto_op(pkt_in[i], &pkt, &param[i]);
+		if (rc < 0)
+			break;
+
+		event = odp_packet_to_event(pkt);
+		if (odp_queue_enq(session->p.compl_queue, event)) {
+			odp_event_free(event);
+			break;
+		}
+	}
+
+	return i;
 }

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -885,7 +885,9 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 	}
 
 	/* Fill in result */
+#if ODP_DEPRECATED_API
 	local_result.ctx = param->ctx;
+#endif
 	local_result.pkt = param->out_pkt;
 	local_result.cipher_status.alg_err = rc_cipher;
 	local_result.cipher_status.hw_err = ODP_CRYPTO_HW_ERR_NONE;
@@ -1045,6 +1047,7 @@ int32_t odp_random_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
 	return len;
 }
 
+#if ODP_DEPRECATED_API
 odp_crypto_compl_t odp_crypto_compl_from_event(odp_event_t ev)
 {
 	/* This check not mandated by the API specification */
@@ -1077,6 +1080,12 @@ odp_crypto_compl_free(odp_crypto_compl_t completion_event)
 	odp_buffer_free(odp_buffer_from_event(ev));
 }
 
+uint64_t odp_crypto_compl_to_u64(odp_crypto_compl_t hdl)
+{
+	return _odp_pri(hdl);
+}
+#endif
+
 void odp_crypto_session_param_init(odp_crypto_session_param_t *param)
 {
 	memset(param, 0, sizeof(odp_crypto_session_param_t));
@@ -1085,9 +1094,4 @@ void odp_crypto_session_param_init(odp_crypto_session_param_t *param)
 uint64_t odp_crypto_session_to_u64(odp_crypto_session_t hdl)
 {
 	return (uint64_t)hdl;
-}
-
-uint64_t odp_crypto_compl_to_u64(odp_crypto_compl_t hdl)
-{
-	return _odp_pri(hdl);
 }

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -88,14 +88,6 @@ struct odp_crypto_global_s {
 static odp_crypto_global_t *global;
 
 static
-odp_crypto_generic_op_result_t *get_op_result_from_event(odp_event_t ev)
-{
-	odp_packet_hdr_t *hdr = odp_packet_hdr(odp_packet_from_event(ev));
-
-	return &hdr->op_result;
-}
-
-static
 odp_crypto_generic_session_t *alloc_session(void)
 {
 	odp_crypto_generic_session_t *session = NULL;
@@ -903,37 +895,14 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 		(rc_cipher == ODP_CRYPTO_ALG_ERR_NONE) &&
 		(rc_auth == ODP_CRYPTO_ALG_ERR_NONE);
 
-	/* If specified during creation post event to completion queue */
-	if (ODP_QUEUE_INVALID != session->p.compl_queue) {
-		odp_event_t completion_event;
-		odp_crypto_generic_op_result_t *op_result;
-		odp_buffer_t buf;
+	/* Synchronous, simply return results */
+	if (!result)
+		goto err;
+	*result = local_result;
 
-		/* Linux generic will always use packet for completion event */
-		completion_event = odp_packet_to_event(param->out_pkt);
-		buf = odp_buffer_from_event(completion_event);
-		_odp_buffer_event_type_set(buf, ODP_EVENT_CRYPTO_COMPL);
-		_odp_buffer_event_subtype_set(buf, ODP_EVENT_NO_SUBTYPE);
-		/* Asynchronous, build result (no HW so no errors) and send it*/
-		op_result = get_op_result_from_event(completion_event);
-		op_result->magic = OP_RESULT_MAGIC;
-		op_result->result = local_result;
-		if (odp_queue_enq(session->p.compl_queue, completion_event)) {
-			odp_event_free(completion_event);
-			goto err;
-		}
+	/* Indicate to caller operation was sync */
+	*posted = 0;
 
-		/* Indicate to caller operation was async */
-		*posted = 1;
-	} else {
-		/* Synchronous, simply return results */
-		if (!result)
-			goto err;
-		*result = local_result;
-
-		/* Indicate to caller operation was sync */
-		*posted = 0;
-	}
 	return 0;
 
 err:
@@ -1093,25 +1062,19 @@ void
 odp_crypto_compl_result(odp_crypto_compl_t completion_event,
 			odp_crypto_op_result_t *result)
 {
-	odp_event_t ev = odp_crypto_compl_to_event(completion_event);
-	odp_crypto_generic_op_result_t *op_result;
+	(void)completion_event;
+	(void)result;
 
-	op_result = get_op_result_from_event(ev);
-
-	if (OP_RESULT_MAGIC != op_result->magic)
-		ODP_ABORT();
-
-	memcpy(result, &op_result->result, sizeof(*result));
+	/* We won't get such events anyway, so there can be no result */
+	ODP_ASSERT(0);
 }
 
 void
 odp_crypto_compl_free(odp_crypto_compl_t completion_event)
 {
-	odp_buffer_t buf =
-		odp_buffer_from_event((odp_event_t)completion_event);
+	odp_event_t ev = odp_crypto_compl_to_event(completion_event);
 
-	_odp_buffer_event_type_set(buf, ODP_EVENT_PACKET);
-	_odp_buffer_event_subtype_set(buf, ODP_EVENT_PACKET_BASIC);
+	odp_buffer_free(odp_buffer_from_event(ev));
 }
 
 void odp_crypto_session_param_init(odp_crypto_session_param_t *param)

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -907,12 +907,13 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 	if (ODP_QUEUE_INVALID != session->p.compl_queue) {
 		odp_event_t completion_event;
 		odp_crypto_generic_op_result_t *op_result;
+		odp_buffer_t buf;
 
 		/* Linux generic will always use packet for completion event */
 		completion_event = odp_packet_to_event(param->out_pkt);
-		_odp_buffer_event_type_set(
-			odp_buffer_from_event(completion_event),
-			ODP_EVENT_CRYPTO_COMPL);
+		buf = odp_buffer_from_event(completion_event);
+		_odp_buffer_event_type_set(buf, ODP_EVENT_CRYPTO_COMPL);
+		_odp_buffer_event_subtype_set(buf, ODP_EVENT_NO_SUBTYPE);
 		/* Asynchronous, build result (no HW so no errors) and send it*/
 		op_result = get_op_result_from_event(completion_event);
 		op_result->magic = OP_RESULT_MAGIC;
@@ -1106,9 +1107,11 @@ odp_crypto_compl_result(odp_crypto_compl_t completion_event,
 void
 odp_crypto_compl_free(odp_crypto_compl_t completion_event)
 {
-	_odp_buffer_event_type_set(
-		odp_buffer_from_event((odp_event_t)completion_event),
-		ODP_EVENT_PACKET);
+	odp_buffer_t buf =
+		odp_buffer_from_event((odp_event_t)completion_event);
+
+	_odp_buffer_event_type_set(buf, ODP_EVENT_PACKET);
+	_odp_buffer_event_subtype_set(buf, ODP_EVENT_PACKET_BASIC);
 }
 
 void odp_crypto_session_param_init(odp_crypto_session_param_t *param)

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -46,9 +46,11 @@ void odp_event_free(odp_event_t event)
 	case ODP_EVENT_TIMEOUT:
 		odp_timeout_free(odp_timeout_from_event(event));
 		break;
+#if ODP_DEPRECATED_API
 	case ODP_EVENT_CRYPTO_COMPL:
 		odp_crypto_compl_free(odp_crypto_compl_from_event(event));
 		break;
+#endif
 	default:
 		ODP_ABORT("Invalid event type: %d\n", odp_event_type(event));
 	}

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -19,6 +19,21 @@ odp_event_type_t odp_event_type(odp_event_t event)
 	return _odp_buffer_event_type(odp_buffer_from_event(event));
 }
 
+odp_event_subtype_t odp_event_subtype(odp_event_t event)
+{
+	return _odp_buffer_event_subtype(odp_buffer_from_event(event));
+}
+
+odp_event_type_t odp_event_types(odp_event_t event,
+				 odp_event_subtype_t *subtype)
+{
+	odp_buffer_t buf = odp_buffer_from_event(event);
+
+	*subtype = _odp_buffer_event_subtype(buf);
+
+	return _odp_buffer_event_type(buf);
+}
+
 void odp_event_free(odp_event_t event)
 {
 	switch (odp_event_type(event)) {

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -166,7 +166,6 @@ static inline void packet_seg_copy_md(odp_packet_hdr_t *dst,
 	dst->dst_queue = src->dst_queue;
 	dst->flow_hash = src->flow_hash;
 	dst->timestamp = src->timestamp;
-	dst->op_result = src->op_result;
 
 	/* buffer header side packet metadata */
 	dst->buf_hdr.buf_u64    = src->buf_hdr.buf_u64;

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -268,6 +268,7 @@ static inline void packet_init(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 			     CONFIG_PACKET_TAILROOM;
 
 	pkt_hdr->input = ODP_PKTIO_INVALID;
+	pkt_hdr->buf_hdr.event_subtype = ODP_EVENT_PACKET_BASIC;
 }
 
 static inline void init_segments(odp_packet_hdr_t *pkt_hdr[], int num)

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -259,6 +259,7 @@ static void init_buffers(pool_t *pool)
 		buf_hdr->size = seg_size;
 		buf_hdr->type = type;
 		buf_hdr->event_type = type;
+		buf_hdr->event_subtype = ODP_EVENT_NO_SUBTYPE;
 		buf_hdr->pool_hdl = pool->pool_hdl;
 		buf_hdr->uarea_addr = uarea;
 		/* Show user requested size through API */
@@ -564,6 +565,16 @@ odp_event_type_t _odp_buffer_event_type(odp_buffer_t buf)
 void _odp_buffer_event_type_set(odp_buffer_t buf, int ev)
 {
 	buf_hdl_to_hdr(buf)->event_type = ev;
+}
+
+odp_event_subtype_t _odp_buffer_event_subtype(odp_buffer_t buf)
+{
+	return buf_hdl_to_hdr(buf)->event_subtype;
+}
+
+void _odp_buffer_event_subtype_set(odp_buffer_t buf, int ev)
+{
+	buf_hdl_to_hdr(buf)->event_subtype = ev;
 }
 
 odp_pool_t odp_pool_lookup(const char *name)

--- a/test/common_plat/performance/odp_crypto.c
+++ b/test/common_plat/performance/odp_crypto.c
@@ -443,9 +443,10 @@ create_session_from_config(odp_crypto_session_t *session,
 			return -1;
 		}
 		params.compl_queue = out_queue;
-
+		params.packet_op_mode = ODP_CRYPTO_ASYNC;
 	} else {
 		params.compl_queue = ODP_QUEUE_INVALID;
+		params.packet_op_mode   = ODP_CRYPTO_SYNC;
 	}
 	if (odp_crypto_session_create(&params, session,
 				      &ses_create_rc)) {
@@ -454,6 +455,24 @@ create_session_from_config(odp_crypto_session_t *session,
 	}
 
 	return 0;
+}
+
+static odp_packet_t
+make_packet(odp_pool_t pkt_pool, unsigned int payload_length)
+{
+	odp_packet_t pkt;
+
+	pkt = odp_packet_alloc(pkt_pool, payload_length);
+	if (pkt == ODP_PACKET_INVALID) {
+		app_err("failed to allocate buffer\n");
+		return pkt;
+	}
+
+	void *mem = odp_packet_data(pkt);
+
+	memset(mem, 1, payload_length);
+
+	return pkt;
 }
 
 /**
@@ -467,14 +486,12 @@ run_measure_one(crypto_args_t *cargs,
 		unsigned int payload_length,
 		crypto_run_result_t *result)
 {
-	odp_crypto_op_param_t params;
+	odp_crypto_packet_op_param_t params;
 
 	odp_pool_t pkt_pool;
 	odp_queue_t out_queue;
-	odp_packet_t pkt;
+	odp_packet_t pkt = ODP_PACKET_INVALID;
 	int rc = 0;
-
-	odp_bool_t posted = 0;
 
 	pkt_pool = odp_pool_lookup("packet_pool");
 	if (pkt_pool == ODP_POOL_INVALID) {
@@ -490,15 +507,11 @@ run_measure_one(crypto_args_t *cargs,
 		}
 	}
 
-	pkt = odp_packet_alloc(pkt_pool, payload_length);
-	if (pkt == ODP_PACKET_INVALID) {
-		app_err("failed to allocate buffer\n");
-		return -1;
+	if (cargs->reuse_packet) {
+		pkt = make_packet(pkt_pool, payload_length);
+		if (ODP_PACKET_INVALID == pkt)
+			return -1;
 	}
-
-	void *mem = odp_packet_data(pkt);
-
-	memset(mem, 1, payload_length);
 
 	time_record_t start, end;
 	int packets_sent = 0;
@@ -515,77 +528,102 @@ run_measure_one(crypto_args_t *cargs,
 	params.auth_range.length = payload_length;
 	params.hash_result_offset = payload_length;
 
-	if (cargs->reuse_packet) {
-		params.pkt = pkt;
-		params.out_pkt = cargs->in_place ? pkt :
-				 ODP_PACKET_INVALID;
-	}
-
 	fill_time_record(&start);
 
 	while ((packets_sent < cargs->iteration_count) ||
 	       (packets_received <  cargs->iteration_count)) {
 		void *mem;
-		odp_crypto_op_result_t result;
 
 		if ((packets_sent < cargs->iteration_count) &&
 		    (packets_sent - packets_received <
 		     cargs->in_flight)) {
-			if (!cargs->reuse_packet) {
-				/*
-				 * For in place test we use just one
-				 * statically allocated buffer.
-				 * For now in place test we have to
-				 * allocate and initialize packet
-				 * every time.
-				 * Note we leaked one packet here.
-				 */
-				odp_packet_t newpkt;
+			odp_packet_t out_pkt;
 
-				newpkt = odp_packet_alloc(pkt_pool,
-							  payload_length);
-				if (newpkt == ODP_PACKET_INVALID) {
-					app_err("failed to allocate buffer\n");
+			if (!cargs->reuse_packet) {
+				pkt = make_packet(pkt_pool, payload_length);
+				if (ODP_PACKET_INVALID == pkt)
 					return -1;
-				}
-				mem = odp_packet_data(newpkt);
-				memset(mem, 1, payload_length);
-				params.pkt = newpkt;
-				params.out_pkt = cargs->in_place ? newpkt :
-						 ODP_PACKET_INVALID;
 			}
 
+			out_pkt = cargs->in_place ? pkt : ODP_PACKET_INVALID;
+
 			if (cargs->debug_packets) {
-				mem = odp_packet_data(params.pkt);
+				mem = odp_packet_data(pkt);
 				print_mem("Packet before encryption:",
 					  mem, payload_length);
 			}
 
-			rc = odp_crypto_operation(&params, &posted,
-						  &result);
-			if (rc)
-				app_err("failed odp_crypto_operation: rc = %d\n",
-					rc);
-			else
-				packets_sent++;
-		}
-
-		if (1) {
-			packets_received++;
-			if (cargs->debug_packets) {
-				mem = odp_packet_data(params.out_pkt);
-				print_mem("Immediately encrypted packet", mem,
-					  payload_length +
-					  config->session.auth_digest_len);
-			}
-			if (!cargs->in_place) {
-				if (cargs->reuse_packet) {
-					params.pkt = params.out_pkt;
-					params.out_pkt = ODP_PACKET_INVALID;
-				} else {
-					odp_packet_free(params.out_pkt);
+			if (cargs->schedule || cargs->poll) {
+				rc = odp_crypto_packet_op_enq(&pkt, &out_pkt,
+							      &params, 1);
+				if (rc <= 0) {
+					app_err("failed odp_crypto_packet_op_enq: rc = %d\n",
+						rc);
+					break;
+				}
+				packets_sent += rc;
+			} else {
+				rc = odp_crypto_packet_op(&pkt, &out_pkt,
+							  &params, 1);
+				if (rc <= 0) {
+					app_err("failed odp_crypto_packet_op: rc = %d\n",
+						rc);
+					break;
+				}
+				packets_sent += rc;
+				packets_received++;
+				if (cargs->debug_packets) {
+					mem = odp_packet_data(out_pkt);
+					print_mem("Immediately encrypted "
+						   "packet",
+						  mem,
+						  payload_length +
+						  config->session.
+						   auth_digest_len);
+				}
+				if (!cargs->in_place) {
+					if (cargs->reuse_packet)
+						pkt = out_pkt;
+					else
+						odp_packet_free(out_pkt);
 				}
 			}
+		}
+
+		if (out_queue != ODP_QUEUE_INVALID) {
+			odp_event_t ev;
+			odp_crypto_packet_result_t result;
+			odp_packet_t out_pkt;
+
+			if (cargs->schedule)
+				ev = odp_schedule(NULL,
+						  ODP_SCHED_NO_WAIT);
+			else
+				ev = odp_queue_deq(out_queue);
+
+			while (ev != ODP_EVENT_INVALID) {
+				out_pkt = odp_crypto_packet_from_event(ev);
+				odp_crypto_packet_result(&result, out_pkt);
+
+				if (cargs->debug_packets) {
+					mem = odp_packet_data(out_pkt);
+					print_mem("Receieved encrypted packet",
+						  mem,
+						  payload_length +
+						  config->
+						  session.auth_digest_len);
+				}
+				if (cargs->reuse_packet)
+					pkt = out_pkt;
+				else
+					odp_packet_free(out_pkt);
+				packets_received++;
+				if (cargs->schedule)
+					ev = odp_schedule(NULL,
+							  ODP_SCHED_NO_WAIT);
+				else
+					ev = odp_queue_deq(out_queue);
+			};
 		}
 	}
 
@@ -607,9 +645,10 @@ run_measure_one(crypto_args_t *cargs,
 					cargs->iteration_count;
 	}
 
-	odp_packet_free(pkt);
+	if (ODP_PACKET_INVALID != pkt)
+		odp_packet_free(pkt);
 
-	return rc;
+	return rc < 0 ? rc : 0;
 }
 
 /**

--- a/test/common_plat/performance/odp_crypto.c
+++ b/test/common_plat/performance/odp_crypto.c
@@ -427,7 +427,6 @@ create_session_from_config(odp_crypto_session_t *session,
 	odp_crypto_session_param_init(&params);
 	memcpy(&params, &config->session, sizeof(odp_crypto_session_param_t));
 	params.op = ODP_CRYPTO_OP_ENCODE;
-	params.pref_mode   = ODP_CRYPTO_SYNC;
 
 	/* Lookup the packet pool */
 	pkt_pool = odp_pool_lookup("packet_pool");
@@ -571,7 +570,7 @@ run_measure_one(crypto_args_t *cargs,
 				packets_sent++;
 		}
 
-		if (!posted) {
+		if (1) {
 			packets_received++;
 			if (cargs->debug_packets) {
 				mem = odp_packet_data(params.out_pkt);
@@ -587,45 +586,6 @@ run_measure_one(crypto_args_t *cargs,
 					odp_packet_free(params.out_pkt);
 				}
 			}
-		} else {
-			odp_event_t ev;
-			odp_crypto_compl_t compl;
-			odp_crypto_op_result_t result;
-			odp_packet_t out_pkt;
-
-			if (cargs->schedule)
-				ev = odp_schedule(NULL,
-						  ODP_SCHED_NO_WAIT);
-			else
-				ev = odp_queue_deq(out_queue);
-
-			while (ev != ODP_EVENT_INVALID) {
-				compl = odp_crypto_compl_from_event(ev);
-				odp_crypto_compl_result(compl, &result);
-				odp_crypto_compl_free(compl);
-				out_pkt = result.pkt;
-
-				if (cargs->debug_packets) {
-					mem = odp_packet_data(out_pkt);
-					print_mem("Receieved encrypted packet",
-						  mem,
-						  payload_length +
-						  config->
-						  session.auth_digest_len);
-				}
-				if (cargs->reuse_packet) {
-					params.pkt = out_pkt;
-					params.out_pkt = ODP_PACKET_INVALID;
-				} else {
-					odp_packet_free(out_pkt);
-				}
-				packets_received++;
-				if (cargs->schedule)
-					ev = odp_schedule(NULL,
-							  ODP_SCHED_NO_WAIT);
-				else
-					ev = odp_queue_deq(out_queue);
-			};
 		}
 	}
 

--- a/test/common_plat/validation/api/buffer/buffer.c
+++ b/test/common_plat/validation/api/buffer/buffer.c
@@ -48,7 +48,8 @@ void buffer_test_pool_alloc(void)
 	odp_buffer_t buffer[num];
 	odp_event_t ev;
 	int index;
-	char wrong_type = 0, wrong_size = 0, wrong_align = 0;
+	odp_bool_t wrong_type = false, wrong_subtype = false;
+	odp_bool_t wrong_size = false, wrong_align = false;
 	odp_pool_param_t params;
 
 	odp_pool_param_init(&params);
@@ -63,6 +64,7 @@ void buffer_test_pool_alloc(void)
 	/* Try to allocate num items from the pool */
 	for (index = 0; index < num; index++) {
 		uintptr_t addr;
+		odp_event_subtype_t subtype;
 
 		buffer[index] = odp_buffer_alloc(pool);
 
@@ -71,14 +73,20 @@ void buffer_test_pool_alloc(void)
 
 		ev = odp_buffer_to_event(buffer[index]);
 		if (odp_event_type(ev) != ODP_EVENT_BUFFER)
-			wrong_type = 1;
+			wrong_type = true;
+		if (odp_event_subtype(ev) != ODP_EVENT_NO_SUBTYPE)
+			wrong_subtype = true;
+		if (odp_event_types(ev, &subtype) != ODP_EVENT_BUFFER)
+			wrong_type = true;
+		if (subtype != ODP_EVENT_NO_SUBTYPE)
+			wrong_subtype = true;
 		if (odp_buffer_size(buffer[index]) < BUF_SIZE)
-			wrong_size = 1;
+			wrong_size = true;
 
 		addr = (uintptr_t)odp_buffer_addr(buffer[index]);
 
 		if ((addr % BUF_ALIGN) != 0)
-			wrong_align = 1;
+			wrong_align = true;
 
 		if (wrong_type || wrong_size || wrong_align)
 			odp_buffer_print(buffer[index]);
@@ -90,9 +98,10 @@ void buffer_test_pool_alloc(void)
 	index--;
 
 	/* Check that the pool had correct buffers */
-	CU_ASSERT(wrong_type == 0);
-	CU_ASSERT(wrong_size == 0);
-	CU_ASSERT(wrong_align == 0);
+	CU_ASSERT(!wrong_type);
+	CU_ASSERT(!wrong_subtype);
+	CU_ASSERT(!wrong_size);
+	CU_ASSERT(!wrong_align);
 
 	for (; index >= 0; index--)
 		odp_buffer_free(buffer[index]);
@@ -123,7 +132,8 @@ void buffer_test_pool_alloc_multi(void)
 	odp_buffer_t buffer[num + 1];
 	odp_event_t ev;
 	int index;
-	char wrong_type = 0, wrong_size = 0, wrong_align = 0;
+	odp_bool_t wrong_type = false, wrong_subtype = false;
+	odp_bool_t wrong_size = false, wrong_align = false;
 	odp_pool_param_t params;
 
 	odp_pool_param_init(&params);
@@ -140,20 +150,27 @@ void buffer_test_pool_alloc_multi(void)
 
 	for (index = 0; index < num; index++) {
 		uintptr_t addr;
+		odp_event_subtype_t subtype;
 
 		if (buffer[index] == ODP_BUFFER_INVALID)
 			break;
 
 		ev = odp_buffer_to_event(buffer[index]);
 		if (odp_event_type(ev) != ODP_EVENT_BUFFER)
-			wrong_type = 1;
+			wrong_type = true;
+		if (odp_event_subtype(ev) != ODP_EVENT_NO_SUBTYPE)
+			wrong_subtype = true;
+		if (odp_event_types(ev, &subtype) != ODP_EVENT_BUFFER)
+			wrong_type = true;
+		if (subtype != ODP_EVENT_NO_SUBTYPE)
+			wrong_subtype = true;
 		if (odp_buffer_size(buffer[index]) < BUF_SIZE)
-			wrong_size = 1;
+			wrong_size = true;
 
 		addr = (uintptr_t)odp_buffer_addr(buffer[index]);
 
 		if ((addr % BUF_ALIGN) != 0)
-			wrong_align = 1;
+			wrong_align = true;
 
 		if (wrong_type || wrong_size || wrong_align)
 			odp_buffer_print(buffer[index]);
@@ -163,9 +180,10 @@ void buffer_test_pool_alloc_multi(void)
 	CU_ASSERT(index == num);
 
 	/* Check that the pool had correct buffers */
-	CU_ASSERT(wrong_type == 0);
-	CU_ASSERT(wrong_size == 0);
-	CU_ASSERT(wrong_align == 0);
+	CU_ASSERT(!wrong_type);
+	CU_ASSERT(!wrong_subtype);
+	CU_ASSERT(!wrong_size);
+	CU_ASSERT(!wrong_align);
 
 	odp_buffer_free_multi(buffer, num);
 
@@ -244,10 +262,14 @@ void buffer_test_pool_free_multi(void)
 void buffer_test_management_basic(void)
 {
 	odp_event_t ev = odp_buffer_to_event(raw_buffer);
+	odp_event_subtype_t subtype;
 
 	CU_ASSERT(odp_buffer_is_valid(raw_buffer) == 1);
 	CU_ASSERT(odp_buffer_pool(raw_buffer) != ODP_POOL_INVALID);
 	CU_ASSERT(odp_event_type(ev) == ODP_EVENT_BUFFER);
+	CU_ASSERT(odp_event_subtype(ev) == ODP_EVENT_NO_SUBTYPE);
+	CU_ASSERT(odp_event_types(ev, &subtype) == ODP_EVENT_BUFFER);
+	CU_ASSERT(subtype == ODP_EVENT_NO_SUBTYPE);
 	CU_ASSERT(odp_buffer_size(raw_buffer) >= BUF_SIZE);
 	CU_ASSERT(odp_buffer_addr(raw_buffer) != NULL);
 	odp_buffer_print(raw_buffer);

--- a/test/common_plat/validation/api/crypto/crypto.c
+++ b/test/common_plat/validation/api/crypto/crypto.c
@@ -15,8 +15,6 @@
 odp_suiteinfo_t crypto_suites[] = {
 	{ODP_CRYPTO_SYNC_INP, crypto_suite_sync_init, crypto_suite_term,
 	 crypto_suite},
-	{ODP_CRYPTO_ASYNC_INP, crypto_suite_async_init, crypto_suite_term,
-	 crypto_suite},
 	ODP_SUITE_INFO_NULL,
 };
 

--- a/test/common_plat/validation/api/crypto/crypto.c
+++ b/test/common_plat/validation/api/crypto/crypto.c
@@ -13,8 +13,12 @@
 #define PKT_POOL_LEN  (1 * 1024)
 
 odp_suiteinfo_t crypto_suites[] = {
-	{ODP_CRYPTO_SYNC_INP, crypto_suite_sync_init, crypto_suite_term,
-	 crypto_suite},
+	{ODP_CRYPTO_SYNC_INP, crypto_suite_sync_init,
+	 crypto_suite_term, crypto_suite},
+	{ODP_CRYPTO_PACKET_SYNC_INP, crypto_suite_packet_sync_init,
+	 crypto_suite_term, crypto_suite},
+	{ODP_CRYPTO_PACKET_ASYNC_INP, crypto_suite_packet_async_init,
+	 crypto_suite_term, crypto_suite},
 	ODP_SUITE_INFO_NULL,
 };
 

--- a/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
@@ -14,7 +14,6 @@
 #define MAX_ALG_CAPA 32
 
 struct suite_context_s {
-	odp_crypto_op_mode_t pref_mode;
 	odp_pool_t pool;
 	odp_queue_t queue;
 };
@@ -92,8 +91,6 @@ static void alg_test(odp_crypto_op_t op,
 	int rc;
 	odp_crypto_ses_create_err_t status;
 	odp_bool_t posted;
-	odp_event_t event;
-	odp_crypto_compl_t compl_event;
 	odp_crypto_op_result_t result;
 	odp_crypto_session_param_t ses_params;
 	odp_crypto_op_param_t op_params;
@@ -196,7 +193,6 @@ static void alg_test(odp_crypto_op_t op,
 	odp_crypto_session_param_init(&ses_params);
 	ses_params.op = op;
 	ses_params.auth_cipher_text = false;
-	ses_params.pref_mode = suite_context.pref_mode;
 	ses_params.cipher_alg = cipher_alg;
 	ses_params.auth_alg = auth_alg;
 	ses_params.compl_queue = suite_context.queue;
@@ -225,7 +221,6 @@ static void alg_test(odp_crypto_op_t op,
 	op_params.session = session;
 	op_params.pkt = pkt;
 	op_params.out_pkt = pkt;
-	op_params.ctx = (void *)0xdeadbeef;
 
 	if (cipher_range) {
 		op_params.cipher_range = *cipher_range;
@@ -258,27 +253,8 @@ static void alg_test(odp_crypto_op_t op,
 		goto cleanup;
 	}
 
-	if (posted) {
-		/* Poll completion queue for results */
-		do {
-			event = odp_queue_deq(suite_context.queue);
-		} while (event == ODP_EVENT_INVALID);
-
-		CU_ASSERT(ODP_EVENT_CRYPTO_COMPL == odp_event_type(event));
-		CU_ASSERT(ODP_EVENT_NO_SUBTYPE == odp_event_subtype(event));
-		CU_ASSERT(ODP_EVENT_CRYPTO_COMPL ==
-			  odp_event_types(event, &subtype));
-		CU_ASSERT(ODP_EVENT_NO_SUBTYPE == subtype);
-
-		compl_event = odp_crypto_compl_from_event(event);
-		CU_ASSERT(odp_crypto_compl_to_u64(compl_event) ==
-			  odp_crypto_compl_to_u64(odp_crypto_compl_from_event(event)));
-		odp_crypto_compl_result(compl_event, &result);
-		odp_crypto_compl_free(compl_event);
-	}
-
+	CU_ASSERT(posted == 0);
 	CU_ASSERT(result.pkt == pkt);
-	CU_ASSERT(result.ctx == (void *)0xdeadbeef);
 	CU_ASSERT(ODP_EVENT_PACKET ==
 		  odp_event_type(odp_packet_to_event(result.pkt)));
 	CU_ASSERT(ODP_EVENT_PACKET_BASIC ==
@@ -1519,20 +1495,6 @@ int crypto_suite_sync_init(void)
 		return -1;
 
 	suite_context.queue = ODP_QUEUE_INVALID;
-	suite_context.pref_mode = ODP_CRYPTO_SYNC;
-	return 0;
-}
-
-int crypto_suite_async_init(void)
-{
-	suite_context.pool = odp_pool_lookup("packet_pool");
-	if (suite_context.pool == ODP_POOL_INVALID)
-		return -1;
-	suite_context.queue = odp_queue_lookup("crypto-out");
-	if (suite_context.queue == ODP_QUEUE_INVALID)
-		return -1;
-
-	suite_context.pref_mode = ODP_CRYPTO_ASYNC;
 	return 0;
 }
 

--- a/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
@@ -103,6 +103,7 @@ static void alg_test(odp_crypto_op_t op,
 	odp_crypto_auth_capability_t   auth_capa[MAX_ALG_CAPA];
 	int num, i;
 	int found;
+	odp_event_subtype_t subtype;
 
 	rc = odp_crypto_capability(&capa);
 	CU_ASSERT(!rc);
@@ -263,6 +264,12 @@ static void alg_test(odp_crypto_op_t op,
 			event = odp_queue_deq(suite_context.queue);
 		} while (event == ODP_EVENT_INVALID);
 
+		CU_ASSERT(ODP_EVENT_CRYPTO_COMPL == odp_event_type(event));
+		CU_ASSERT(ODP_EVENT_NO_SUBTYPE == odp_event_subtype(event));
+		CU_ASSERT(ODP_EVENT_CRYPTO_COMPL ==
+			  odp_event_types(event, &subtype));
+		CU_ASSERT(ODP_EVENT_NO_SUBTYPE == subtype);
+
 		compl_event = odp_crypto_compl_from_event(event);
 		CU_ASSERT(odp_crypto_compl_to_u64(compl_event) ==
 			  odp_crypto_compl_to_u64(odp_crypto_compl_from_event(event)));
@@ -272,6 +279,13 @@ static void alg_test(odp_crypto_op_t op,
 
 	CU_ASSERT(result.pkt == pkt);
 	CU_ASSERT(result.ctx == (void *)0xdeadbeef);
+	CU_ASSERT(ODP_EVENT_PACKET ==
+		  odp_event_type(odp_packet_to_event(result.pkt)));
+	CU_ASSERT(ODP_EVENT_PACKET_BASIC ==
+		  odp_event_subtype(odp_packet_to_event(result.pkt)));
+	CU_ASSERT(ODP_EVENT_PACKET ==
+		  odp_event_types(odp_packet_to_event(result.pkt), &subtype));
+	CU_ASSERT(ODP_EVENT_PACKET_BASIC == subtype);
 
 	if (should_fail) {
 		CU_ASSERT(!result.ok);

--- a/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/common_plat/validation/api/crypto/odp_crypto_test_inp.c
@@ -14,6 +14,8 @@
 #define MAX_ALG_CAPA 32
 
 struct suite_context_s {
+	odp_bool_t packet;
+	odp_crypto_op_mode_t packet_op_mode;
 	odp_pool_t pool;
 	odp_queue_t queue;
 };
@@ -58,6 +60,217 @@ static const char *cipher_alg_name(odp_cipher_alg_t cipher)
 	}
 }
 
+static int alg_op(odp_packet_t pkt,
+		  odp_bool_t *ok,
+		  odp_crypto_session_t session,
+		  uint8_t *op_iv_ptr,
+		  odp_packet_data_range_t *cipher_range,
+		  odp_packet_data_range_t *auth_range,
+		  uint8_t *aad,
+		  uint32_t aad_len,
+		  unsigned int plaintext_len)
+{
+	int data_off = 0, rc;
+	odp_crypto_op_result_t result;
+	odp_crypto_op_param_t op_params;
+	odp_bool_t posted;
+	odp_event_subtype_t subtype;
+
+	/* Prepare input/output params */
+	memset(&op_params, 0, sizeof(op_params));
+	op_params.session = session;
+	op_params.pkt = pkt;
+	op_params.out_pkt = pkt;
+
+	if (cipher_range) {
+		op_params.cipher_range = *cipher_range;
+		data_off = cipher_range->offset;
+	} else {
+		op_params.cipher_range.offset = data_off;
+		op_params.cipher_range.length = plaintext_len;
+	}
+	if (auth_range) {
+		op_params.auth_range = *auth_range;
+	} else {
+		op_params.auth_range.offset = data_off;
+		op_params.auth_range.length = plaintext_len;
+	}
+	if (op_iv_ptr)
+		op_params.override_iv_ptr = op_iv_ptr;
+
+	op_params.aad.ptr = aad;
+	op_params.aad.length = aad_len;
+
+	op_params.hash_result_offset = plaintext_len;
+
+	rc = odp_crypto_operation(&op_params, &posted, &result);
+	if (rc < 0) {
+		CU_FAIL("Failed odp_crypto_operation()");
+		return rc;
+	}
+
+	CU_ASSERT(posted == 0);
+	CU_ASSERT(result.pkt == pkt);
+	CU_ASSERT(ODP_EVENT_PACKET ==
+		  odp_event_type(odp_packet_to_event(result.pkt)));
+	CU_ASSERT(ODP_EVENT_PACKET_BASIC ==
+		  odp_event_subtype(odp_packet_to_event(result.pkt)));
+	CU_ASSERT(ODP_EVENT_PACKET ==
+		  odp_event_types(odp_packet_to_event(result.pkt), &subtype));
+	CU_ASSERT(ODP_EVENT_PACKET_BASIC == subtype);
+
+	*ok = result.ok;
+
+	return 0;
+}
+
+static int alg_packet_op(odp_packet_t pkt,
+			 odp_bool_t *ok,
+			 odp_crypto_session_t session,
+			 uint8_t *op_iv_ptr,
+			 odp_packet_data_range_t *cipher_range,
+			 odp_packet_data_range_t *auth_range,
+			 uint8_t *aad,
+			 uint32_t aad_len,
+			 unsigned int plaintext_len)
+{
+	int data_off = 0, rc;
+	odp_crypto_packet_result_t result;
+	odp_crypto_packet_op_param_t op_params;
+	odp_event_subtype_t subtype;
+	odp_packet_t out_pkt = pkt;
+
+	/* Prepare input/output params */
+	memset(&op_params, 0, sizeof(op_params));
+	op_params.session = session;
+
+	if (cipher_range) {
+		op_params.cipher_range = *cipher_range;
+		data_off = cipher_range->offset;
+	} else {
+		op_params.cipher_range.offset = data_off;
+		op_params.cipher_range.length = plaintext_len;
+	}
+	if (auth_range) {
+		op_params.auth_range = *auth_range;
+	} else {
+		op_params.auth_range.offset = data_off;
+		op_params.auth_range.length = plaintext_len;
+	}
+	if (op_iv_ptr)
+		op_params.override_iv_ptr = op_iv_ptr;
+
+	op_params.aad.ptr = aad;
+	op_params.aad.length = aad_len;
+
+	op_params.hash_result_offset = plaintext_len;
+
+	rc = odp_crypto_packet_op(&pkt, &out_pkt, &op_params, 1);
+	if (rc < 0) {
+		CU_FAIL("Failed odp_crypto_packet_op()");
+		return rc;
+	}
+
+	CU_ASSERT(out_pkt == pkt);
+	CU_ASSERT(ODP_EVENT_PACKET ==
+		  odp_event_type(odp_packet_to_event(pkt)));
+	CU_ASSERT(ODP_EVENT_PACKET_CRYPTO ==
+		  odp_event_subtype(odp_packet_to_event(pkt)));
+	CU_ASSERT(ODP_EVENT_PACKET ==
+		  odp_event_types(odp_packet_to_event(pkt), &subtype));
+	CU_ASSERT(ODP_EVENT_PACKET_CRYPTO == subtype);
+
+	rc = odp_crypto_packet_result(&result, pkt);
+	if (rc < 0) {
+		CU_FAIL("Failed odp_crypto_packet_result()");
+		return rc;
+	}
+
+	*ok = result.ok;
+
+	return 0;
+}
+
+static int alg_packet_op_enq(odp_packet_t pkt,
+			     odp_bool_t *ok,
+			     odp_crypto_session_t session,
+			     uint8_t *op_iv_ptr,
+			     odp_packet_data_range_t *cipher_range,
+			     odp_packet_data_range_t *auth_range,
+			     uint8_t *aad,
+			     uint32_t aad_len,
+			     unsigned int plaintext_len)
+{
+	int data_off = 0, rc;
+	odp_event_t event;
+	odp_crypto_packet_result_t result;
+	odp_crypto_packet_op_param_t op_params;
+	odp_event_subtype_t subtype;
+	odp_packet_t out_pkt = pkt;
+
+	/* Prepare input/output params */
+	memset(&op_params, 0, sizeof(op_params));
+	op_params.session = session;
+
+	if (cipher_range) {
+		op_params.cipher_range = *cipher_range;
+		data_off = cipher_range->offset;
+	} else {
+		op_params.cipher_range.offset = data_off;
+		op_params.cipher_range.length = plaintext_len;
+	}
+	if (auth_range) {
+		op_params.auth_range = *auth_range;
+	} else {
+		op_params.auth_range.offset = data_off;
+		op_params.auth_range.length = plaintext_len;
+	}
+	if (op_iv_ptr)
+		op_params.override_iv_ptr = op_iv_ptr;
+
+	op_params.aad.ptr = aad;
+	op_params.aad.length = aad_len;
+
+	op_params.hash_result_offset = plaintext_len;
+
+	rc = odp_crypto_packet_op_enq(&pkt, &pkt, &op_params, 1);
+	if (rc < 0) {
+		CU_FAIL("Failed odp_crypto_op_enq()");
+		return rc;
+	}
+
+	/* Poll completion queue for results */
+	do {
+		event = odp_queue_deq(suite_context.queue);
+	} while (event == ODP_EVENT_INVALID);
+
+	CU_ASSERT(ODP_EVENT_PACKET == odp_event_type(event));
+	CU_ASSERT(ODP_EVENT_PACKET_CRYPTO == odp_event_subtype(event));
+	CU_ASSERT(ODP_EVENT_PACKET == odp_event_types(event, &subtype));
+	CU_ASSERT(ODP_EVENT_PACKET_CRYPTO == subtype);
+
+	pkt = odp_crypto_packet_from_event(event);
+
+	CU_ASSERT(out_pkt == pkt);
+	CU_ASSERT(ODP_EVENT_PACKET ==
+		  odp_event_type(odp_packet_to_event(pkt)));
+	CU_ASSERT(ODP_EVENT_PACKET_CRYPTO ==
+		  odp_event_subtype(odp_packet_to_event(pkt)));
+	CU_ASSERT(ODP_EVENT_PACKET ==
+		  odp_event_types(odp_packet_to_event(pkt), &subtype));
+	CU_ASSERT(ODP_EVENT_PACKET_CRYPTO == subtype);
+
+	rc = odp_crypto_packet_result(&result, pkt);
+	if (rc < 0) {
+		CU_FAIL("Failed odp_crypto_packet_result()");
+		return rc;
+	}
+
+	*ok = result.ok;
+
+	return 0;
+}
+
 /* Basic algorithm run function for async inplace mode.
  * Creates a session from input parameters and runs one operation
  * on input_vec. Checks the output of the crypto operation against
@@ -90,17 +303,13 @@ static void alg_test(odp_crypto_op_t op,
 	odp_crypto_capability_t capa;
 	int rc;
 	odp_crypto_ses_create_err_t status;
-	odp_bool_t posted;
-	odp_crypto_op_result_t result;
+	odp_bool_t ok;
 	odp_crypto_session_param_t ses_params;
-	odp_crypto_op_param_t op_params;
 	uint8_t *data_addr;
-	int data_off;
 	odp_crypto_cipher_capability_t cipher_capa[MAX_ALG_CAPA];
 	odp_crypto_auth_capability_t   auth_capa[MAX_ALG_CAPA];
 	int num, i;
 	int found;
-	odp_event_subtype_t subtype;
 
 	rc = odp_crypto_capability(&capa);
 	CU_ASSERT(!rc);
@@ -193,6 +402,7 @@ static void alg_test(odp_crypto_op_t op,
 	odp_crypto_session_param_init(&ses_params);
 	ses_params.op = op;
 	ses_params.auth_cipher_text = false;
+	ses_params.packet_op_mode = suite_context.packet_op_mode;
 	ses_params.cipher_alg = cipher_alg;
 	ses_params.auth_alg = auth_alg;
 	ses_params.compl_queue = suite_context.queue;
@@ -214,67 +424,40 @@ static void alg_test(odp_crypto_op_t op,
 	CU_ASSERT(pkt != ODP_PACKET_INVALID);
 	data_addr = odp_packet_data(pkt);
 	memcpy(data_addr, plaintext, plaintext_len);
-	data_off = 0;
-
-	/* Prepare input/output params */
-	memset(&op_params, 0, sizeof(op_params));
-	op_params.session = session;
-	op_params.pkt = pkt;
-	op_params.out_pkt = pkt;
-
-	if (cipher_range) {
-		op_params.cipher_range = *cipher_range;
-		data_off = cipher_range->offset;
-	} else {
-		op_params.cipher_range.offset = data_off;
-		op_params.cipher_range.length = plaintext_len;
-	}
-	if (auth_range) {
-		op_params.auth_range = *auth_range;
-	} else {
-		op_params.auth_range.offset = data_off;
-		op_params.auth_range.length = plaintext_len;
-	}
-	if (op_iv_ptr)
-		op_params.override_iv_ptr = op_iv_ptr;
-
-	op_params.aad.ptr = aad;
-	op_params.aad.length = aad_len;
-
-	op_params.hash_result_offset = plaintext_len;
 	if (0 != digest_len) {
-		memcpy(data_addr + op_params.hash_result_offset,
+		memcpy(data_addr + plaintext_len,
 		       digest, digest_len);
 	}
 
-	rc = odp_crypto_operation(&op_params, &posted, &result);
+	if (!suite_context.packet)
+		rc = alg_op(pkt, &ok, session, op_iv_ptr,
+			    cipher_range, auth_range, aad, aad_len,
+			    plaintext_len);
+	else if (ODP_CRYPTO_ASYNC == suite_context.packet_op_mode)
+		rc = alg_packet_op_enq(pkt, &ok, session, op_iv_ptr,
+				       cipher_range, auth_range, aad, aad_len,
+				       plaintext_len);
+	else
+		rc = alg_packet_op(pkt, &ok, session, op_iv_ptr,
+				   cipher_range, auth_range, aad, aad_len,
+				   plaintext_len);
 	if (rc < 0) {
-		CU_FAIL("Failed odp_crypto_operation()");
 		goto cleanup;
 	}
-
-	CU_ASSERT(posted == 0);
-	CU_ASSERT(result.pkt == pkt);
-	CU_ASSERT(ODP_EVENT_PACKET ==
-		  odp_event_type(odp_packet_to_event(result.pkt)));
-	CU_ASSERT(ODP_EVENT_PACKET_BASIC ==
-		  odp_event_subtype(odp_packet_to_event(result.pkt)));
-	CU_ASSERT(ODP_EVENT_PACKET ==
-		  odp_event_types(odp_packet_to_event(result.pkt), &subtype));
-	CU_ASSERT(ODP_EVENT_PACKET_BASIC == subtype);
 
 	if (should_fail) {
-		CU_ASSERT(!result.ok);
+		CU_ASSERT(!ok);
 		goto cleanup;
 	}
 
-	CU_ASSERT(result.ok);
+	CU_ASSERT(ok);
 
+	data_addr = odp_packet_data(pkt);
 	if (cipher_alg != ODP_CIPHER_ALG_NULL)
 		CU_ASSERT(!memcmp(data_addr, ciphertext, ciphertext_len));
 
 	if (op == ODP_CRYPTO_OP_ENCODE && auth_alg != ODP_AUTH_ALG_NULL)
-		CU_ASSERT(!memcmp(data_addr + op_params.hash_result_offset,
+		CU_ASSERT(!memcmp(data_addr + plaintext_len,
 				  digest, digest_len));
 cleanup:
 	rc = odp_crypto_session_destroy(session);
@@ -1495,6 +1678,34 @@ int crypto_suite_sync_init(void)
 		return -1;
 
 	suite_context.queue = ODP_QUEUE_INVALID;
+	return 0;
+}
+
+int crypto_suite_packet_sync_init(void)
+{
+	suite_context.packet = true;
+	suite_context.packet_op_mode = ODP_CRYPTO_SYNC;
+
+	suite_context.pool = odp_pool_lookup("packet_pool");
+	if (suite_context.pool == ODP_POOL_INVALID)
+		return -1;
+
+	suite_context.queue = ODP_QUEUE_INVALID;
+	return 0;
+}
+
+int crypto_suite_packet_async_init(void)
+{
+	suite_context.packet = true;
+	suite_context.packet_op_mode = ODP_CRYPTO_ASYNC;
+
+	suite_context.pool = odp_pool_lookup("packet_pool");
+	if (suite_context.pool == ODP_POOL_INVALID)
+		return -1;
+
+	suite_context.queue = odp_queue_lookup("crypto-out");
+	if (suite_context.queue == ODP_QUEUE_INVALID)
+		return -1;
 	return 0;
 }
 

--- a/test/common_plat/validation/api/crypto/odp_crypto_test_inp.h
+++ b/test/common_plat/validation/api/crypto/odp_crypto_test_inp.h
@@ -9,14 +9,12 @@
 #include <odp_cunit_common.h>
 
 /* Suite names */
-#define ODP_CRYPTO_ASYNC_INP	"odp_crypto_async_inp"
 #define ODP_CRYPTO_SYNC_INP    "odp_crypto_sync_inp"
 
 /* Suite test array */
 extern odp_testinfo_t crypto_suite[];
 
 int crypto_suite_sync_init(void);
-int crypto_suite_async_init(void);
 int crypto_suite_term(void);
 
 #endif

--- a/test/common_plat/validation/api/crypto/odp_crypto_test_inp.h
+++ b/test/common_plat/validation/api/crypto/odp_crypto_test_inp.h
@@ -9,12 +9,16 @@
 #include <odp_cunit_common.h>
 
 /* Suite names */
-#define ODP_CRYPTO_SYNC_INP    "odp_crypto_sync_inp"
+#define ODP_CRYPTO_SYNC_INP         "odp_crypto_sync_inp"
+#define ODP_CRYPTO_PACKET_SYNC_INP  "odp_crypto_packet_sync_inp"
+#define ODP_CRYPTO_PACKET_ASYNC_INP "odp_crypto_packet_async_inp"
 
 /* Suite test array */
 extern odp_testinfo_t crypto_suite[];
 
 int crypto_suite_sync_init(void);
+int crypto_suite_packet_sync_init(void);
+int crypto_suite_packet_async_init(void);
 int crypto_suite_term(void);
 
 #endif

--- a/test/common_plat/validation/api/packet/packet.c
+++ b/test/common_plat/validation/api/packet/packet.c
@@ -241,6 +241,7 @@ void packet_test_alloc_free(void)
 	odp_packet_t packet;
 	odp_pool_param_t params;
 	odp_pool_capability_t capa;
+	odp_event_subtype_t subtype;
 
 	CU_ASSERT_FATAL(odp_pool_capability(&capa) == 0);
 
@@ -259,7 +260,12 @@ void packet_test_alloc_free(void)
 	CU_ASSERT_FATAL(packet != ODP_PACKET_INVALID);
 	CU_ASSERT(odp_packet_len(packet) == packet_len);
 	CU_ASSERT(odp_event_type(odp_packet_to_event(packet)) ==
-			ODP_EVENT_PACKET);
+		  ODP_EVENT_PACKET);
+	CU_ASSERT(odp_event_subtype(odp_packet_to_event(packet)) ==
+		  ODP_EVENT_PACKET_BASIC);
+	CU_ASSERT(odp_event_types(odp_packet_to_event(packet), &subtype) ==
+		  ODP_EVENT_PACKET);
+	CU_ASSERT(subtype == ODP_EVENT_PACKET_BASIC);
 	CU_ASSERT(odp_packet_to_u64(packet) !=
 		  odp_packet_to_u64(ODP_PACKET_INVALID));
 
@@ -329,9 +335,17 @@ void packet_test_alloc_free_multi(void)
 	CU_ASSERT_FATAL(ret == num_pkt);
 
 	for (i = 0; i < 2 * num_pkt; ++i) {
+		odp_event_subtype_t subtype;
+
 		CU_ASSERT(odp_packet_len(packet[i]) == packet_len);
 		CU_ASSERT(odp_event_type(odp_packet_to_event(packet[i])) ==
 			  ODP_EVENT_PACKET);
+		CU_ASSERT(odp_event_subtype(odp_packet_to_event(packet[i])) ==
+			  ODP_EVENT_PACKET_BASIC);
+		CU_ASSERT(odp_event_types(odp_packet_to_event(packet[i]),
+					  &subtype) ==
+			  ODP_EVENT_PACKET);
+		CU_ASSERT(subtype == ODP_EVENT_PACKET_BASIC);
 		CU_ASSERT(odp_packet_to_u64(packet[i]) !=
 			  odp_packet_to_u64(ODP_PACKET_INVALID));
 	}
@@ -449,10 +463,15 @@ void packet_test_event_conversion(void)
 	odp_packet_t pkt = test_packet;
 	odp_packet_t tmp_pkt;
 	odp_event_t ev;
+	odp_event_subtype_t subtype;
 
 	ev = odp_packet_to_event(pkt);
 	CU_ASSERT_FATAL(ev != ODP_EVENT_INVALID);
 	CU_ASSERT(odp_event_type(ev) == ODP_EVENT_PACKET);
+	CU_ASSERT(odp_event_subtype(ev) == ODP_EVENT_PACKET_BASIC);
+	CU_ASSERT(odp_event_types(ev, &subtype) ==
+		  ODP_EVENT_PACKET);
+	CU_ASSERT(subtype == ODP_EVENT_PACKET_BASIC);
 
 	tmp_pkt = odp_packet_from_event(ev);
 	CU_ASSERT_FATAL(tmp_pkt != ODP_PACKET_INVALID);

--- a/test/common_plat/validation/api/timer/timer.c
+++ b/test/common_plat/validation/api/timer/timer.c
@@ -59,7 +59,7 @@ void timer_test_timeout_pool_alloc(void)
 	odp_timeout_t tmo[num];
 	odp_event_t ev;
 	int index;
-	char wrong_type = 0;
+	odp_bool_t wrong_type = false, wrong_subtype = false;
 	odp_pool_param_t params;
 
 	odp_pool_param_init(&params);
@@ -73,6 +73,8 @@ void timer_test_timeout_pool_alloc(void)
 
 	/* Try to allocate num items from the pool */
 	for (index = 0; index < num; index++) {
+		odp_event_subtype_t subtype;
+
 		tmo[index] = odp_timeout_alloc(pool);
 
 		if (tmo[index] == ODP_TIMEOUT_INVALID)
@@ -80,7 +82,13 @@ void timer_test_timeout_pool_alloc(void)
 
 		ev = odp_timeout_to_event(tmo[index]);
 		if (odp_event_type(ev) != ODP_EVENT_TIMEOUT)
-			wrong_type = 1;
+			wrong_type = true;
+		if (odp_event_subtype(ev) != ODP_EVENT_NO_SUBTYPE)
+			wrong_subtype = true;
+		if (odp_event_types(ev, &subtype) != ODP_EVENT_TIMEOUT)
+			wrong_type = true;
+		if (subtype != ODP_EVENT_NO_SUBTYPE)
+			wrong_subtype = true;
 	}
 
 	/* Check that the pool had at least num items */
@@ -89,7 +97,8 @@ void timer_test_timeout_pool_alloc(void)
 	index--;
 
 	/* Check that the pool had correct buffers */
-	CU_ASSERT(wrong_type == 0);
+	CU_ASSERT(!wrong_type);
+	CU_ASSERT(!wrong_subtype);
 
 	for (; index >= 0; index--)
 		odp_timeout_free(tmo[index]);
@@ -219,10 +228,27 @@ void timer_test_odp_timer_cancel(void)
 /* @private Handle a received (timeout) event */
 static void handle_tmo(odp_event_t ev, bool stale, uint64_t prev_tick)
 {
+	odp_event_subtype_t subtype;
+
 	CU_ASSERT_FATAL(ev != ODP_EVENT_INVALID); /* Internal error */
 	if (odp_event_type(ev) != ODP_EVENT_TIMEOUT) {
 		/* Not a timeout event */
 		CU_FAIL("Unexpected event type received");
+		return;
+	}
+	if (odp_event_subtype(ev) != ODP_EVENT_NO_SUBTYPE) {
+		/* Not a timeout event */
+		CU_FAIL("Unexpected event subtype received");
+		return;
+	}
+	if (odp_event_types(ev, &subtype) != ODP_EVENT_TIMEOUT) {
+		/* Not a timeout event */
+		CU_FAIL("Unexpected event type received");
+		return;
+	}
+	if (subtype != ODP_EVENT_NO_SUBTYPE) {
+		/* Not a timeout event */
+		CU_FAIL("Unexpected event subtype received");
 		return;
 	}
 	/* Read the metadata from the timeout */


### PR DESCRIPTION
Provide crypto API using packets to pass results. This PR also contains changes from `[PATCH API-NEXT v3 0/2] event subtype implementation`.