### PR TITLE
[PATCH v2] [MONARCH_LTS PATCH v1] linux-gen: port fix out of tree build commits

### DIFF
--- a/example/Makefile.inc
+++ b/example/Makefile.inc
@@ -6,6 +6,8 @@ AM_CFLAGS += \
 	-I$(top_srcdir)/example \
 	-I$(top_srcdir)/platform/@with_platform@/include \
 	-I$(top_srcdir)/include/ \
-	-I$(top_srcdir)/helper/include
+	-I$(top_srcdir)/helper/include \
+	-I$(top_builddir)/platform/@with_platform@/include \
+	-I$(top_builddir)/include
 
 AM_LDFLAGS += -L$(LIB)

--- a/helper/Makefile.am
+++ b/helper/Makefile.am
@@ -7,6 +7,8 @@ LIB   = $(top_builddir)/lib
 AM_CFLAGS  = -I$(srcdir)/include
 AM_CFLAGS += -I$(top_srcdir)/platform/@with_platform@/include
 AM_CFLAGS += -I$(top_srcdir)/include
+AM_CFLAGS += -I$(top_builddir)/platform/@with_platform@/include
+AM_CFLAGS += -I$(top_builddir)/include
 
 AM_LDFLAGS += -version-number '$(ODPHELPER_LIBSO_VERSION)'
 

--- a/platform/Makefile.inc
+++ b/platform/Makefile.inc
@@ -57,5 +57,5 @@ odpapispecinclude_HEADERS = \
 		  $(top_srcdir)/include/odp/api/spec/ticketlock.h \
 		  $(top_srcdir)/include/odp/api/spec/time.h \
 		  $(top_srcdir)/include/odp/api/spec/timer.h \
-		  $(top_srcdir)/include/odp/api/spec/traffic_mngr.h \
-		  $(top_srcdir)/include/odp/api/spec/version.h
+		  $(top_builddir)/include/odp/api/spec/version.h \
+		  $(top_srcdir)/include/odp/api/spec/traffic_mngr.h

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -6,6 +6,8 @@ include $(top_srcdir)/platform/@with_platform@/Makefile.inc
 
 AM_CFLAGS +=  -I$(srcdir)/include
 AM_CFLAGS +=  -I$(top_srcdir)/include
+AM_CFLAGS +=  -I$(top_builddir)/include
+AM_CFLAGS +=  -Iinclude
 
 include_HEADERS = \
 		  $(top_srcdir)/include/odp.h \

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -6,10 +6,14 @@ LIB   = $(top_builddir)/lib
 #before libodp by setting PRE_LDADD before the inclusion.
 LDADD = $(PRE_LDADD) $(LIB)/libodphelper-linux.la $(LIB)/libodp-linux.la
 
-INCFLAGS = -I$(top_srcdir)/test \
+INCFLAGS = -I$(top_builddir)/include \
+	-I$(top_srcdir)/test \
 	-I$(top_srcdir)/platform/@with_platform@/include \
 	-I$(top_srcdir)/include \
-	-I$(top_srcdir)/helper/include
+	-I$(top_srcdir)/helper/include \
+	-I$(top_srcdir)/test \
+	-I$(top_srcdir)/test/validation/common
+
 AM_CFLAGS += $(INCFLAGS)
 AM_CXXFLAGS = $(INCFLAGS)
 

--- a/test/platform/linux-generic/Makefile.inc
+++ b/test/platform/linux-generic/Makefile.inc
@@ -8,9 +8,16 @@ LIBCUNIT_COMMON = $(top_builddir)/test/validation/common/libcunit_common.la
 LIB   = $(top_builddir)/lib
 LIBODP = $(LIB)/libodphelper-linux.la $(LIB)/libodp-linux.la
 
-INCCUNIT_COMMON = -I$(top_srcdir)/test/validation/common
-INCODP = -I$(top_srcdir)/test \
+INCCUNIT_COMMON = -I$(top_srcdir)/test/common_plat/common
+INCODP =  \
+	 -I$(top_builddir)/include \
+	 -I$(top_builddir)/platform/@with_platform@/include \
+	 -I$(top_srcdir)/helper/include \
+	 -I$(top_srcdir)/include \
+	 -I$(top_srcdir)/platform/@with_platform@/arch/$(ARCH_DIR) \
 	 -I$(top_srcdir)/platform/@with_platform@/include \
 	 -I$(top_srcdir)/platform/@with_platform@/arch/$(ARCH_DIR) \
+	 -I$(top_srcdir)/test \
+	 -I$(top_srcdir)/test/validation/common \
 	 -I$(top_srcdir)/include \
 	 -I$(top_srcdir)/helper/include


### PR DESCRIPTION
Combined fix for 2 commits to fix out of tree build.

1.
commit 5dd7d9ed05ee ("linux-gen: makefile: fix out of tree build")

Author: Petri Savolainen <petri.savolainen@linaro.org>
Date:   Mon Jun 19 11:25:19 2017 +0300

    linux-gen: makefile: fix out of tree build

    Generated files need $(top_builddir) instead of $(top_srcdir)

    Fixes bug https://bugs.linaro.org/show_bug.cgi?id=3052

2.
b35abec0 (fix out of tree build)

Commit:
	eebd6b0 configure: the version cannot use a script
Did generation of version.h which is done in $dest_dir. Includes
paths have to be corrected accordingly.

Conflicts:
	example/Makefile.inc
	helper/Makefile.am
	platform/Makefile.inc
	platform/linux-generic/Makefile.am
	test/Makefile.inc
	test/platform/linux-generic/Makefile.inc

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>