### PR TITLE
[PATCH v1] example: ipsec: fix build with OpenSSL located in non-standard path

### DIFF
--- a/example/ipsec/Makefile.am
+++ b/example/ipsec/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/example/Makefile.inc
 
+AM_CPPFLAGS = $(OPENSSL_CPPFLAGS)
+
 bin_PROGRAMS = odp_ipsec$(EXEEXT)
 odp_ipsec_LDFLAGS = $(AM_LDFLAGS) -static
 odp_ipsec_CFLAGS = $(AM_CFLAGS) -I${top_srcdir}/example


### PR DESCRIPTION
IPsec example uses OpenSSL directly to generate packages stream. Thus
use $(OPENSSL_CPPFLAGS) and $(OPENSSL_LIBS) to let compiler find OpenSSL
if it is present in non-standard location.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>