### PR TITLE
[PATCH CLOUD-DEV v1] linux-dpdk: separate data plane and control plane pool info

### DIFF
--- a/platform/linux-dpdk/include/odp_pool_internal.h
+++ b/platform/linux-dpdk/include/odp_pool_internal.h
@@ -67,7 +67,12 @@ typedef union pool_entry_u {
 
 } pool_entry_t;
 
-extern void *pool_entry_ptr[];
+typedef struct pool_table_t {
+	pool_entry_t pool[ODP_CONFIG_POOLS];
+	odp_shm_t shm;
+} pool_table_t;
+
+extern pool_table_t *pool_tbl;
 
 static inline uint32_t pool_handle_to_index(odp_pool_t pool_hdl)
 {
@@ -76,7 +81,7 @@ static inline uint32_t pool_handle_to_index(odp_pool_t pool_hdl)
 
 static inline void *get_pool_entry(uint32_t pool_id)
 {
-	return pool_entry_ptr[pool_id];
+	return &pool_tbl->pool[pool_id];
 }
 
 static inline pool_entry_t *odp_pool_to_entry(odp_pool_t pool)

--- a/platform/linux-dpdk/pool/dpdk.c
+++ b/platform/linux-dpdk/pool/dpdk.c
@@ -43,16 +43,8 @@
 /* Define a practical limit for contiguous memory allocations */
 #define MAX_SIZE   (10 * 1024 * 1024)
 
-typedef struct pool_table_t {
-	pool_entry_t pool[ODP_CONFIG_POOLS];
-	odp_shm_t shm;
-} pool_table_t;
-
 /* The pool table ptr - resides in shared memory */
-static pool_table_t *pool_tbl;
-
-/* Pool entry pointers (for inlining) */
-void *pool_entry_ptr[ODP_CONFIG_POOLS];
+pool_table_t *pool_tbl;
 
 static int dpdk_pool_init_global(void)
 {
@@ -77,8 +69,6 @@ static int dpdk_pool_init_global(void)
 
 		LOCK_INIT(&pool->s.lock);
 		pool->s.pool_hdl = pool_index_to_handle(i);
-
-		pool_entry_ptr[i] = pool;
 	}
 
 	ODP_DBG("\nPool init global\n");


### PR DESCRIPTION
    Separate the pool's control plane and data plane data structures.
    This provides the following advantages:
        1) Avoids sharing control plane related data and dataplane
           related data on the same cache line
        2) Allows for tight packing of data plane only data
           to reduce the required cache size