### PR TITLE
[PATCH API-NEXT v3] linux-gen: timer: control the timer pool polling frequency dynamically

### DIFF
--- a/platform/linux-generic/include/odp_timer_internal.h
+++ b/platform/linux-generic/include/odp_timer_internal.h
@@ -20,9 +20,6 @@
 #include <odp_pool_internal.h>
 #include <odp/api/timer.h>
 
-/* Minimum number of nanoseconds between checking timer pools. */
-#define CONFIG_TIMER_RUN_RATELIMIT_NS 100
-
 /* Minimum number of scheduling rounds between checking timer pools. */
 #define CONFIG_TIMER_RUN_RATELIMIT_ROUNDS 1
 


### PR DESCRIPTION
The frequency of timer pool polling needs to be adjusted according to
the duration of the timer started in the timer module. And there need
to be 0 timer pool polling when no timer pools/timers created.

At the same time, enable inline timers when passing NULL for odp_init_global.

Signed-off-by: Joyce Kong <joyce.kong@arm.com>