### PR TITLE
[PATCH API-NEXT v14] api: add schedule order unlock lock 

### DIFF
--- a/include/odp/api/spec/queue.h
+++ b/include/odp/api/spec/queue.h
@@ -106,7 +106,7 @@ typedef struct odp_queue_capability_t {
 	uint32_t max_queues;
 
 	/** Maximum number of ordered locks per queue */
-	unsigned max_ordered_locks;
+	uint32_t max_ordered_locks;
 
 	/** Maximum number of scheduling groups */
 	unsigned max_sched_groups;
@@ -393,10 +393,11 @@ odp_schedule_group_t odp_queue_sched_group(odp_queue_t queue);
  *
  * @param queue   Queue handle
  *
- * @return Number of ordered locks associated with this ordered queue
- * @retval <0 Specified queue is not ordered
+ * @return	Number of ordered locks associated with this ordered queue
+ * @retval 0	Specified queue is not ordered or no ordered lock associated
+ *		with the ordered queue.
  */
-int odp_queue_lock_count(odp_queue_t queue);
+uint32_t odp_queue_lock_count(odp_queue_t queue);
 
 /**
  * Get printable value for an odp_queue_t

--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -371,6 +371,27 @@ void odp_schedule_order_lock(uint32_t lock_index);
 void odp_schedule_order_unlock(uint32_t lock_index);
 
 /**
+ * Release existing ordered context lock and acquire a new lock
+ *
+ * This call is valid only when holding an ordered synchronization context.
+ * Release a previously locked ordered context lock and acquire a new ordered
+ * context lock. The operation is equivalent to application calling first
+ * odp_schedule_order_unlock(unlock_index) and then
+ * odp_schedule_order_lock(lock_index). The same constraints apply with this
+ * call as with those two.
+ *
+ * @param unlock_index	Index of the acquired ordered lock in the current
+ *			context to be released.
+ * @param lock_index	Index of the ordered lock in the current context to be
+ *			acquired. Must be in the range
+ *			0...odp_queue_lock_count() - 1.
+ *
+ * @see odp_schedule_order_lock(), odp_schedule_order_unlock()
+ *
+ */
+void odp_schedule_order_unlock_lock(uint32_t unlock_index, uint32_t lock_index);
+
+/**
  * @}
  */
 

--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -347,12 +347,15 @@ int odp_schedule_group_info(odp_schedule_group_t group,
  * be protected by its own ordered lock. This promotes maximum parallelism by
  * allowing order to maintained on a more granular basis. If an ordered lock
  * is used multiple times in the same ordered context results are undefined.
+ * Only one ordered lock can be active in an ordered context at any given time.
+ * Results are undefined when multiple ordered locks are acquired in nested
+ * fashion within the same ordered context.
  *
  * @param lock_index Index of the ordered lock in the current context to be
  *                   acquired. Must be in the range 0..odp_queue_lock_count()
  *                   - 1
  */
-void odp_schedule_order_lock(unsigned lock_index);
+void odp_schedule_order_lock(uint32_t lock_index);
 
 /**
  * Release ordered context lock
@@ -365,7 +368,7 @@ void odp_schedule_order_lock(unsigned lock_index);
  *                   hold this lock. Must be in the range
  *                   0..odp_queue_lock_count() - 1
  */
-void odp_schedule_order_unlock(unsigned lock_index);
+void odp_schedule_order_unlock(uint32_t lock_index);
 
 /**
  * @}

--- a/include/odp/api/spec/schedule_types.h
+++ b/include/odp/api/spec/schedule_types.h
@@ -146,7 +146,7 @@ typedef	struct odp_schedule_param_t {
 	/** Ordered lock count for this queue
 	  *
 	  * Default value is 0. */
-	unsigned lock_count;
+	uint32_t lock_count;
 } odp_schedule_param_t;
 
 /**

--- a/platform/linux-generic/include/odp_queue_if.h
+++ b/platform/linux-generic/include/odp_queue_if.h
@@ -38,7 +38,7 @@ typedef struct {
 	odp_schedule_sync_t (*queue_sched_type)(odp_queue_t queue);
 	odp_schedule_prio_t (*queue_sched_prio)(odp_queue_t queue);
 	odp_schedule_group_t (*queue_sched_group)(odp_queue_t queue);
-	int (*queue_lock_count)(odp_queue_t queue);
+	uint32_t (*queue_lock_count)(odp_queue_t queue);
 	uint64_t (*queue_to_u64)(odp_queue_t hdl);
 	void (*queue_param_init)(odp_queue_param_t *param);
 	int (*queue_info)(odp_queue_t queue, odp_queue_info_t *info);

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -34,7 +34,7 @@ typedef int (*schedule_init_local_fn_t)(void);
 typedef int (*schedule_term_local_fn_t)(void);
 typedef void (*schedule_order_lock_fn_t)(void);
 typedef void (*schedule_order_unlock_fn_t)(void);
-typedef unsigned (*schedule_max_ordered_locks_fn_t)(void);
+typedef uint32_t (*schedule_max_ordered_locks_fn_t)(void);
 typedef void (*schedule_save_context_fn_t)(uint32_t queue_index);
 
 typedef struct schedule_fn_t {
@@ -93,8 +93,8 @@ typedef struct {
 	int (*schedule_group_thrmask)(odp_schedule_group_t, odp_thrmask_t *);
 	int (*schedule_group_info)(odp_schedule_group_t,
 				   odp_schedule_group_info_t *);
-	void (*schedule_order_lock)(unsigned);
-	void (*schedule_order_unlock)(unsigned);
+	void (*schedule_order_lock)(uint32_t);
+	void (*schedule_order_unlock)(uint32_t);
 
 } schedule_api_t;
 

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -34,6 +34,7 @@ typedef int (*schedule_init_local_fn_t)(void);
 typedef int (*schedule_term_local_fn_t)(void);
 typedef void (*schedule_order_lock_fn_t)(void);
 typedef void (*schedule_order_unlock_fn_t)(void);
+typedef void (*schedule_order_unlock_lock_fn_t)(void);
 typedef uint32_t (*schedule_max_ordered_locks_fn_t)(void);
 typedef void (*schedule_save_context_fn_t)(uint32_t queue_index);
 
@@ -53,6 +54,7 @@ typedef struct schedule_fn_t {
 	schedule_term_local_fn_t    term_local;
 	schedule_order_lock_fn_t    order_lock;
 	schedule_order_unlock_fn_t  order_unlock;
+	schedule_order_unlock_lock_fn_t  order_unlock_lock;
 	schedule_max_ordered_locks_fn_t max_ordered_locks;
 
 	/* Called only when status_sync is set */
@@ -95,6 +97,7 @@ typedef struct {
 				   odp_schedule_group_info_t *);
 	void (*schedule_order_lock)(uint32_t);
 	void (*schedule_order_unlock)(uint32_t);
+	void (*schedule_order_unlock_lock)(uint32_t, uint32_t);
 
 } schedule_api_t;
 

