### PR TITLE
[PATCH API-NEXT v1] api: ipsec: pass OUT_INLINE outer headers as const

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -1024,7 +1024,7 @@ typedef struct odp_ipsec_out_inline_param_t {
 		/** Points to first byte of outer headers to be copied in
 		 *  front of the outgoing IPSEC packet. Implementation copies
 		 *  the headers during odp_ipsec_out_inline() call. */
-		uint8_t *ptr;
+		const uint8_t *ptr;
 
 		/** Outer header length in bytes */
 		uint32_t len;


### PR DESCRIPTION
Pass outer headers for outbound inline packets as const pointers.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>