### PR TITLE
[MONARCH_LTS PATCH v1] configure.ac: inc library version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ AM_SILENT_RULES([yes])
 ##########################################################################
 # Set correct platform library version
 ##########################################################################
-ODP_LIBSO_VERSION=111:0:0
+ODP_LIBSO_VERSION=111:1:0
 AC_SUBST(ODP_LIBSO_VERSION)
 
 ODPHELPER_LIBSO_VERSION=110:0:1


### PR DESCRIPTION
I think that the latest thing for monarch is inc of that version.

-----
only source code was changed to inc only middle number.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>