### PR TITLE
[PATCH v1] test: fixup CUNIT_CFLAGS variable reference

### DIFF
--- a/test/common_plat/validation/api/Makefile.inc
+++ b/test/common_plat/validation/api/Makefile.inc
@@ -6,7 +6,7 @@ AM_CFLAGS += -I$(top_srcdir)/test/common_plat/common
 AM_LDFLAGS += -static
 AM_LDFLAGS += $(DPDK_PMDS)
 
-AM_CFLAGS += $(CUNIT_PFLAGS)
+AM_CFLAGS += $(CUNIT_CFLAGS)
 
 LIBCUNIT_COMMON = $(COMMON_DIR)/libcunit_common.la
 LIBCPUMASK_COMMON = $(COMMON_DIR)/libcpumask_common.la


### PR DESCRIPTION
Fix type in previous refactoring, which used CUNIT_PFLAGS instead of
CUNIT_CFLAGS.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>