### PR TITLE
[PATCH v3] validation: classification: support for classifier_enable boolean

### DIFF
--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -328,7 +328,6 @@ int odp_pktio_default_cos_set(odp_pktio_t pktio_in, odp_cos_t default_cos)
 	}
 
 	entry->s.cls.default_cos = cos;
-	pktio_cls_enabled_set(entry, 1);
 	return 0;
 }
 
@@ -403,7 +402,6 @@ int odp_cos_with_l2_priority(odp_pktio_t pktio_in,
 				l2_cos->cos[qos_table[i]] = cos;
 		}
 	}
-	pktio_cls_enabled_set(entry, 1);
 	UNLOCK(&l2_cos->lock);
 	return 0;
 }
@@ -436,7 +434,6 @@ int odp_cos_with_l3_qos(odp_pktio_t pktio_in,
 				l3_cos->cos[qos_table[i]] = cos;
 		}
 	}
-	pktio_cls_enabled_set(entry, 1);
 	UNLOCK(&l3_cos->lock);
 	return 0;
 }

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1234,6 +1234,8 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 		return -1;
 	}
 
+	pktio_cls_enabled_set(entry, param->classifier_enable);
+
 	if (num_queues > capa.max_input_queues) {
 		ODP_DBG("pktio %s: too many input queues\n", entry->s.name);
 		return -1;

--- a/test/common_plat/validation/api/classification/classification.h
+++ b/test/common_plat/validation/api/classification/classification.h
@@ -102,6 +102,7 @@ void classification_test_pmr_term_vlan_id_0(void);
 void classification_test_pmr_term_vlan_id_x(void);
 void classification_test_pmr_term_eth_type_0(void);
 void classification_test_pmr_term_eth_type_x(void);
+void classification_test_pktin_classifier_flag(void);
 
 /* test arrays: */
 extern odp_testinfo_t classification_suite_basic[];

--- a/test/common_plat/validation/api/classification/odp_classification_basic.c
+++ b/test/common_plat/validation/api/classification/odp_classification_basic.c
@@ -87,7 +87,7 @@ void classification_test_create_pmr_match(void)
 	pkt_pool = pool_create("pkt_pool");
 	CU_ASSERT_FATAL(pkt_pool != ODP_POOL_INVALID);
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 
 	configure_default_cos(pktio, &default_cos,
@@ -271,7 +271,7 @@ void classification_test_pmr_composite_create(void)
 	pkt_pool = pool_create("pkt_pool");
 	CU_ASSERT_FATAL(pkt_pool != ODP_POOL_INVALID);
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 
 	configure_default_cos(pktio, &default_cos,

--- a/test/common_plat/validation/api/classification/odp_classification_common.c
+++ b/test/common_plat/validation/api/classification/odp_classification_common.c
@@ -24,7 +24,8 @@ static uint8_t IPV6_DST_ADDR[ODPH_IPV6ADDR_LEN] = {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 10, 0, 0, 100
 };
 
-odp_pktio_t create_pktio(odp_queue_type_t q_type, odp_pool_t pool)
+odp_pktio_t create_pktio(odp_queue_type_t q_type, odp_pool_t pool,
+			 odp_bool_t cls_enable)
 {
 	odp_pktio_t pktio;
 	odp_pktio_param_t pktio_param;
@@ -50,6 +51,8 @@ odp_pktio_t create_pktio(odp_queue_type_t q_type, odp_pool_t pool)
 
 	odp_pktin_queue_param_init(&pktin_param);
 	pktin_param.queue_param.sched.sync = ODP_SCHED_SYNC_ATOMIC;
+	pktin_param.classifier_enable = cls_enable;
+	pktin_param.hash_enable = false;
 
 	if (odp_pktin_queue_config(pktio, &pktin_param)) {
 		fprintf(stderr, "pktin queue config failed.\n");

--- a/test/common_plat/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/common_plat/validation/api/classification/odp_classification_test_pmr.c
@@ -86,6 +86,104 @@ int classification_suite_pmr_term(void)
 	return retcode;
 }
 
+void classification_test_pktin_classifier_flag(void)
+{
+	odp_packet_t pkt;
+	odph_tcphdr_t *tcp;
+	uint32_t seqno;
+	uint16_t val;
+	uint16_t mask;
+	int retval;
+	odp_pktio_t pktio;
+	odp_queue_t queue;
+	odp_queue_t retqueue;
+	odp_queue_t default_queue;
+	odp_cos_t default_cos;
+	odp_pool_t default_pool;
+	odp_pmr_t pmr;
+	odp_cos_t cos;
+	char cosname[ODP_COS_NAME_LEN];
+	odp_cls_cos_param_t cls_param;
+	odp_pool_t pool;
+	odp_pool_t pool_recv;
+	odp_pmr_param_t pmr_param;
+	odph_ethhdr_t *eth;
+
+	val = CLS_DEFAULT_DPORT;
+	mask = 0xffff;
+	seqno = 0;
+
+	/* classifier is disabled in pktin queue configuration */
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, false);
+	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
+	retval = start_pktio(pktio);
+	CU_ASSERT(retval == 0);
+
+	configure_default_cos(pktio, &default_cos,
+			      &default_queue, &default_pool);
+
+	queue = queue_create("tcp_dport1", true);
+	CU_ASSERT(queue != ODP_QUEUE_INVALID);
+
+	pool = pool_create("tcp_dport1");
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	sprintf(cosname, "tcp_dport");
+	odp_cls_cos_param_init(&cls_param);
+	cls_param.pool = pool;
+	cls_param.queue = queue;
+	cls_param.drop_policy = ODP_COS_DROP_POOL;
+
+	cos = odp_cls_cos_create(cosname, &cls_param);
+	CU_ASSERT(cos != ODP_COS_INVALID);
+
+	odp_cls_pmr_param_init(&pmr_param);
+	pmr_param.term = ODP_PMR_TCP_DPORT;
+	pmr_param.match.value = &val;
+	pmr_param.match.mask = &mask;
+	pmr_param.val_sz = sizeof(val);
+
+	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
+	CU_ASSERT(pmr != ODP_PMR_INVAL);
+
+	pkt = create_packet(default_pkt_info);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	seqno = cls_pkt_get_seq(pkt);
+	CU_ASSERT(seqno != TEST_SEQ_INVALID);
+	eth = (odph_ethhdr_t *)odp_packet_l2_ptr(pkt, NULL);
+	odp_pktio_mac_addr(pktio, eth->src.addr, ODPH_ETHADDR_LEN);
+	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
+
+	tcp = (odph_tcphdr_t *)odp_packet_l4_ptr(pkt, NULL);
+	tcp->dst_port = odp_cpu_to_be_16(CLS_DEFAULT_DPORT);
+
+	enqueue_pktio_interface(pkt, pktio);
+
+	/* since classifier flag is disabled in pktin queue configuration
+	packet will not be delivered in classifier queues */
+	pkt = receive_packet(&retqueue, ODP_TIME_SEC_IN_NS);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+	pool_recv = odp_packet_pool(pkt);
+	/* since classifier is disabled packet should not be received in
+	pool and queue configured with classifier */
+	CU_ASSERT(pool != pool_recv);
+	CU_ASSERT(retqueue != queue);
+	CU_ASSERT(seqno == cls_pkt_get_seq(pkt));
+
+	odp_packet_free(pkt);
+
+	odp_packet_free(pkt);
+	odp_cos_destroy(cos);
+	odp_cos_destroy(default_cos);
+	odp_cls_pmr_destroy(pmr);
+	stop_pktio(pktio);
+	odp_queue_destroy(queue);
+	odp_queue_destroy(default_queue);
+	odp_pool_destroy(pool);
+	odp_pool_destroy(default_pool);
+	odp_pktio_close(pktio);
+}
+
 void classification_test_pmr_term_tcp_dport(void)
 {
 	odp_packet_t pkt;
@@ -113,7 +211,7 @@ void classification_test_pmr_term_tcp_dport(void)
 	mask = 0xffff;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -227,7 +325,7 @@ void classification_test_pmr_term_tcp_sport(void)
 	mask = 0xffff;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -340,7 +438,7 @@ void classification_test_pmr_term_udp_dport(void)
 	mask = 0xffff;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -456,7 +554,7 @@ void classification_test_pmr_term_udp_sport(void)
 	mask = 0xffff;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -570,7 +668,7 @@ void classification_test_pmr_term_ipproto(void)
 	mask = 0xff;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -679,7 +777,7 @@ void classification_test_pmr_term_dmac(void)
 	mask = 0xffffffffffff;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -786,7 +884,7 @@ void classification_test_pmr_term_packet_len(void)
 	mask = 0xff00;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -898,7 +996,7 @@ void classification_test_pmr_term_vlan_id_0(void)
 	mask = 0xff00;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -1011,7 +1109,7 @@ void classification_test_pmr_term_vlan_id_x(void)
 	mask = 0xff00;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -1124,7 +1222,7 @@ void classification_test_pmr_term_eth_type_0(void)
 	mask = 0xffff;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -1234,7 +1332,7 @@ void classification_test_pmr_term_eth_type_x(void)
 	mask = 0xff00;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -1347,7 +1445,7 @@ static void classification_test_pmr_pool_set(void)
 	mask = 0xff;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -1446,7 +1544,7 @@ static void classification_test_pmr_queue_set(void)
 	mask = 0xff;
 	seqno = 0;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	CU_ASSERT_FATAL(pktio != ODP_PKTIO_INVALID);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
@@ -1539,7 +1637,7 @@ static void classification_test_pmr_term_daddr(void)
 	const char *dst_addr = "10.0.0.99/32";
 	odph_ethhdr_t *eth;
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
 
@@ -1650,7 +1748,7 @@ static void classification_test_pmr_term_ipv6daddr(void)
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
 	};
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
 
@@ -1760,7 +1858,7 @@ static void classification_test_pmr_term_ipv6saddr(void)
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
 	};
 
-	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool);
+	pktio = create_pktio(ODP_QUEUE_TYPE_SCHED, pkt_pool, true);
 	retval = start_pktio(pktio);
 	CU_ASSERT(retval == 0);
 
@@ -1860,5 +1958,6 @@ odp_testinfo_t classification_suite_pmr[] = {
 	ODP_TEST_INFO(classification_test_pmr_term_vlan_id_x),
 	ODP_TEST_INFO(classification_test_pmr_term_eth_type_0),
 	ODP_TEST_INFO(classification_test_pmr_term_eth_type_x),
+	ODP_TEST_INFO(classification_test_pktin_classifier_flag),
 	ODP_TEST_INFO_NULL,
 };

--- a/test/common_plat/validation/api/classification/odp_classification_tests.c
+++ b/test/common_plat/validation/api/classification/odp_classification_tests.c
@@ -52,6 +52,8 @@ int classification_suite_init(void)
 
 	odp_pktin_queue_param_init(&pktin_param);
 	pktin_param.queue_param.sched.sync = ODP_SCHED_SYNC_ATOMIC;
+	pktin_param.classifier_enable = true;
+	pktin_param.hash_enable = false;
 
 	if (odp_pktin_queue_config(pktio_loop, &pktin_param)) {
 		fprintf(stderr, "pktin queue config failed.\n");

--- a/test/common_plat/validation/api/classification/odp_classification_testsuites.h
+++ b/test/common_plat/validation/api/classification/odp_classification_testsuites.h
@@ -35,7 +35,8 @@ int classification_suite_pmr_init(void);
 odp_packet_t create_packet(cls_packet_info_t pkt_info);
 int cls_pkt_set_seq(odp_packet_t pkt);
 uint32_t cls_pkt_get_seq(odp_packet_t pkt);
-odp_pktio_t create_pktio(odp_queue_type_t q_type, odp_pool_t pool);
+odp_pktio_t create_pktio(odp_queue_type_t q_type, odp_pool_t pool,
+			 odp_bool_t cls_enable);
 void configure_default_cos(odp_pktio_t pktio, odp_cos_t *cos,
 			   odp_queue_t *queue, odp_pool_t *pool);
 int parse_ipv4_string(const char *ipaddress, uint32_t *addr, uint32_t *mask);


### PR DESCRIPTION
Adds implementation and test case for classifier_enable boolean in odp_pktin_queue_param_t struct.

Fixes https://bugs.linaro.org/show_bug.cgi?id=3177