### PR TITLE
[PATCH v2] dpdk zero-copy pktio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ env:
         - CONF="--disable-abi-compat"
         - CONF="--enable-schedule-sp"
         - CONF="--enable-schedule-iquery"
+        - CONF="--enable-dpdk-zero-copy"
 
 before_install:
 #       Install cunit for the validation tests because distro version is too old and fails C99 compile

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -100,7 +100,7 @@ struct odp_buffer_hdr_t {
 
 	/* Data or next header */
 	uint8_t data[0];
-};
+} ODP_ALIGNED_CACHE;
 
 ODP_STATIC_ASSERT(CONFIG_PACKET_MAX_SEGS < 256,
 		  "CONFIG_PACKET_MAX_SEGS_TOO_LARGE");

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -56,10 +56,10 @@ extern "C" {
  * size e.g. due to HW or a protocol specific alignment requirement.
  *
  * @internal In odp-linux implementation:
- * The default value (66) allows a 1500-byte packet to be received into a single
- * segment with Ethernet offset alignment and room for some header expansion.
+ * The default value (128) allows a 1500-byte packet to be received into a
+ * single segment with room for some header expansion.
  */
-#define CONFIG_PACKET_HEADROOM 66
+#define CONFIG_PACKET_HEADROOM 128
 
 /*
  * Default packet tailroom

--- a/platform/linux-generic/include/odp_packet_dpdk.h
+++ b/platform/linux-generic/include/odp_packet_dpdk.h
@@ -52,8 +52,6 @@ typedef struct {
 	odp_pktio_capability_t	capa;	  /**< interface capabilities */
 	uint32_t data_room;		  /**< maximum packet length */
 	uint16_t mtu;			  /**< maximum transmission unit */
-	/** DPDK packet pool name (pktpool_<ifname>) */
-	char pool_name[IF_NAMESIZE + 8];
 	/** Use system call to get/set vdev promisc mode */
 	odp_bool_t vdev_sysc_promisc;
 	uint8_t port_id;		  /**< DPDK port identifier */

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -159,6 +159,45 @@ static inline odp_packet_t packet_from_buf_hdr(odp_buffer_hdr_t *buf_hdr)
 	return (odp_packet_t)(odp_packet_hdr_t *)buf_hdr;
 }
 
