### PR TITLE
[PATCH v1] travis: cache cunit and netmap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ cache:
         - directories:
                 - dpdk
                 - netmap
+                - $HOME/cunit-install
 
 env:
         - CONF=""
@@ -88,23 +89,26 @@ before_install:
           fi
         - if test ! -L /usr/lib/ccache/${CC%% *} ; then sudo ln -s -t /usr/lib/ccache/ `which ${CC%% *}` ; fi
         - ccache -s
-
         # Install cunit for the validation tests because distro version is too old and fails C99 compile
         - sudo apt-get remove libcunit1-dev libcunit1
-        - export CUNIT_VERSION=2.1-3
-        - curl -sSOL https://github.com/Linaro/libcunit/releases/download/${CUNIT_VERSION}/CUnit-${CUNIT_VERSION}.tar.bz2
-        - tar -jxf *.bz2
-        - pushd CUnit*
-        - libtoolize --force --copy
-        - aclocal
-        - autoheader
-        - automake --add-missing --include-deps --copy
-        - autoconf
-        - ./configure --enable-debug --enable-automated --enable-basic --enable-console --enable-examples --enable-test $CROSS || cat config.log
-        - make
-        - sudo make install
-        - popd
-        - export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+        - export LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH"
+        - |
+          if [ ! -f "$HOME/cunit-install/$CROSS_ARCH/lib/libcunit.a" ]; then
+            export CUNIT_VERSION=2.1-3
+            curl -sSOL https://github.com/Linaro/libcunit/releases/download/${CUNIT_VERSION}/CUnit-${CUNIT_VERSION}.tar.bz2
+            tar -jxf *.bz2
+            pushd CUnit*
+            libtoolize --force --copy
+            aclocal
+            autoheader
+            automake --add-missing --include-deps --copy
+            autoconf
+            ./configure --prefix=$HOME/cunit-install/$CROSS_ARCH --enable-debug --enable-automated --enable-basic --enable-console --enable-examples --enable-test $CROSS || cat config.log
+            make
+            sudo make install
+            popd
+          fi
+        - find $HOME/cunit-install
 
 install:
         - echo 1000 | sudo tee /proc/sys/vm/nr_hugepages
@@ -146,10 +150,10 @@ install:
 
 script:
         - ./bootstrap
-        - ./configure --prefix=$HOME/odp-install  --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example --with-dpdk-path=`pwd`/dpdk/${TARGET} --with-netmap-path=`pwd`/netmap $CONF
+        - ./configure --prefix=$HOME/odp-install  --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example --with-dpdk-path=`pwd`/dpdk/${TARGET} --with-netmap-path=`pwd`/netmap --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH $CONF
         - make -j $(nproc)
         - mkdir /dev/shm/odp
-        - sudo LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check
+        - sudo LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check
         - make install
 
         - echo "Checking linking and run from install..."
@@ -171,7 +175,7 @@ jobs:
                   script:
                           - ./bootstrap
                           - ./configure --prefix=$HOME/odp-install $CROSS
-                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example
+                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
                   compiler: "\"clang-3.8 --target=aarch64-linux-gnu\""
@@ -179,8 +183,8 @@ jobs:
                   install: true
                   script:
                           - ./bootstrap
-                          - ./configure --prefix=$HOME/odp-install $CROSS
-                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example
+                          - ./configure --prefix=$HOME/odp/odp-install $CROSS
+                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
                   compiler: arm-linux-gnueabihf-gcc
@@ -189,7 +193,7 @@ jobs:
                   script:
                           - ./bootstrap
                           - ./configure --prefix=$HOME/odp-install $CROSS
-                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example
+                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
                   compiler: "\"clang-3.8 --target=arm-linux-gnueabihf\""
@@ -198,7 +202,7 @@ jobs:
                   script:
                           - ./bootstrap
                           - ./configure --prefix=$HOME/odp-install $CROSS
-                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example
+                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
                   compiler: powerpc-linux-gnu-gcc
@@ -207,7 +211,7 @@ jobs:
                   script:
                           - ./bootstrap
                           - ./configure --prefix=$HOME/odp-install $CROSS
-                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example
+                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
                   compiler: "\"clang-3.8 --target=powerpc-linux-gnu\""
@@ -216,23 +220,23 @@ jobs:
                   script:
                           - ./bootstrap
                           - ./configure --prefix=$HOME/odp-install $CROSS
-                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example
+                            --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
                   env: TEST=coverage
                   compiler: gcc
                   script:
                           - ./bootstrap
-                          - ./configure --prefix=$HOME/odp-install --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example --with-dpdk-path=`pwd`/dpdk/${TARGET} --with-netmap-path=`pwd`/netmap CFLAGS="-O0 -coverage" CXXFLAGS="-O0 -coverage" LDFLAGS="--coverage"
-                          - sudo LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" PATH=${PATH//:\.\/node_modules\/\.bin/} make check
+                          - ./configure --prefix=$HOME/odp-install --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example --with-dpdk-path=`pwd`/dpdk/${TARGET} --with-netmap-path=`pwd`/netmap CFLAGS="-O0 -coverage" --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH CXXFLAGS="-O0 -coverage" LDFLAGS="--coverage"
+                          - sudo LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" PATH=${PATH//:\.\/node_modules\/\.bin/} make check
                           - find . -type f -iname '*.[ch]' -not -path ".git/*" -execdir gcov {} \; ; bash <(curl -s https://codecov.io/bash) -X coveragepy
                 - stage: test
                   env: TEST=distcheck
                   compiler: gcc
                   script:
                           - ./bootstrap
-                          - ./configure --prefix=$HOME/odp-install --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example
-                          - sudo PATH="$PATH" LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" make distcheck
+                          - ./configure --prefix=$HOME/odp-install --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
+                          - sudo PATH="$PATH" LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" make distcheck
                 - stage: test
                   env: TEST=doxygen
                   compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -236,7 +236,7 @@ jobs:
                   script:
                           - ./bootstrap
                           - ./configure --prefix=$HOME/odp-install --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
-                          - sudo PATH="$PATH" LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" make distcheck
+                          - sudo PATH="$PATH" LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" make distcheck CFLAGS="-I$HOME/cunit-install/$CROSS_ARCH/include" LDFLAGS="-L$HOME/cunit-install/$CROSS_ARCH/lib"
                 - stage: test
                   env: TEST=doxygen
                   compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ cache:
         - pip
         - directories:
                 - dpdk
+                - netmap
 
 env:
         - CONF=""
@@ -133,12 +134,15 @@ install:
           fi
 
 #	Netmap pktio
-        - git -c advice.detachedHead=false clone -q --depth=1 --single-branch --branch=v11.2 https://github.com/luigirizzo/netmap.git
-        - pushd netmap/LINUX
-        - ./configure
-        - make
-        - sudo insmod ./netmap.ko
-        - popd
+        - |
+          if [ ! -f "netmap/LINUX/netmap.ko" ]; then
+            git -c advice.detachedHead=false clone -q --depth=1 --single-branch --branch=v11.2 https://github.com/luigirizzo/netmap.git
+            pushd netmap/LINUX
+            ./configure
+            make
+            sudo insmod ./netmap.ko
+            popd
+          fi
 
 script:
         - ./bootstrap


### PR DESCRIPTION
Adding cache for cunit and netmap decreases each test about 3 minutes. Most of the tests now run in less then 10 minutes.