### PR TITLE
[PATCH v1] linux-gen: dpdk: make sure mbuf memory is allocated from huge pages

### DIFF
--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -71,6 +71,7 @@ typedef struct pool_t {
 	uint8_t         *uarea_base_addr;
 
 	/* Used by DPDK zero-copy pktio */
+	uint8_t		mem_from_huge_pages;
 	pool_destroy_cb_fn ext_destroy;
 	void            *ext_desc;
 


### PR DESCRIPTION
DPDK requires that mbuf memory is allocated from huge pages to ensure page
locking. Modify zero-copy dpdk pktio to fall back to packet copy if
transmitted ODP packet is not allocated from huge page memory.

Signed-off-by: Matias Elo <matias.elo@nokia.com>