### PR TITLE
[PATCH v2] travis: fix DPDK cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@
 # See https://scan.coverity.com/travis_ci
 
 language: c
-cache:
-  directories:
-  - dpdk
 sudo: required
 dist: trusty
 group: deprecated-2017Q2
@@ -61,6 +58,8 @@ compiler:
 cache:
         - ccache
         - pip
+        - directories:
+                - dpdk
 
 env:
         - CONF=""


### PR DESCRIPTION
Unfortunately, keys in .travis.yml override each other rather than just
combining. Thus second cache instance (ccache) disabled first one
(DPDK). Fix that by merging both cache instance into single key in
.travis.yml.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>