### PR TITLE
[PATCH v1] test: fix cunit include path

### DIFF
--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -16,6 +16,7 @@ INCFLAGS = \
 	-I$(top_builddir)/include
 
 AM_CFLAGS += $(INCFLAGS)
+AM_CPPFLAGS += $(CUNIT_CPPFLAGS)
 AM_CXXFLAGS = $(INCFLAGS)
 
 AM_LDFLAGS += -L$(LIB)


### PR DESCRIPTION
If CUnit is places in non standard directory and path
to it specified with configure option following error
occurs:
fatal error: CUnit/Basic.h: No such file or directory
Patch corrects CFLAGS to make compilation pass.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>