### PR TITLE
[PATCH CLOUD-DEV v1] linux-gen: buffer: move buffer to modular framework

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -242,7 +242,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_atomic.c \
 			   odp_barrier.c \
 			   odp_bitmap.c \
-			   odp_buffer.c \
+			   buffer/generic.c \
 			   buffer/subsystem.c \
 			   odp_byteorder.c \
 			   odp_classification.c \
@@ -331,6 +331,7 @@ __LIB__libodp_linux_la_SOURCES += pktio/pcap.c
 endif
 
 pool/generic.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
+buffer/generic.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
 
 # Build modular framework into odp-linux library
 modularframeworkdir = $(top_srcdir)/frameworks/modular

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -171,6 +171,7 @@ noinst_HEADERS = \
 		  ${srcdir}/include/odp_bitmap_internal.h \
 		  ${srcdir}/include/odp_bitset.h \
 		  ${srcdir}/include/odp_buffer_internal.h \
+		  ${srcdir}/include/odp_buffer_subsystem.h \
 		  ${srcdir}/include/odp_classification_datamodel.h \
 		  ${srcdir}/include/odp_classification_inlines.h \
 		  ${srcdir}/include/odp_classification_internal.h \
@@ -242,6 +243,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_barrier.c \
 			   odp_bitmap.c \
 			   odp_buffer.c \
+			   buffer/subsystem.c \
 			   odp_byteorder.c \
 			   odp_classification.c \
 			   odp_cpu.c \

