### PR TITLE
[PATCH v5] helper: ip: correct ipv4 header checksum calculation

### DIFF
--- a/helper/include/odp/helper/chksum.h
+++ b/helper/include/odp/helper/chksum.h
@@ -40,7 +40,7 @@ typedef enum {
  * @param buffer calculate chksum for buffer
  * @param len    buffer length
  *
- * @return checksum value in host cpu order
+ * @return checksum value in network order
  */
 static inline odp_u16sum_t odph_chksum(void *buffer, int len)
 {

--- a/helper/test/chksum.c
+++ b/helper/test/chksum.c
@@ -108,9 +108,17 @@ int main(int argc ODPH_UNUSED, char *argv[] ODPH_UNUSED)
 				       ODPH_IPV4HDR_LEN);
 	ip->proto = ODPH_IPPROTO_UDP;
 	ip->id = odp_cpu_to_be_16(1);
-	ip->chksum = 0;
 	odp_packet_has_ipv4_set(test_packet, 1);
-	odph_ipv4_csum_update(test_packet);
+	if (odph_ipv4_csum_update(test_packet) < 0)
+		status = -1;
+
+	if (!odph_ipv4_csum_valid(test_packet))
+		status = -1;
+
+	printf("IP chksum = 0x%x\n", odp_be_to_cpu_16(ip->chksum));
+
+	if (odp_be_to_cpu_16(ip->chksum) != 0x3965)
+		status = -1;
 
 	/* udp */
 	odp_packet_l4_offset_set(test_packet, ODPH_ETHHDR_LEN

--- a/test/common_plat/validation/api/classification/odp_classification_common.c
+++ b/test/common_plat/validation/api/classification/odp_classification_common.c
@@ -315,8 +315,7 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 		ip->src_addr = odp_cpu_to_be_32(addr);
 		ip->ver_ihl = ODPH_IPV4 << 4 | ODPH_IPV4HDR_IHL_MIN;
 		ip->id = odp_cpu_to_be_16(seqno);
-		ip->chksum = 0;
-		ip->chksum = odph_ipv4_csum_update(pkt);
+		odph_ipv4_csum_update(pkt);
 		ip->proto = next_hdr;
 		ip->tot_len = odp_cpu_to_be_16(l3_len);
 		ip->ttl = DEFAULT_TTL;

--- a/test/common_plat/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/common_plat/validation/api/classification/odp_classification_test_pmr.c
@@ -1676,7 +1676,7 @@ static void classification_test_pmr_term_daddr(void)
 	odp_pktio_mac_addr(pktio, eth->dst.addr, ODPH_ETHADDR_LEN);
 	ip = (odph_ipv4hdr_t *)odp_packet_l3_ptr(pkt, NULL);
 	ip->dst_addr = odp_cpu_to_be_32(addr);
-	ip->chksum = odph_ipv4_csum_update(pkt);
+	odph_ipv4_csum_update(pkt);
 
 	seqno = cls_pkt_get_seq(pkt);
 	CU_ASSERT(seqno != TEST_SEQ_INVALID);

--- a/test/common_plat/validation/api/classification/odp_classification_tests.c
+++ b/test/common_plat/validation/api/classification/odp_classification_tests.c
@@ -237,8 +237,7 @@ void test_cls_pmr_chain(void)
 	ip = (odph_ipv4hdr_t *)odp_packet_l3_ptr(pkt, NULL);
 	parse_ipv4_string(CLS_PMR_CHAIN_SADDR, &addr, &mask);
 	ip->src_addr = odp_cpu_to_be_32(addr);
-	ip->chksum = 0;
-	ip->chksum = odph_ipv4_csum_update(pkt);
+	odph_ipv4_csum_update(pkt);
 
 	set_first_supported_pmr_port(pkt, CLS_PMR_CHAIN_PORT);
 
@@ -260,8 +259,7 @@ void test_cls_pmr_chain(void)
 	ip = (odph_ipv4hdr_t *)odp_packet_l3_ptr(pkt, NULL);
 	parse_ipv4_string(CLS_PMR_CHAIN_SADDR, &addr, &mask);
 	ip->src_addr = odp_cpu_to_be_32(addr);
-	ip->chksum = 0;
-	ip->chksum = odph_ipv4_csum_update(pkt);
+	odph_ipv4_csum_update(pkt);
 
 	enqueue_pktio_interface(pkt, pktio_loop);
 	pkt = receive_packet(&queue, ODP_TIME_SEC_IN_NS);
@@ -668,8 +666,7 @@ void test_pktio_pmr_composite_cos(void)
 	ip = (odph_ipv4hdr_t *)odp_packet_l3_ptr(pkt, NULL);
 	parse_ipv4_string(CLS_PMR_SET_SADDR, &addr, &mask);
 	ip->src_addr = odp_cpu_to_be_32(addr);
-	ip->chksum = 0;
-	ip->chksum = odph_ipv4_csum_update(pkt);
+	odph_ipv4_csum_update(pkt);
 
 	set_first_supported_pmr_port(pkt, CLS_PMR_SET_PORT);
 	enqueue_pktio_interface(pkt, pktio_loop);


### PR DESCRIPTION
Current code for IPv4 header checksum calculation assumes that packet
data is aligned on 2-byte boundary, that there are no optional headers,
etc. Rewrite checksumming code to properly copy & process headers.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>