### PR TITLE
[PATCH v7] travis: add --enable-debug to list of test variants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,6 +151,7 @@ install:
 script:
         - ./bootstrap
         - ./configure --prefix=$HOME/odp-install  --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example --with-dpdk-path=`pwd`/dpdk/${TARGET} --with-netmap-path=`pwd`/netmap --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH $CONF
+          --enable-debug
         - make -j $(nproc)
         - mkdir /dev/shm/odp
         - sudo LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check
@@ -174,7 +175,7 @@ jobs:
                   install: true
                   script:
                           - ./bootstrap
-                          - ./configure --prefix=$HOME/odp-install $CROSS
+                          - ./configure --prefix=$HOME/odp-install $CROSS --enable-debug
                             --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
@@ -183,7 +184,7 @@ jobs:
                   install: true
                   script:
                           - ./bootstrap
-                          - ./configure --prefix=$HOME/odp/odp-install $CROSS
+                          - ./configure --prefix=$HOME/odp/odp-install $CROSS --enable-debug
                             --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
@@ -192,7 +193,7 @@ jobs:
                   install: true
                   script:
                           - ./bootstrap
-                          - ./configure --prefix=$HOME/odp-install $CROSS
+                          - ./configure --prefix=$HOME/odp-install $CROSS --enable-debug
                             --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
@@ -201,7 +202,7 @@ jobs:
                   install: true
                   script:
                           - ./bootstrap
-                          - ./configure --prefix=$HOME/odp-install $CROSS
+                          - ./configure --prefix=$HOME/odp-install $CROSS --enable-debug
                             --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
@@ -210,7 +211,7 @@ jobs:
                   install: true
                   script:
                           - ./bootstrap
-                          - ./configure --prefix=$HOME/odp-install $CROSS
+                          - ./configure --prefix=$HOME/odp-install $CROSS --enable-debug
                             --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
@@ -219,7 +220,7 @@ jobs:
                   install: true
                   script:
                           - ./bootstrap
-                          - ./configure --prefix=$HOME/odp-install $CROSS
+                          - ./configure --prefix=$HOME/odp-install $CROSS --enable-debug
                             --disable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH
                           - make -j $(nproc)
                 - stage: test
@@ -228,6 +229,7 @@ jobs:
                   script:
                           - ./bootstrap
                           - ./configure --prefix=$HOME/odp-install --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example --with-dpdk-path=`pwd`/dpdk/${TARGET} --with-netmap-path=`pwd`/netmap CFLAGS="-O0 -coverage" --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH CXXFLAGS="-O0 -coverage" LDFLAGS="--coverage"
+                            --enable-debug
                           - sudo LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" PATH=${PATH//:\.\/node_modules\/\.bin/} make check
                           - find . -type f -iname '*.[ch]' -not -path ".git/*" -execdir gcov {} \; ; bash <(curl -s https://codecov.io/bash) -X coveragepy
                 - stage: test


### PR DESCRIPTION
ODP includes a number of ODP_ASSERT() calls to assist in debugging but
these never expand unless --enable-debug is used. Add that test variant
to test new ODP_ASSERT() calls added as part of PRs as well as to do
additional testing on PRs to verify that they don't contain more subtle
problems that the existing ODP_ASSERT() calls are designed to catch.

Signed-off-by: Bill Fischofer <bill.fischofer@linaro.org>