--- a/platform/linux-generic/buffer/subsystem.c
+++ b/platform/linux-generic/buffer/subsystem.c
@@ -1,0 +1,17 @@
+/* Copyright (c) 2017, ARM Limited. All rights reserved.
+ *
+ * Copyright (c) 2017, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <odp_module.h>
+
+#define SUBSYSTEM_VERSION 0x00010000UL
+ODP_SUBSYSTEM_DEFINE(buffer, "memory buffer public APIs", SUBSYSTEM_VERSION);
+
+ODP_SUBSYSTEM_CONSTRUCTOR(buffer)
+{
+	odp_subsystem_constructor(buffer);
+}
+

--- a/platform/linux-generic/buffer/subsystem.c
+++ b/platform/linux-generic/buffer/subsystem.c
@@ -5,13 +5,112 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <odp/api/buffer.h>
+#include <odp_buffer_subsystem.h>
+#include <odp_debug_internal.h>
 #include <odp_module.h>
 
-#define SUBSYSTEM_VERSION 0x00010000UL
-ODP_SUBSYSTEM_DEFINE(buffer, "memory buffer public APIs", SUBSYSTEM_VERSION);
+ODP_SUBSYSTEM_DEFINE(buffer, "memory buffer public APIs",
+		     BUFFER_SUBSYSTEM_VERSION);
 
 ODP_SUBSYSTEM_CONSTRUCTOR(buffer)
 {
 	odp_subsystem_constructor(buffer);
+}
+
+odp_buffer_t odp_buffer_from_event(odp_event_t ev)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_from_event(ev);
+}
+
+odp_event_t odp_buffer_to_event(odp_buffer_t buf)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_to_event(buf);
+}
+
+void *odp_buffer_addr(odp_buffer_t buf)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_addr(buf);
+}
+
+uint32_t odp_buffer_size(odp_buffer_t buf)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_size(buf);
+}
+
+void odp_buffer_print(odp_buffer_t buf)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_print(buf);
+}
+
+uint64_t odp_buffer_to_u64(odp_buffer_t hdl)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_to_u64(hdl);
+}
+
+odp_buffer_t odp_buffer_alloc(odp_pool_t pool_hdl)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_alloc(pool_hdl);
+}
+
+int odp_buffer_alloc_multi(odp_pool_t pool_hdl, odp_buffer_t buf[], int num)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_alloc_multi(pool_hdl, buf, num);
+}
+
+void odp_buffer_free(odp_buffer_t buf)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_free(buf);
+}
+
+void odp_buffer_free_multi(const odp_buffer_t buf[], int num)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_free_multi(buf, num);
+}
+
+odp_pool_t odp_buffer_pool(odp_buffer_t buf)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_pool(buf);
+}
+
+int odp_buffer_is_valid(odp_buffer_t buf)
+{
+	odp_buffer_module_t *mod;
+
+	mod = odp_subsystem_active_module(buffer, mod);
+	return mod->buffer_is_valid(buf);
 }
 

--- a/platform/linux-generic/include/odp_buffer_subsystem.h
+++ b/platform/linux-generic/include/odp_buffer_subsystem.h
@@ -1,0 +1,60 @@
+/* Copyright (c) 2017, ARM Limited. All rights reserved.
+ *
+ * Copyright (c) 2017, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef ODP_BUFFER_SUBSYSTEM_H_
+#define ODP_BUFFER_SUBSYSTEM_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp_module.h>
+#include <odp/api/buffer.h>
+
+/* ODP buffer public APIs subsystem */
+ODP_SUBSYSTEM_DECLARE(buffer);
+
+/* Subsystem APIs declarations */
+ODP_SUBSYSTEM_API(buffer, odp_buffer_t, buffer_from_event, odp_event_t ev);
+ODP_SUBSYSTEM_API(buffer, odp_event_t, buffer_to_event, odp_buffer_t buf);
+ODP_SUBSYSTEM_API(buffer, void *, buffer_addr, odp_buffer_t buf);
+ODP_SUBSYSTEM_API(buffer, uint32_t, buffer_size, odp_buffer_t buf);
+ODP_SUBSYSTEM_API(buffer, int, buffer_is_valid, odp_buffer_t buf);
+ODP_SUBSYSTEM_API(buffer, odp_pool_t, buffer_pool, odp_buffer_t buf);
+ODP_SUBSYSTEM_API(buffer, odp_buffer_t, buffer_alloc, odp_pool_t pool_hdl);
+ODP_SUBSYSTEM_API(buffer, int, buffer_alloc_multi, odp_pool_t pool_hdl,
+		  odp_buffer_t buf[], int num);
+ODP_SUBSYSTEM_API(buffer, void, buffer_free, odp_buffer_t buf);
+ODP_SUBSYSTEM_API(buffer, void, buffer_free_multi,
+		  const odp_buffer_t buf[], int num);
+ODP_SUBSYSTEM_API(buffer, void, buffer_print, odp_buffer_t buf);
+ODP_SUBSYSTEM_API(buffer, uint64_t, buffer_to_u64, odp_buffer_t hdl);
+
+typedef ODP_MODULE_CLASS(buffer) {
+	odp_module_base_t base;
+
+	odp_api_proto(buffer, buffer_from_event) buffer_from_event;
+	odp_api_proto(buffer, buffer_to_event) buffer_to_event;
+	odp_api_proto(buffer, buffer_addr) buffer_addr;
+	odp_api_proto(buffer, buffer_alloc_multi) buffer_alloc_multi;
+	odp_api_proto(buffer, buffer_free_multi) buffer_free_multi;
+	odp_api_proto(buffer, buffer_alloc) buffer_alloc;
+	odp_api_proto(buffer, buffer_free) buffer_free;
+	odp_api_proto(buffer, buffer_size) buffer_size;
+	odp_api_proto(buffer, buffer_is_valid) buffer_is_valid;
+	odp_api_proto(buffer, buffer_pool) buffer_pool;
+	odp_api_proto(buffer, buffer_print) buffer_print;
+	odp_api_proto(buffer, buffer_to_u64) buffer_to_u64;
+} odp_buffer_module_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/platform/linux-generic/include/odp_buffer_subsystem.h
+++ b/platform/linux-generic/include/odp_buffer_subsystem.h
@@ -16,6 +16,8 @@ extern "C" {
 #include <odp_module.h>
 #include <odp/api/buffer.h>
 
+#define BUFFER_SUBSYSTEM_VERSION 0x00010000UL
+
 /* ODP buffer public APIs subsystem */
 ODP_SUBSYSTEM_DECLARE(buffer);
 


### PR DESCRIPTION
Separate with two commits.
First one is to add the buffer subsystem in modular framework.
Second one is to add the generic buffer implementation to the buffer subsystem.