### PR TITLE
[PATCH API-NEXT v1] Packet checksum calculation

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -156,7 +156,9 @@ typedef struct odp_ipsec_inbound_config_t {
 	odp_ipsec_proto_layer_t parse;
 
 	/** Flags to control IPSEC payload data checks up to the selected parse
-	 *  level. */
+	 *  level. Checksum checking status can be queried for each packet with
+	 *  odp_packet_l3_chksum_status() and odp_packet_l4_chksum_status().
+	 */
 	union {
 		/** Mapping for individual bits */
 		struct {
@@ -191,10 +193,12 @@ typedef struct odp_ipsec_inbound_config_t {
  */
 typedef struct odp_ipsec_outbound_config_t {
 	/** Flags to control L3/L4 checksum insertion as part of outbound
-	 *  packet processing. Packet must have set with valid L3/L4 offsets.
-	 *  Checksum configuration is ignored for packets that checksum cannot
-	 *  be computed for (e.g. IPv4 fragments). Application may use a packet
-	 *  metadata flag to disable checksum insertion per packet bases.
+	 *  packet processing. These flags control checksum insertion (for the
+	 *  payload packet) in the same way as the checksum flags in
+	 *  odp_pktout_config_opt_t control checksum insertion when sending
+	 *  packets out through a pktio interface. Also packet checksum override
+	 *  functions (e.g. odp_packet_l4_chksum_insert()) can be used in
+	 *  the same way.
 	 */
 	union {
 		/** Mapping for individual bits */

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -83,6 +83,22 @@ typedef struct odp_packet_data_range {
 
 } odp_packet_data_range_t;
 
+/**
+ * Checksum check status in packet
+ */
+typedef enum odp_packet_chksum_status_t {
+	/** Checksum was not checked. Checksum check was not attempted or
+	  * the attempt failed. */
+	ODP_PACKET_CHKSUM_UNKNOWN = 0,
+
+	/** Checksum was checked and it was not correct */
+	ODP_PACKET_CHKSUM_BAD,
+
+	/** Checksum was checked and it was correct */
+	ODP_PACKET_CHKSUM_OK
+
+} odp_packet_chksum_status_t;
+
 /*
  *
  * Alloc and free
@@ -1376,6 +1392,34 @@ uint32_t odp_packet_l4_offset(odp_packet_t pkt);
  * @retval <0 on failure
  */
 int odp_packet_l4_offset_set(odp_packet_t pkt, uint32_t offset);
+
+/**
+ * Layer 3 checksum check status
+ *
+ * Returns the result of the latest layer 3 checksum check done for the packet.
+ * The status tells if checksum check was attempted and the result of the
+ * attempt. It depends on packet input (or IPSEC) configuration, packet content
+ * and implementation capabilities if checksum check is attempted for a packet.
+ *
+ * @param pkt     Packet handle
+ *
+ * @return L3 checksum check status
+ */
+odp_packet_chksum_status_t odp_packet_l3_chksum_status(odp_packet_t pkt);
+
+/**
+ * Layer 4 checksum check status
+ *
+ * Returns the result of the latest layer 4 checksum check done for the packet.
+ * The status tells if checksum check was attempted and the result of the
+ * attempt. It depends on packet input (or IPSEC) configuration, packet content
+ * and implementation capabilities if checksum check is attempted for a packet.
+ *
+ * @param pkt     Packet handle
+ *
+ * @return L4 checksum check status
+ */
+odp_packet_chksum_status_t odp_packet_l4_chksum_status(odp_packet_t pkt);
 
 /**
  * Layer 3 checksum insertion override

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1428,6 +1428,10 @@ odp_packet_chksum_status_t odp_packet_l4_chksum_status(odp_packet_t pkt);
  * overrides a higher level configuration for checksum insertion into a L3
  * header during packet output processing.
  *
+ * Calling this function is always allowed but the checksum will not be
+ * inserted if the packet is output through a pktio that does not have
+ * the relevant pktout chksum bit set in the pktio capability.
+ *
  * @param pkt     Packet handle
  * @param l3      0: do not insert L3 checksum
  *                1: insert L3 checksum
@@ -1440,6 +1444,10 @@ void odp_packet_l3_chksum_insert(odp_packet_t pkt, int l3);
  * Override checksum insertion configuration per packet. This per packet setting
  * overrides a higher level configuration for checksum insertion into a L4
  * header during packet output processing.
+ *
+ * Calling this function is always allowed but the checksum will not be
+ * inserted if the packet is output through a pktio that does not have
+ * the relevant pktout chksum bit set in the pktio capability.
  *
  * @param pkt     Packet handle
  * @param l4      0: do not insert L4 checksum

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -889,6 +889,11 @@ uint64_t odp_pktin_wait_time(uint64_t nsec);
  * is less than 'num', the remaining packets at the end of packets[] array
  * are not consumed, and the caller has to take care of them.
  *
+ * Entire packet data is sent out (odp_packet_len() bytes of data, starting from
+ * odp_packet_data()). All other packet metadata is ignored unless otherwise
+ * specified e.g. for protocol offload purposes. Link protocol specific frame
+ * checksum and padding are added to frames before transmission.
+ *
  * @param queue        Packet output queue handle for sending packets
  * @param packets[]    Array of packets to send
  * @param num          Number of packets to send


### PR DESCRIPTION
Improve packet checksum check and insertion specification. Packet checksum status is added which informs if a checksum was checked or not, and if the checksum was find to be OK or not. When checksum check is enabled, an implementation should check basic packets, but may report unknown checksum status for e.g. packets that have extension headers. Also checksum insertion rules were refined e.g. so that application must not ask L4 checksum insertion for IP fragments.


 