### PR TITLE
[PATCH API-NEXT v1] linux-gen: timer: set sigev_value in timer_res_init

### DIFF
--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -844,6 +844,7 @@ static int timer_res_init(void)
 
 	sigev.sigev_notify = SIGEV_THREAD_ID;
 	sigev._sigev_un._tid = (pid_t)syscall(SYS_gettid);
+	sigev.sigev_value.sival_ptr = NULL;
 	sigev.sigev_signo = SIGUSR1;
 
 	/* Create timer */


### PR DESCRIPTION
Even if signal is never to be delivered, it is still required to set
sigev_value in sigevent structure.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>