### PR TITLE
[PATCH v2] linux-gen: socket: use segment data pointers in _tx_pkt_to_iovec()

### DIFF
--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -697,7 +697,7 @@ static uint32_t _tx_pkt_to_iovec(odp_packet_t pkt,
 				 struct iovec iovecs[MAX_SEGS])
 {
 	uint32_t pkt_len = odp_packet_len(pkt);
-	uint32_t offset = odp_packet_l2_offset(pkt);
+	uint32_t offset = 0;
 	uint32_t iov_count = 0;
 
 	while (offset < pkt_len) {


### PR DESCRIPTION
A packet may not have valid L2 offset set, so odp_packet_l2_offset() cannot
be used when transmitting packets.

Signed-off-by: Matias Elo <matias.elo@nokia.com>