+/**
+ * Initialize packet
+ */
+static inline void packet_init(odp_packet_hdr_t *pkt_hdr, uint32_t len)
+{
+	uint32_t seg_len;
+	int num = pkt_hdr->buf_hdr.segcount;
+
+	if (odp_likely(CONFIG_PACKET_MAX_SEGS == 1 || num == 1)) {
+		seg_len = len;
+		pkt_hdr->buf_hdr.seg[0].len = len;
+	} else {
+		seg_len = len - ((num - 1) * CONFIG_PACKET_MAX_SEG_LEN);
+
+		/* Last segment data length */
+		pkt_hdr->buf_hdr.seg[num - 1].len = seg_len;
+	}
+
+	pkt_hdr->p.input_flags.all  = 0;
+	pkt_hdr->p.output_flags.all = 0;
+	pkt_hdr->p.error_flags.all  = 0;
+
+	pkt_hdr->p.l2_offset = 0;
+	pkt_hdr->p.l3_offset = ODP_PACKET_OFFSET_INVALID;
+	pkt_hdr->p.l4_offset = ODP_PACKET_OFFSET_INVALID;
+
+       /*
+	* Packet headroom is set from the pool's headroom
+	* Packet tailroom is rounded up to fill the last
+	* segment occupied by the allocated length.
+	*/
+	pkt_hdr->frame_len = len;
+	pkt_hdr->headroom  = CONFIG_PACKET_HEADROOM;
+	pkt_hdr->tailroom  = CONFIG_PACKET_MAX_SEG_LEN - seg_len +
+			     CONFIG_PACKET_TAILROOM;
+
+	pkt_hdr->input = ODP_PKTIO_INVALID;
+}
+
 static inline void copy_packet_parser_metadata(odp_packet_hdr_t *src_hdr,
 					       odp_packet_hdr_t *dst_hdr)
 {

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -93,6 +93,12 @@ typedef struct {
 	uint32_t l4_offset; /**< offset to L4 hdr (TCP, UDP, SCTP, also ICMP) */
 } packet_parser_t;
 
+/* Packet extra data length */
+#define PKT_EXTRA_LEN 128
+
+/* Packet extra data types */
+#define PKT_EXTRA_TYPE_DPDK 1
+
 /**
  * Internal Packet header
  *
@@ -131,6 +137,13 @@ typedef struct {
 
 	/* Result for crypto */
 	odp_crypto_generic_op_result_t op_result;
+
+#ifdef ODP_PKTIO_DPDK
+	/* Type of extra data */
+	uint8_t extra_type;
+	/* Extra space for packet descriptors. E.g. DPDK mbuf  */
+	uint8_t extra[PKT_EXTRA_LEN] ODP_ALIGNED_CACHE;
+#endif
 
 	/* Packet data storage */
 	uint8_t data[0];

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -42,6 +42,9 @@ typedef struct {
 
 } pool_ring_t ODP_ALIGNED_CACHE;
 
+/* Callback function for pool destroy */
+typedef void (*pool_destroy_cb_fn)(void *pool);
+
 typedef struct pool_t {
 	odp_ticketlock_t lock ODP_ALIGNED_CACHE;
 
@@ -66,6 +69,10 @@ typedef struct pool_t {
 	uint32_t         uarea_shm_size;
 	uint8_t         *base_addr;
 	uint8_t         *uarea_base_addr;
+
+	/* Used by DPDK zero-copy pktio */
+	pool_destroy_cb_fn ext_destroy;
+	void            *ext_desc;
 
 	pool_cache_t     local_cache[ODP_THREAD_COUNT_MAX];
 

--- a/platform/linux-generic/m4/odp_dpdk.m4
+++ b/platform/linux-generic/m4/odp_dpdk.m4
@@ -9,6 +9,16 @@ AC_HELP_STRING([--with-dpdk-path=DIR   path to dpdk build directory]),
     pktio_dpdk_support=yes],[])
 
 ##########################################################################
+# Enable zero-copy DPDK pktio
+##########################################################################
+zero_copy=0
+AC_ARG_ENABLE([dpdk-zero-copy],
+    [  --enable-dpdk-zero-copy  enable experimental zero-copy DPDK pktio mode],
+    [if test x$enableval = xyes; then
+        zero_copy=1
+    fi])
+
+##########################################################################
 # Save and set temporary compilation flags
 ##########################################################################
 OLD_CPPFLAGS="$CPPFLAGS"
@@ -37,8 +47,8 @@ then
     done
     AS_VAR_APPEND([DPDK_PMDS], [--no-whole-archive])
 
-    ODP_CFLAGS="$ODP_CFLAGS -DODP_PKTIO_DPDK"
-    DPDK_LIBS="-L$DPDK_PATH/lib -ldpdk -lpthread -ldl -lpcap"
+    ODP_CFLAGS="$ODP_CFLAGS -DODP_PKTIO_DPDK -DODP_DPDK_ZERO_COPY=$zero_copy"
+    DPDK_LIBS="-L$DPDK_PATH/lib -ldpdk -lpthread -ldl -lpcap -lm"
     AC_SUBST([DPDK_CPPFLAGS])
     AC_SUBST([DPDK_LIBS])
     AC_SUBST([DPDK_PMDS])

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -241,45 +241,6 @@ void packet_parse_reset(odp_packet_hdr_t *pkt_hdr)
 	pkt_hdr->p.l4_offset        = ODP_PACKET_OFFSET_INVALID;
 }
 
