### PR TITLE
[PATCH v1] linux-gen: crypto: add support for AES-192 and AES-256

### DIFF
--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -44,10 +44,14 @@ static const odp_crypto_cipher_capability_t cipher_capa_trides_cbc[] = {
 {.key_len = 24, .iv_len = 8} };
 
 static const odp_crypto_cipher_capability_t cipher_capa_aes_cbc[] = {
-{.key_len = 16, .iv_len = 16} };
+{.key_len = 16, .iv_len = 16},
+{.key_len = 24, .iv_len = 16},
+{.key_len = 32, .iv_len = 16} };
 
 static const odp_crypto_cipher_capability_t cipher_capa_aes_gcm[] = {
-{.key_len = 16, .iv_len = 12} };
+{.key_len = 16, .iv_len = 12},
+{.key_len = 24, .iv_len = 12},
+{.key_len = 32, .iv_len = 12} };
 
 /*
  * Authentication algorithm capabilities
@@ -734,23 +738,47 @@ odp_crypto_session_create(odp_crypto_session_param_t *param,
 	case ODP_CIPHER_ALG_3DES_CBC:
 		rc = process_cipher_param(session, EVP_des_ede3_cbc());
 		break;
-	case ODP_CIPHER_ALG_AES_CBC:
 #if ODP_DEPRECATED_API
 	case ODP_CIPHER_ALG_AES128_CBC:
+		if (param->cipher_key.length == 16)
+			rc = process_cipher_param(session, EVP_aes_128_cbc());
+		else
+			rc = -1;
+		break;
 #endif
-		rc = process_cipher_param(session, EVP_aes_128_cbc());
+	case ODP_CIPHER_ALG_AES_CBC:
+		if (param->cipher_key.length == 16)
+			rc = process_cipher_param(session, EVP_aes_128_cbc());
+		else if (param->cipher_key.length == 24)
+			rc = process_cipher_param(session, EVP_aes_192_cbc());
+		else if (param->cipher_key.length == 32)
+			rc = process_cipher_param(session, EVP_aes_256_cbc());
+		else
+			rc = -1;
 		break;
 #if ODP_DEPRECATED_API
 	case ODP_CIPHER_ALG_AES128_GCM:
-		if (param->auth_alg == ODP_AUTH_ALG_AES128_GCM)
-			aes_gcm = 1;
-		/* Fallthrough */
+		/* AES-GCM requires to do both auth and
+		 * cipher at the same time */
+		if (param->auth_alg != ODP_AUTH_ALG_AES128_GCM)
+			rc = -1;
+		else if (param->cipher_key.length == 16)
+			rc = process_aes_gcm_param(session, EVP_aes_128_gcm());
+		else
+			rc = -1;
+		break;
 #endif
 	case ODP_CIPHER_ALG_AES_GCM:
 		/* AES-GCM requires to do both auth and
 		 * cipher at the same time */
-		if (param->auth_alg == ODP_AUTH_ALG_AES_GCM || aes_gcm)
+		if (param->auth_alg != ODP_AUTH_ALG_AES_GCM)
+			rc = -1;
+		else if (param->cipher_key.length == 16)
 			rc = process_aes_gcm_param(session, EVP_aes_128_gcm());
+		else if (param->cipher_key.length == 24)
+			rc = process_aes_gcm_param(session, EVP_aes_192_gcm());
+		else if (param->cipher_key.length == 32)
+			rc = process_aes_gcm_param(session, EVP_aes_256_gcm());
 		else
 			rc = -1;
 		break;


### PR DESCRIPTION
Add support for AES with keys of 192 and 256 bits.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>