--- a/platform/linux-generic/include/odp_schedule_scalable_ordered.h
+++ b/platform/linux-generic/include/odp_schedule_scalable_ordered.h
@@ -79,7 +79,7 @@ typedef struct reorder_window {
 	uint32_t tail;
 	uint32_t turn;
 	uint32_t olock[CONFIG_QUEUE_MAX_ORD_LOCKS];
-	uint16_t lock_count;
+	uint32_t lock_count;
 	/* Reorder contexts in this window */
 	reorder_context_t *ring[RWIN_SIZE];
 } reorder_window_t;

--- a/platform/linux-generic/odp_queue.c
+++ b/platform/linux-generic/odp_queue.c
@@ -175,12 +175,12 @@ static odp_schedule_group_t queue_sched_group(odp_queue_t handle)
 	return handle_to_qentry(handle)->s.param.sched.group;
 }
 
-static int queue_lock_count(odp_queue_t handle)
+static uint32_t queue_lock_count(odp_queue_t handle)
 {
 	queue_entry_t *queue = handle_to_qentry(handle);
 
 	return queue->s.param.sched.sync == ODP_SCHED_SYNC_ORDERED ?
-		(int)queue->s.param.sched.lock_count : -1;
+		queue->s.param.sched.lock_count : 0;
 }
 
 static odp_queue_t queue_create(const char *name,

--- a/platform/linux-generic/odp_queue_if.c
+++ b/platform/linux-generic/odp_queue_if.c
@@ -92,7 +92,7 @@ odp_schedule_group_t odp_queue_sched_group(odp_queue_t queue)
 	return queue_api->queue_sched_group(queue);
 }
 