-/**
- * Initialize packet
- */
-static inline void packet_init(odp_packet_hdr_t *pkt_hdr, uint32_t len)
-{
-	uint32_t seg_len;
-	int num = pkt_hdr->buf_hdr.segcount;
-
-	if (odp_likely(CONFIG_PACKET_MAX_SEGS == 1 || num == 1)) {
-		seg_len = len;
-		pkt_hdr->buf_hdr.seg[0].len = len;
-	} else {
-		seg_len = len - ((num - 1) * CONFIG_PACKET_MAX_SEG_LEN);
-
-		/* Last segment data length */
-		pkt_hdr->buf_hdr.seg[num - 1].len = seg_len;
-	}
-
-	pkt_hdr->p.input_flags.all  = 0;
-	pkt_hdr->p.output_flags.all = 0;
-	pkt_hdr->p.error_flags.all  = 0;
-
-	pkt_hdr->p.l2_offset = 0;
-	pkt_hdr->p.l3_offset = ODP_PACKET_OFFSET_INVALID;
-	pkt_hdr->p.l4_offset = ODP_PACKET_OFFSET_INVALID;
-
-       /*
-	* Packet headroom is set from the pool's headroom
-	* Packet tailroom is rounded up to fill the last
-	* segment occupied by the allocated length.
-	*/
-	pkt_hdr->frame_len = len;
-	pkt_hdr->headroom  = CONFIG_PACKET_HEADROOM;
-	pkt_hdr->tailroom  = CONFIG_PACKET_MAX_SEG_LEN - seg_len +
-			     CONFIG_PACKET_TAILROOM;
-
-	pkt_hdr->input = ODP_PKTIO_INVALID;
-}
-
 static inline void init_segments(odp_packet_hdr_t *pkt_hdr[], int num)
 {
 	odp_packet_hdr_t *hdr;

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -376,7 +376,9 @@ int odp_pktio_close(odp_pktio_t hdl)
 	entry->s.num_in_queue  = 0;
 	entry->s.num_out_queue = 0;
 
+	odp_spinlock_lock(&pktio_tbl->lock);
 	res = _pktio_close(entry);
+	odp_spinlock_unlock(&pktio_tbl->lock);
 	if (res)
 		ODP_ABORT("unable to close pktio\n");
 

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -703,6 +703,8 @@ static inline void buffer_free_to_pool(pool_t *pool,
 
 		if (odp_unlikely(num > CACHE_BURST))
 			burst = num;
+		if (odp_unlikely((uint32_t)num > cache_num))
+			burst = cache_num;
 
 		{
 			/* Temporary copy needed since odp_buffer_t is

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -355,9 +355,9 @@ static void mmap_fill_ring(struct ring *ring, odp_pool_t pool_hdl, int fanout)
 	pool = pool_entry_from_hdl(pool_hdl);
 
 	/* Frame has to capture full packet which can fit to the pool block.*/
-	ring->req.tp_frame_size = (pool->data_size +
-				   TPACKET_HDRLEN + TPACKET_ALIGNMENT +
-				   + (pz - 1)) & (-pz);
+	ring->req.tp_frame_size = (pool->headroom + pool->data_size +
+				   pool->tailroom + TPACKET_HDRLEN +
+				   TPACKET_ALIGNMENT + + (pz - 1)) & (-pz);
 
 	/* Calculate how many pages do we need to hold all pool packets
 	*  and align size to page boundary.


### PR DESCRIPTION
V2:
- Simplify mbuf_pool_create() arguments (Krishna)
- Fix bug in dpdk_send() (Krishna)
- Add Travis test (Maxim)
- Destroy dpdk memory pool using a callback in odp_pool_destroy(). Fixes a bug detected by Travis.

This patch set adds an experimental zero-copy mode for DPDK pktio. Zero-copy
operation is enabled with a new '--enable-dpdk-zero-copy' configure flag.

This feature has been put behind an extra configure flag as it doesn't
entirely adhere to the DPDK API and may behave unexpectedly with untested DPDK
NIC drivers. The patch has been tested with pcap, ixgbe, and i40e drivers.

The patch is based on the DPDK external memory pool concept with the following
exception. Instead of using the standard DPDK API functions, which use a given
memory block to populate the external memory pool, this patch maps individual
ODP buffers directly to rte_mbufs. The rte_mbuf header is stored in extra space
added to the end of odp_packet_hdr_t struct. 

The ODP packet default headroom is modified to be the same as in DPDK to enable
interoperability between ODP and DPDK packets (matching packet size).

Some performance numbers compared to the standard DPDK pktio:

odp_l2fwd throughput (Mpps) with 64B packets:
- 2 x 40Gbps NICs

Cores   Standard    Zero-copy
  1     11.4        20.1
  2     21.4        43.5
  4     42.8        71.0 (Already limited by NIC capacity)
  6     63.5        68.0
  8     66.6        66.3
