### PR TITLE
[PATCH v2] api: pktio: deprecate redundant loop_supported field in capability

### DIFF
--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 
+#include <odp/api/deprecated.h>
 #include <odp/api/packet_io_stats.h>
 #include <odp/api/queue.h>
 #include <odp/api/time.h>
@@ -445,11 +446,8 @@ typedef struct odp_pktio_capability_t {
 	 * set to zero. */
 	odp_pktio_set_op_t set_op;
 
-	/** Support of Loopback mode
-	 *
-	 * A boolean to denote whether loop back mode is supported on this
-	 * specific interface. */
-	odp_bool_t loop_supported;
+	/** @deprecated Use enable_loop inside odp_pktin_config_t */
+	odp_bool_t ODP_DEPRECATE(loop_supported);
 } odp_pktio_capability_t;
 
 /**

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -416,7 +416,7 @@ int odp_pktio_config(odp_pktio_t hdl, const odp_pktio_config_t *config)
 		return -1;
 	}
 
-	if (config->enable_loop && !capa.loop_supported) {
+	if (config->enable_loop && !capa.config.enable_loop) {
 		ODP_ERR("Loopback mode not supported\n");
 		return -1;
 	}


### PR DESCRIPTION
removes redundant loop_supported boolean in odp_pktio_capability_t
Fixes https://bugs.linaro.org/show_bug.cgi?id=2861

Signed-off-by: Balasubramanian Manoharan <bala.manoharan@linaro.org>