-int odp_queue_lock_count(odp_queue_t queue)
+uint32_t odp_queue_lock_count(odp_queue_t queue)
 {
 	return queue_api->queue_lock_count(queue);
 }

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -333,12 +333,12 @@ static odp_schedule_group_t queue_sched_group(odp_queue_t handle)
 	return qentry_from_int(queue_from_ext(handle))->s.param.sched.group;
 }
 
-static int queue_lock_count(odp_queue_t handle)
+static uint32_t queue_lock_count(odp_queue_t handle)
 {
 	queue_entry_t *queue = qentry_from_int(queue_from_ext(handle));
 
 	return queue->s.param.sched.sync == ODP_SCHED_SYNC_ORDERED ?
-		(int)queue->s.param.sched.lock_count : -1;
+		queue->s.param.sched.lock_count : 0;
 }
 
 static odp_queue_t queue_create(const char *name,

--- a/platform/linux-generic/odp_schedule.c
+++ b/platform/linux-generic/odp_schedule.c
@@ -250,7 +250,7 @@ typedef struct {
 		int         prio;
 		int         queue_per_prio;
 		int         sync;
-		unsigned    order_lock_count;
+		uint32_t    order_lock_count;
 	} queue[ODP_CONFIG_QUEUES];
 
 	struct {
@@ -465,7 +465,7 @@ static inline int grp_update_tbl(void)
 	return num;
 }
 
-static unsigned schedule_max_ordered_locks(void)
+static uint32_t schedule_max_ordered_locks(void)
 {
 	return CONFIG_QUEUE_MAX_ORD_LOCKS;
 }
@@ -699,7 +699,7 @@ static inline void ordered_stash_release(void)
 static inline void release_ordered(void)
 {
 	uint32_t qi;
-	unsigned i;
+	uint32_t i;
 
 	qi = sched_local.ordered.src_queue;
 
@@ -1100,7 +1100,7 @@ static void order_unlock(void)
 {
 }
 
-static void schedule_order_lock(unsigned lock_index)
+static void schedule_order_lock(uint32_t lock_index)
 {
 	odp_atomic_u64_t *ord_lock;
 	uint32_t queue_index;
@@ -1127,7 +1127,7 @@ static void schedule_order_lock(unsigned lock_index)
 	}
 }
 
-static void schedule_order_unlock(unsigned lock_index)
+static void schedule_order_unlock(uint32_t lock_index)
 {
 	odp_atomic_u64_t *ord_lock;
 	uint32_t queue_index;

--- a/platform/linux-generic/odp_schedule.c
+++ b/platform/linux-generic/odp_schedule.c
@@ -1144,6 +1144,13 @@ static void schedule_order_unlock(uint32_t lock_index)
 	odp_atomic_store_rel_u64(ord_lock, sched_local.ordered.ctx + 1);
 }
 
+static void schedule_order_unlock_lock(uint32_t unlock_index,
+				       uint32_t lock_index)
+{
+	schedule_order_unlock(unlock_index);
+	schedule_order_lock(lock_index);
+}
+
 static void schedule_pause(void)
 {
 	sched_local.pause = 1;
@@ -1429,5 +1436,6 @@ const schedule_api_t schedule_default_api = {
 	.schedule_group_thrmask   = schedule_group_thrmask,
 	.schedule_group_info      = schedule_group_info,
 	.schedule_order_lock      = schedule_order_lock,
-	.schedule_order_unlock    = schedule_order_unlock
+	.schedule_order_unlock    = schedule_order_unlock,
+	.schedule_order_unlock_lock    = schedule_order_unlock_lock
 };

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -129,3 +129,8 @@ void odp_schedule_order_unlock(uint32_t lock_index)
 {
 	return sched_api->schedule_order_unlock(lock_index);
 }
+
+void odp_schedule_order_unlock_lock(uint32_t unlock_index, uint32_t lock_index)
+{
+	sched_api->schedule_order_unlock_lock(unlock_index, lock_index);
+}

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -120,12 +120,12 @@ int odp_schedule_group_info(odp_schedule_group_t group,
 	return sched_api->schedule_group_info(group, info);
 }
 
-void odp_schedule_order_lock(unsigned lock_index)
+void odp_schedule_order_lock(uint32_t lock_index)
 {
 	return sched_api->schedule_order_lock(lock_index);
 }
 
-void odp_schedule_order_unlock(unsigned lock_index)
+void odp_schedule_order_unlock(uint32_t lock_index)
 {
 	return sched_api->schedule_order_unlock(lock_index);
 }

--- a/platform/linux-generic/odp_schedule_iquery.c
+++ b/platform/linux-generic/odp_schedule_iquery.c
@@ -1296,6 +1296,13 @@ static void schedule_order_unlock(uint32_t lock_index)
 	odp_atomic_store_rel_u64(ord_lock, thread_local.ordered.ctx + 1);
 }
 
+static void schedule_order_unlock_lock(uint32_t unlock_index,
+				       uint32_t lock_index)
+{
+	schedule_order_unlock(unlock_index);
+	schedule_order_lock(lock_index);
+}
+
 static uint32_t schedule_max_ordered_locks(void)
 {
 	return CONFIG_QUEUE_MAX_ORD_LOCKS;
@@ -1368,7 +1375,8 @@ const schedule_api_t schedule_iquery_api = {
 	.schedule_group_thrmask   = schedule_group_thrmask,
 	.schedule_group_info      = schedule_group_info,
 	.schedule_order_lock      = schedule_order_lock,
-	.schedule_order_unlock    = schedule_order_unlock
+	.schedule_order_unlock    = schedule_order_unlock,
+	.schedule_order_unlock_lock    = schedule_order_unlock_lock
 };
 
 static void thread_set_interest(sched_thread_local_t *thread,

--- a/platform/linux-generic/odp_schedule_iquery.c
+++ b/platform/linux-generic/odp_schedule_iquery.c
@@ -1150,7 +1150,7 @@ static inline void ordered_stash_release(void)
 static inline void release_ordered(void)
 {
 	uint32_t qi;
-	unsigned i;
+	uint32_t i;
 
 	qi = thread_local.ordered.src_queue;
 
@@ -1252,7 +1252,7 @@ static void order_unlock(void)
 {
 }
 
-static void schedule_order_lock(unsigned lock_index)
+static void schedule_order_lock(uint32_t lock_index)
 {
 	odp_atomic_u64_t *ord_lock;
 	uint32_t queue_index;
@@ -1279,7 +1279,7 @@ static void schedule_order_lock(unsigned lock_index)
 	}
 }
 
-static void schedule_order_unlock(unsigned lock_index)
+static void schedule_order_unlock(uint32_t lock_index)
 {
 	odp_atomic_u64_t *ord_lock;
 	uint32_t queue_index;
@@ -1296,7 +1296,7 @@ static void schedule_order_unlock(unsigned lock_index)
 	odp_atomic_store_rel_u64(ord_lock, thread_local.ordered.ctx + 1);
 }
 
-static unsigned schedule_max_ordered_locks(void)
+static uint32_t schedule_max_ordered_locks(void)
 {
 	return CONFIG_QUEUE_MAX_ORD_LOCKS;
 }

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -990,7 +990,7 @@ restart_same:
 
 /******************************************************************************/
 
-static void schedule_order_lock(unsigned lock_index)
+static void schedule_order_lock(uint32_t lock_index)
 {
 	struct reorder_context *rctx = sched_ts->rctx;
 
@@ -1010,7 +1010,7 @@ static void schedule_order_lock(unsigned lock_index)
 	}
 }
 
-static void schedule_order_unlock(unsigned lock_index)
+static void schedule_order_unlock(uint32_t lock_index)
 {
 	struct reorder_context *rctx;
 
@@ -1936,7 +1936,7 @@ static void order_unlock(void)
 {
 }
 
-static unsigned schedule_max_ordered_locks(void)
+static uint32_t schedule_max_ordered_locks(void)
 {
 	return CONFIG_QUEUE_MAX_ORD_LOCKS;
 }

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -1028,6 +1028,13 @@ static void schedule_order_unlock(uint32_t lock_index)
 	rctx->olock_flags |= 1U << lock_index;
 }
 
+static void schedule_order_unlock_lock(uint32_t unlock_index,
+				       uint32_t lock_index)
+{
+	schedule_order_unlock(unlock_index);
+	schedule_order_lock(lock_index);
+}
+
 static void schedule_release_atomic(void)
 {
 	sched_scalable_thread_state_t *ts;
@@ -1978,4 +1985,5 @@ const schedule_api_t schedule_scalable_api = {
 	.schedule_group_info		= schedule_group_info,
 	.schedule_order_lock		= schedule_order_lock,
 	.schedule_order_unlock		= schedule_order_unlock,
+	.schedule_order_unlock_lock	= schedule_order_unlock_lock,
 };

--- a/platform/linux-generic/odp_schedule_scalable_ordered.c
+++ b/platform/linux-generic/odp_schedule_scalable_ordered.c
@@ -220,7 +220,7 @@ static inline void olock_unlock(const reorder_context_t *rctx,
 static void olock_release(const reorder_context_t *rctx)
 {
 	reorder_window_t *rwin;
-	int i;
+	uint32_t i;
 
 	rwin = rctx->rwin;
 

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -243,7 +243,7 @@ static int term_local(void)
 	return 0;
 }
 
-static unsigned max_ordered_locks(void)
+static uint32_t max_ordered_locks(void)
 {
 	return NUM_ORDERED_LOCKS;
 }
@@ -809,12 +809,12 @@ static int schedule_group_info(odp_schedule_group_t group,
 	return 0;
 }
 
-static void schedule_order_lock(unsigned lock_index)
+static void schedule_order_lock(uint32_t lock_index)
 {
 	(void)lock_index;
 }
 
-static void schedule_order_unlock(unsigned lock_index)
+static void schedule_order_unlock(uint32_t lock_index)
 {
 	(void)lock_index;
 }

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -819,6 +819,13 @@ static void schedule_order_unlock(uint32_t lock_index)
 	(void)lock_index;
 }
 
+static void schedule_order_unlock_lock(uint32_t unlock_index,
+				       uint32_t lock_index)
+{
+	(void)unlock_index;
+	(void)lock_index;
+}
+
 static void order_lock(void)
 {
 }
@@ -868,5 +875,6 @@ const schedule_api_t schedule_sp_api = {
 	.schedule_group_thrmask   = schedule_group_thrmask,
 	.schedule_group_info      = schedule_group_info,
 	.schedule_order_lock      = schedule_order_lock,
-	.schedule_order_unlock    = schedule_order_unlock
+	.schedule_order_unlock    = schedule_order_unlock,
+	.schedule_order_unlock_lock	= schedule_order_unlock_lock
 };

--- a/test/common_plat/validation/api/queue/queue.c
+++ b/test/common_plat/validation/api/queue/queue.c
@@ -267,9 +267,9 @@ void queue_test_info(void)
 	odp_queue_capability_t capability;
 	char q_plain_ctx[] = "test_q_plain context data";
 	char q_order_ctx[] = "test_q_order context data";
-	unsigned lock_count;
+	uint32_t lock_count;
 	char *ctx;
-	int ret;
+	uint32_t ret;
 
 	/* Create a plain queue and set context */
 	q_plain = odp_queue_create(nq_plain, NULL);
@@ -314,8 +314,8 @@ void queue_test_info(void)
 	CU_ASSERT(info.param.sched.sync == odp_queue_sched_type(q_order));
 	CU_ASSERT(info.param.sched.group == odp_queue_sched_group(q_order));
 	ret = odp_queue_lock_count(q_order);
-	CU_ASSERT(ret >= 0);
-	lock_count = (unsigned)ret;
+	CU_ASSERT(ret > 0);
+	lock_count = ret;
 	CU_ASSERT(info.param.sched.lock_count == lock_count);
 
 	CU_ASSERT(odp_queue_destroy(q_plain) == 0);

--- a/test/common_plat/validation/api/scheduler/scheduler.c
+++ b/test/common_plat/validation/api/scheduler/scheduler.c
@@ -730,12 +730,12 @@ static int schedule_common_(void *arg)
 				continue;
 
 			if (sync == ODP_SCHED_SYNC_ORDERED) {
-				int ndx;
-				int ndx_max;
+				uint32_t ndx;
+				uint32_t ndx_max;
 				int rc;
 
 				ndx_max = odp_queue_lock_count(from);
-				CU_ASSERT_FATAL(ndx_max >= 0);
+				CU_ASSERT_FATAL(ndx_max > 0);
 
 				qctx = odp_queue_context(from);
 
@@ -781,12 +781,12 @@ static int schedule_common_(void *arg)
 			buf = odp_buffer_from_event(ev);
 			num = 1;
 			if (sync == ODP_SCHED_SYNC_ORDERED) {
-				int ndx;
-				int ndx_max;
+				uint32_t ndx;
+				uint32_t ndx_max;
 				int rc;
 
 				ndx_max = odp_queue_lock_count(from);
-				CU_ASSERT_FATAL(ndx_max >= 0);
+				CU_ASSERT_FATAL(ndx_max > 0);
 
 				qctx = odp_queue_context(from);
 				bctx = odp_buffer_addr(buf);
@@ -996,11 +996,11 @@ static void reset_queues(thread_args_t *args)
 			for (k = 0; k < args->num_bufs; k++) {
 				queue_context *qctx =
 					odp_queue_context(queue);
-				int ndx;
-				int ndx_max;
+				uint32_t ndx;
+				uint32_t ndx_max;
 
 				ndx_max = odp_queue_lock_count(queue);
-				CU_ASSERT_FATAL(ndx_max >= 0);
+				CU_ASSERT_FATAL(ndx_max > 0);
 				qctx->sequence = 0;
 				for (ndx = 0; ndx < ndx_max; ndx++)
 					qctx->lock_sequence[ndx] = 0;
@@ -1436,7 +1436,7 @@ static int create_queues(void)
 				return -1;
 			}
 			if (odp_queue_lock_count(q) !=
-			    (int)capa.max_ordered_locks) {
+			    capa.max_ordered_locks) {
 				printf("Queue %" PRIu64 " created with "
 				       "%d locks instead of expected %d\n",
 				       odp_queue_to_u64(q),


### PR DESCRIPTION
Adds odp_schedule_order_unlock_lock() api.
This API combines schedule order unlock and lock into a single api for HW performance optimisation.