### PR TITLE
[PATCH v3] Packet references re-implementation

### DIFF
--- a/include/odp/arch/default/api/abi/packet.h
+++ b/include/odp/arch/default/api/abi/packet.h
@@ -28,7 +28,7 @@ typedef _odp_abi_packet_seg_t *odp_packet_seg_t;
 
 #define ODP_PACKET_INVALID        ((odp_packet_t)0xffffffff)
 #define ODP_PACKET_SEG_INVALID    ((odp_packet_seg_t)0xffffffff)
-#define ODP_PACKET_OFFSET_INVALID (0x0fffffff)
+#define ODP_PACKET_OFFSET_INVALID 0xffff
 
 typedef enum {
 	ODP_PACKET_GREEN = 0,

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -56,13 +56,13 @@ static inline uint32_t _odp_packet_len(odp_packet_t pkt)
 /** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_headroom(odp_packet_t pkt)
 {
-	return _odp_pkt_get(pkt, uint32_t, headroom);
+	return _odp_pkt_get(pkt, uint16_t, headroom);
 }
 
 /** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_tailroom(odp_packet_t pkt)
 {
-	return _odp_pkt_get(pkt, uint32_t, tailroom);
+	return _odp_pkt_get(pkt, uint16_t, tailroom);
 }
 
 /** @internal Inline function @param pkt @return */

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -50,19 +50,7 @@ static inline uint32_t _odp_packet_seg_len(odp_packet_t pkt)
 /** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_len(odp_packet_t pkt)
 {
-	uint32_t pkt_len = _odp_pkt_get(pkt, uint32_t, frame_len);
-	void *ref_nxt    = _odp_pkt_get(pkt, void *, ref_hdr);
-	void *ref_pkt    = (void *)pkt;
-
-	while (ref_nxt) {
-		pkt_len += _odp_pkt_get(ref_pkt, uint32_t, ref_len) -
-			_odp_pkt_get(ref_pkt, uint32_t, ref_offset);
-
-		ref_pkt = ref_nxt;
-		ref_nxt = _odp_pkt_get(ref_nxt, void *, ref_hdr);
-	}
-
-	return pkt_len;
+	return _odp_pkt_get(pkt, uint32_t, frame_len);
 }
 
 /** @internal Inline function @param pkt @return */
@@ -87,6 +75,12 @@ static inline odp_pool_t _odp_packet_pool(odp_packet_t pkt)
 static inline odp_pktio_t _odp_packet_input(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, odp_pktio_t, input);
+}
+
+/** @internal Inline function @param pkt @return */
+static inline int _odp_packet_num_segs(odp_packet_t pkt)
+{
+	return _odp_pkt_get(pkt, uint8_t, segcount);
 }
 
 /** @internal Inline function @param pkt @return */
@@ -128,8 +122,7 @@ static inline void *_odp_packet_head(odp_packet_t pkt)
 /** @internal Inline function @param pkt @return */
 static inline int _odp_packet_is_segmented(odp_packet_t pkt)
 {
-	return _odp_pkt_get(pkt, uint8_t, segcount) > 1 ||
-		_odp_pkt_get(pkt, void *, ref_hdr) != NULL;
+	return _odp_pkt_get(pkt, uint8_t, segcount) > 1;
 }
 
 /** @internal Inline function @param pkt @return */
@@ -138,6 +131,23 @@ static inline odp_packet_seg_t _odp_packet_first_seg(odp_packet_t pkt)
 	(void)pkt;
 
 	return _odp_packet_seg_from_ndx(0);
+}
+
+/** @internal Inline function @param pkt @return */
+static inline odp_packet_seg_t _odp_packet_last_seg(odp_packet_t pkt)
+{
+	return _odp_packet_seg_from_ndx(_odp_packet_num_segs(pkt) - 1);
+}
+
+/** @internal Inline function @param pkt @param seg @return */
+static inline odp_packet_seg_t _odp_packet_next_seg(odp_packet_t pkt,
+						    odp_packet_seg_t seg)
+{
+	if (odp_unlikely(_odp_packet_seg_to_ndx(seg) >=
+			 _odp_packet_seg_to_ndx(_odp_packet_last_seg(pkt))))
+		return ODP_PACKET_SEG_INVALID;
+
+	return seg + 1;
 }
 
 /** @internal Inline function @param pkt @param offset @param len */

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
@@ -48,6 +48,11 @@ _ODP_INLINE odp_pktio_t odp_packet_input(odp_packet_t pkt)
 	return _odp_packet_input(pkt);
 }
 
+_ODP_INLINE int odp_packet_num_segs(odp_packet_t pkt)
+{
+	return _odp_packet_num_segs(pkt);
+}
+
 _ODP_INLINE void *odp_packet_user_ptr(odp_packet_t pkt)
 {
 	return _odp_packet_user_ptr(pkt);
@@ -86,6 +91,17 @@ _ODP_INLINE int odp_packet_is_segmented(odp_packet_t pkt)
 _ODP_INLINE odp_packet_seg_t odp_packet_first_seg(odp_packet_t pkt)
 {
 	return _odp_packet_first_seg(pkt);
+}
+
+_ODP_INLINE odp_packet_seg_t odp_packet_last_seg(odp_packet_t pkt)
+{
+	return _odp_packet_last_seg(pkt);
+}
+
+_ODP_INLINE odp_packet_seg_t odp_packet_next_seg(odp_packet_t pkt,
+						 odp_packet_seg_t seg)
+{
+	return _odp_packet_next_seg(pkt, seg);
 }
 
 _ODP_INLINE void odp_packet_prefetch(odp_packet_t pkt, uint32_t offset,

--- a/platform/linux-generic/include/odp/api/plat/packet_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_types.h
@@ -36,7 +36,7 @@ typedef ODP_HANDLE_T(odp_packet_t);
 
 #define ODP_PACKET_INVALID _odp_cast_scalar(odp_packet_t, 0)
 
-#define ODP_PACKET_OFFSET_INVALID (0x0fffffff)
+#define ODP_PACKET_OFFSET_INVALID 0xffff
 
 typedef uint8_t odp_packet_seg_t;
 

--- a/platform/linux-generic/include/odp/api/plat/packet_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_types.h
@@ -74,33 +74,33 @@ typedef enum {
 /** @internal Packet header field offsets for inline functions */
 typedef struct _odp_packet_inline_offset_t {
 	/** @internal field offset */
-	size_t data;
+	uint16_t data;
 	/** @internal field offset */
-	size_t seg_len;
+	uint16_t seg_len;
 	/** @internal field offset */
-	size_t frame_len;
+	uint16_t frame_len;
 	/** @internal field offset */
-	size_t headroom;
+	uint16_t headroom;
 	/** @internal field offset */
-	size_t tailroom;
+	uint16_t tailroom;
 	/** @internal field offset */
-	size_t pool;
+	uint16_t pool;
 	/** @internal field offset */
-	size_t input;
+	uint16_t input;
 	/** @internal field offset */
-	size_t segcount;
+	uint16_t segcount;
 	/** @internal field offset */
-	size_t user_ptr;
+	uint16_t user_ptr;
 	/** @internal field offset */
-	size_t user_area;
+	uint16_t user_area;
 	/** @internal field offset */
-	size_t user_area_size;
+	uint16_t user_area_size;
 	/** @internal field offset */
-	size_t flow_hash;
+	uint16_t flow_hash;
 	/** @internal field offset */
-	size_t timestamp;
+	uint16_t timestamp;
 	/** @internal field offset */
-	size_t input_flags;
+	uint16_t input_flags;
 
 } _odp_packet_inline_offset_t;
 

--- a/platform/linux-generic/include/odp/api/plat/packet_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_types.h
@@ -84,14 +84,6 @@ typedef struct _odp_packet_inline_offset_t {
 	/** @internal field offset */
 	size_t tailroom;
 	/** @internal field offset */
-	size_t unshared_len;
-	/** @internal field offset */
-	size_t ref_hdr;
-	/** @internal field offset */
-	size_t ref_offset;
-	/** *internal field offset */
-	size_t ref_len;
-	/** @internal field offset */
 	size_t pool;
 	/** @internal field offset */
 	size_t input;

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -43,28 +43,18 @@ typedef struct seg_entry_t {
 
 /* Common buffer header */
 struct odp_buffer_hdr_t {
+
 	/* Buffer index in the pool */
-	uint32_t index;
+	uint32_t  index;
 
-	/* Initial buffer data pointer and length */
-	uint8_t  *base_data;
-	uint8_t  *buf_end;
-
-	/* Max data size */
-	uint32_t  size;
+	/* Total segment count */
+	uint16_t  segcount;
 
 	/* Pool type */
 	int8_t    type;
 
-	/* Burst counts */
-	uint8_t   burst_num;
-	uint8_t   burst_first;
-
 	/* Number of seg[] entries used */
 	uint8_t   num_seg;
-
-	/* Total segment count */
-	uint32_t  segcount;
 
 	/* Next header which continues the segment list */
 	void *next_seg;
@@ -72,11 +62,26 @@ struct odp_buffer_hdr_t {
 	/* Last header of the segment list */
 	void *last_seg;
 
+	/* Initial buffer data pointer and length */
+	uint8_t  *base_data;
+	uint8_t  *buf_end;
+
+	/* --- 40 bytes --- */
+
 	/* Segments */
 	seg_entry_t seg[CONFIG_PACKET_MAX_SEGS];
 
+	/* Burst counts */
+	uint8_t   burst_num;
+	uint8_t   burst_first;
+
 	/* Next buf in a list */
 	struct odp_buffer_hdr_t *next;
+
+	/* Burst table */
+	struct odp_buffer_hdr_t *burst[BUFFER_BURST_SIZE];
+
+	/* --- Mostly read only data --- */
 
 	/* User context pointer or u64 */
 	union {
@@ -84,6 +89,9 @@ struct odp_buffer_hdr_t {
 		void       *buf_ctx;
 		const void *buf_cctx; /* const alias for ctx */
 	};
+
+	/* Pool pointer */
+	void *pool_ptr;
 
 	/* User area pointer */
 	void    *uarea_addr;
@@ -94,9 +102,6 @@ struct odp_buffer_hdr_t {
 	/* Event type. Maybe different than pool type (crypto compl event) */
 	int8_t    event_type;
 
-	/* Burst table */
-	struct odp_buffer_hdr_t *burst[BUFFER_BURST_SIZE];
-
 	/* ipc mapped process can not walk over pointers,
 	 * offset has to be used */
 	uint64_t ipc_data_offset;
@@ -105,8 +110,8 @@ struct odp_buffer_hdr_t {
 	 * inlining */
 	odp_pool_t pool_hdl;
 
-	/* Pool pointer */
-	void *pool_ptr;
+	/* Max data size */
+	uint32_t size;
 
 	/* Data or next header */
 	uint8_t data[0];

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -62,11 +62,16 @@ struct odp_buffer_hdr_t {
 	/* Last header of the segment list */
 	void *last_seg;
 
-	/* Initial buffer data pointer and length */
+	/* Initial buffer data pointer */
 	uint8_t  *base_data;
-	uint8_t  *buf_end;
 
-	/* --- 40 bytes --- */
+	/* Reference count */
+	odp_atomic_u32_t ref_cnt;
+
+	/* Event type. Maybe different than pool type (crypto compl event) */
+	int8_t    event_type;
+
+	/* --- 37 bytes --- */
 
 	/* Segments */
 	seg_entry_t seg[CONFIG_PACKET_MAX_SEGS];
@@ -93,14 +98,17 @@ struct odp_buffer_hdr_t {
 	/* Pool pointer */
 	void *pool_ptr;
 
+	/* Initial buffer tail pointer */
+	uint8_t  *buf_end;
+
 	/* User area pointer */
 	void    *uarea_addr;
 
 	/* User area size */
 	uint32_t uarea_size;
 
-	/* Event type. Maybe different than pool type (crypto compl event) */
-	int8_t    event_type;
+	/* Max data size */
+	uint32_t size;
 
 	/* ipc mapped process can not walk over pointers,
 	 * offset has to be used */
@@ -109,9 +117,6 @@ struct odp_buffer_hdr_t {
 	/* Pool handle: will be removed, used only for odp_packet_pool()
 	 * inlining */
 	odp_pool_t pool_hdl;
-
-	/* Max data size */
-	uint32_t size;
 
 	/* Data or next header */
 	uint8_t data[0];

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -35,6 +35,12 @@ extern "C" {
 
 #define BUFFER_BURST_SIZE    CONFIG_BURST_SIZE
 
+typedef struct seg_entry_t {
+	void     *hdr;
+	uint8_t  *data;
+	uint32_t  len;
+} seg_entry_t;
+
 /* Common buffer header */
 struct odp_buffer_hdr_t {
 	/* Buffer index in the pool */
@@ -54,15 +60,20 @@ struct odp_buffer_hdr_t {
 	uint8_t   burst_num;
 	uint8_t   burst_first;
 
-	/* Segment count */
-	uint8_t   segcount;
+	/* Number of seg[] entries used */
+	uint8_t   num_seg;
+
+	/* Total segment count */
+	uint32_t  segcount;
+
+	/* Next header which continues the segment list */
+	void *next_seg;
+
+	/* Last header of the segment list */
+	void *last_seg;
 
 	/* Segments */
-	struct {
-		void     *hdr;
-		uint8_t  *data;
-		uint32_t  len;
-	} seg[CONFIG_PACKET_MAX_SEGS];
+	seg_entry_t seg[CONFIG_PACKET_MAX_SEGS];
 
 	/* Next buf in a list */
 	struct odp_buffer_hdr_t *next;

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -65,13 +65,10 @@ struct odp_buffer_hdr_t {
 	/* Initial buffer data pointer */
 	uint8_t  *base_data;
 
-	/* Reference count */
-	odp_atomic_u32_t ref_cnt;
+	/* Pool pointer */
+	void *pool_ptr;
 
-	/* Event type. Maybe different than pool type (crypto compl event) */
-	int8_t    event_type;
-
-	/* --- 37 bytes --- */
+	/* --- 40 bytes --- */
 
 	/* Segments */
 	seg_entry_t seg[CONFIG_PACKET_MAX_SEGS];
@@ -95,8 +92,11 @@ struct odp_buffer_hdr_t {
 		const void *buf_cctx; /* const alias for ctx */
 	};
 
-	/* Pool pointer */
-	void *pool_ptr;
+	/* Reference count */
+	odp_atomic_u32_t ref_cnt;
+
+	/* Event type. Maybe different than pool type (crypto compl event) */
+	int8_t    event_type;
 
 	/* Initial buffer tail pointer */
 	uint8_t  *buf_end;

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -88,9 +88,14 @@ typedef struct {
 	error_flags_t  error_flags;
 	output_flags_t output_flags;
 
-	uint32_t l2_offset; /**< offset to L2 hdr, e.g. Eth */
-	uint32_t l3_offset; /**< offset to L3 hdr, e.g. IPv4, IPv6 */
-	uint32_t l4_offset; /**< offset to L4 hdr (TCP, UDP, SCTP, also ICMP) */
+	 /* offset to L2 hdr, e.g. Eth */
+	uint16_t l2_offset;
+
+	/* offset to L3 hdr, e.g. IPv4, IPv6 */
+	uint16_t l3_offset;
+
+	/* offset to L4 hdr (TCP, UDP, SCTP, also ICMP) */
+	uint16_t l4_offset;
 } packet_parser_t;
 
 /* Packet extra data length */
@@ -116,13 +121,13 @@ typedef struct {
 
 	packet_parser_t p;
 
-	uint32_t frame_len;
-
 	odp_pktio_t input;
 
-	uint32_t headroom;
-	uint32_t tailroom;
+	uint32_t frame_len;
 	uint32_t shared_len;
+
+	uint16_t headroom;
+	uint16_t tailroom;
 
 	/*
 	 * Members below are not initialized by packet_init()

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -116,11 +116,13 @@ typedef struct {
 
 	packet_parser_t p;
 
+	uint32_t frame_len;
+
 	odp_pktio_t input;
 
-	uint32_t frame_len;
 	uint32_t headroom;
 	uint32_t tailroom;
+	uint32_t shared_len;
 
 	/*
 	 * Members below are not initialized by packet_init()
@@ -217,6 +219,7 @@ static inline void packet_init(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 	* segment occupied by the allocated length.
 	*/
 	pkt_hdr->frame_len = len;
+	pkt_hdr->shared_len = 0;
 	pkt_hdr->headroom  = CONFIG_PACKET_HEADROOM;
 	pkt_hdr->tailroom  = CONFIG_PACKET_MAX_SEG_LEN - seg_len +
 			     CONFIG_PACKET_TAILROOM;

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -35,10 +35,6 @@ const _odp_packet_inline_offset_t _odp_packet_inline ODP_ALIGNED_CACHE = {
 	.frame_len      = offsetof(odp_packet_hdr_t, frame_len),
 	.headroom       = offsetof(odp_packet_hdr_t, headroom),
 	.tailroom       = offsetof(odp_packet_hdr_t, tailroom),
-	.unshared_len   = offsetof(odp_packet_hdr_t, unshared_len),
-	.ref_hdr        = offsetof(odp_packet_hdr_t, ref_hdr),
-	.ref_offset     = offsetof(odp_packet_hdr_t, ref_offset),
-	.ref_len        = offsetof(odp_packet_hdr_t, ref_len),
 	.pool           = offsetof(odp_packet_hdr_t, buf_hdr.pool_hdl),
 	.input          = offsetof(odp_packet_hdr_t, input),
 	.segcount       = offsetof(odp_packet_hdr_t, buf_hdr.segcount),
@@ -63,16 +59,6 @@ static inline odp_buffer_t buffer_handle(odp_packet_hdr_t *pkt_hdr)
 	return (odp_buffer_t)pkt_hdr;
 }
 
-static inline void packet_ref_inc(odp_packet_hdr_t *pkt_hdr)
-{
-	odp_atomic_inc_u32(&pkt_hdr->ref_count);
-}
-
-static inline uint32_t packet_ref_dec(odp_packet_hdr_t *pkt_hdr)
-{
-	return odp_atomic_fetch_dec_u32(&pkt_hdr->ref_count);
-}
-
 static inline odp_packet_hdr_t *buf_to_packet_hdr(odp_buffer_t buf)
 {
 	return (odp_packet_hdr_t *)buf_hdl_to_hdr(buf);
@@ -94,13 +80,12 @@ static inline uint32_t packet_seg_len(odp_packet_hdr_t *pkt_hdr,
 	return pkt_hdr->buf_hdr.seg[seg_idx].len;
 }
 
-static inline uint8_t *packet_seg_data(odp_packet_hdr_t *pkt_hdr,
-				       uint32_t seg_idx)
+static inline void *packet_seg_data(odp_packet_hdr_t *pkt_hdr, uint32_t seg_idx)
 {
 	return pkt_hdr->buf_hdr.seg[seg_idx].data;
 }
 
-static inline uint32_t packet_last_seg(odp_packet_hdr_t *pkt_hdr)
+static inline uint16_t packet_last_seg(odp_packet_hdr_t *pkt_hdr)
 {
 	if (CONFIG_PACKET_MAX_SEGS == 1)
 		return 0;
@@ -155,7 +140,6 @@ static inline void push_head(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 {
 	pkt_hdr->headroom  -= len;
 	pkt_hdr->frame_len += len;
-	pkt_hdr->unshared_len += len;
 	pkt_hdr->buf_hdr.seg[0].data -= len;
 	pkt_hdr->buf_hdr.seg[0].len  += len;
 }
@@ -164,7 +148,6 @@ static inline void pull_head(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 {
 	pkt_hdr->headroom  += len;
 	pkt_hdr->frame_len -= len;
-	pkt_hdr->unshared_len -= len;
 	pkt_hdr->buf_hdr.seg[0].data += len;
 	pkt_hdr->buf_hdr.seg[0].len  -= len;
 }
@@ -175,7 +158,6 @@ static inline void push_tail(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 
 	pkt_hdr->tailroom  -= len;
 	pkt_hdr->frame_len += len;
-	pkt_hdr->unshared_len += len;
 	pkt_hdr->buf_hdr.seg[last].len += len;
 }
 
@@ -203,10 +185,6 @@ static inline void packet_seg_copy_md(odp_packet_hdr_t *dst,
 	dst->buf_hdr.uarea_addr = src->buf_hdr.uarea_addr;
 	dst->buf_hdr.uarea_size = src->buf_hdr.uarea_size;
 
-	/* reference related metadata */
-	dst->ref_len      = src->ref_len;
-	dst->unshared_len = src->unshared_len;
-
 	/* segmentation data is not copied:
 	 *   buf_hdr.seg[]
 	 *   buf_hdr.segcount
@@ -221,15 +199,7 @@ static inline void *packet_map(odp_packet_hdr_t *pkt_hdr,
 	int seg = 0;
 	int seg_count = pkt_hdr->buf_hdr.segcount;
 
-	/* Special processing for references */
-	while (offset >= pkt_hdr->frame_len && pkt_hdr->ref_hdr) {
-		offset   -= (pkt_hdr->frame_len - pkt_hdr->ref_offset);
-		offset   += (pkt_hdr->ref_hdr->frame_len - pkt_hdr->ref_len);
-		pkt_hdr   = pkt_hdr->ref_hdr;
-		seg_count = pkt_hdr->buf_hdr.segcount;
-	}
-
-	if (odp_unlikely(offset > pkt_hdr->frame_len))
+	if (odp_unlikely(offset >= pkt_hdr->frame_len))
 		return NULL;
 
 	if (odp_likely(CONFIG_PACKET_MAX_SEGS == 1 || seg_count == 1)) {
@@ -271,9 +241,6 @@ void packet_parse_reset(odp_packet_hdr_t *pkt_hdr)
 	pkt_hdr->p.l2_offset        = 0;
 	pkt_hdr->p.l3_offset        = ODP_PACKET_OFFSET_INVALID;
 	pkt_hdr->p.l4_offset        = ODP_PACKET_OFFSET_INVALID;
-
-	/* Ensure dummy pkt hdrs used in I/O recv classification are valid */
-	pkt_hdr->ref_hdr = NULL;
 }
 
 static inline void init_segments(odp_packet_hdr_t *pkt_hdr[], int num)
@@ -286,7 +253,6 @@ static inline void init_segments(odp_packet_hdr_t *pkt_hdr[], int num)
 
 	hdr->buf_hdr.seg[0].data = hdr->buf_hdr.base_data;
 	hdr->buf_hdr.seg[0].len  = BASE_LEN;
-	packet_ref_count_set(hdr, 1);
 
 	/* Link segments */
 	if (CONFIG_PACKET_MAX_SEGS != 1) {
@@ -296,7 +262,6 @@ static inline void init_segments(odp_packet_hdr_t *pkt_hdr[], int num)
 			for (i = 1; i < num; i++) {
 				odp_buffer_hdr_t *buf_hdr;
 
-				packet_ref_count_set(pkt_hdr[i], 1);
 				buf_hdr = &pkt_hdr[i]->buf_hdr;
 				hdr->buf_hdr.seg[i].hdr  = buf_hdr;
 				hdr->buf_hdr.seg[i].data = buf_hdr->base_data;
@@ -414,10 +379,9 @@ static inline odp_packet_hdr_t *add_segments(odp_packet_hdr_t *pkt_hdr,
 		new_hdr->buf_hdr.seg[0].len   = seg_len;
 
 		packet_seg_copy_md(new_hdr, pkt_hdr);
-		new_hdr->frame_len    = pkt_hdr->frame_len + len;
-		new_hdr->unshared_len = pkt_hdr->unshared_len + len;
-		new_hdr->headroom     = pool->headroom + offset;
-		new_hdr->tailroom     = pkt_hdr->tailroom;
+		new_hdr->frame_len = pkt_hdr->frame_len + len;
+		new_hdr->headroom  = pool->headroom + offset;
+		new_hdr->tailroom  = pkt_hdr->tailroom;
 
 		pkt_hdr = new_hdr;
 	} else {
@@ -430,9 +394,8 @@ static inline odp_packet_hdr_t *add_segments(odp_packet_hdr_t *pkt_hdr,
 		last = packet_last_seg(pkt_hdr);
 		pkt_hdr->buf_hdr.seg[last].len = seg_len;
 
-		pkt_hdr->frame_len    += len;
-		pkt_hdr->unshared_len += len;
-		pkt_hdr->tailroom      = pool->tailroom + offset;
+		pkt_hdr->frame_len += len;
+		pkt_hdr->tailroom   = pool->tailroom + offset;
 	}
 
 	return pkt_hdr;
@@ -440,20 +403,13 @@ static inline odp_packet_hdr_t *add_segments(odp_packet_hdr_t *pkt_hdr,
 
 static inline void free_bufs(odp_packet_hdr_t *pkt_hdr, int first, int num)
 {
-	int i, nfree;
+	int i;
 	odp_buffer_hdr_t *buf_hdr[num];
 
-	for (i = 0, nfree = 0; i < num; i++) {
-		odp_packet_hdr_t *hdr = pkt_hdr->buf_hdr.seg[first + i].hdr;
+	for (i = 0; i < num; i++)
+		buf_hdr[i] = pkt_hdr->buf_hdr.seg[first + i].hdr;
 
-		if (packet_ref_count(hdr) == 1 || packet_ref_dec(hdr) == 1) {
-			ODP_ASSERT((packet_ref_count_set(hdr, 0), 1));
-			buf_hdr[nfree++] = &hdr->buf_hdr;
-		}
-	}
-
-	if (nfree > 0)
-		buffer_free_multi(buf_hdr, nfree);
+	buffer_free_multi(buf_hdr, num);
 }
 
 static inline odp_packet_hdr_t *free_segments(odp_packet_hdr_t *pkt_hdr,
@@ -464,19 +420,11 @@ static inline odp_packet_hdr_t *free_segments(odp_packet_hdr_t *pkt_hdr,
 
 	if (head) {
 		odp_packet_hdr_t *new_hdr;
-		int i, nfree;
+		int i;
 		odp_buffer_hdr_t *buf_hdr[num];
 
-		for (i = 0, nfree = 0; i < num; i++) {
-			new_hdr = pkt_hdr->buf_hdr.seg[i].hdr;
-
-			if (packet_ref_count(new_hdr) == 1 ||
-			    packet_ref_dec(new_hdr) == 1) {
-				ODP_ASSERT((packet_ref_count_set(new_hdr, 0),
-					    1));
-				buf_hdr[nfree++] = &new_hdr->buf_hdr;
-			}
-		}
+		for (i = 0; i < num; i++)
+			buf_hdr[i] = pkt_hdr->buf_hdr.seg[i].hdr;
 
 		/* First remaining segment is the new packet descriptor */
 		new_hdr = pkt_hdr->buf_hdr.seg[num].hdr;
@@ -485,17 +433,15 @@ static inline odp_packet_hdr_t *free_segments(odp_packet_hdr_t *pkt_hdr,
 		packet_seg_copy_md(new_hdr, pkt_hdr);
 
 		/* Tailroom not changed */
-		new_hdr->tailroom     = pkt_hdr->tailroom;
-		new_hdr->headroom     = seg_headroom(new_hdr, 0);
-		new_hdr->frame_len    = pkt_hdr->frame_len - free_len;
-		new_hdr->unshared_len = pkt_hdr->unshared_len - free_len;
+		new_hdr->tailroom  = pkt_hdr->tailroom;
+		new_hdr->headroom  = seg_headroom(new_hdr, 0);
+		new_hdr->frame_len = pkt_hdr->frame_len - free_len;
 
 		pull_head(new_hdr, pull_len);
 
 		pkt_hdr = new_hdr;
 
-		if (nfree > 0)
-			buffer_free_multi(buf_hdr, nfree);
+		buffer_free_multi(buf_hdr, num);
 	} else {
 		/* Free last 'num' bufs */
 		free_bufs(pkt_hdr, num_remain, num);
@@ -504,7 +450,6 @@ static inline odp_packet_hdr_t *free_segments(odp_packet_hdr_t *pkt_hdr,
 		 * of the metadata. */
 		pkt_hdr->buf_hdr.segcount = num_remain;
 		pkt_hdr->frame_len -= free_len;
-		pkt_hdr->unshared_len -= free_len;
 		pkt_hdr->tailroom = seg_tailroom(pkt_hdr, num_remain - 1);
 
 		pull_tail(pkt_hdr, pull_len);
@@ -611,80 +556,48 @@ int odp_packet_alloc_multi(odp_pool_t pool_hdl, uint32_t len,
 	return num;
 }
 
-static inline void packet_free(odp_packet_hdr_t *pkt_hdr)
-{
-	odp_packet_hdr_t *ref_hdr;
-	odp_buffer_hdr_t *buf_hdr;
-	uint32_t ref_count;
-	int num_seg;
-
-	do {
-		buf_hdr = &pkt_hdr->buf_hdr;
-		ref_count = packet_ref_count(pkt_hdr);
-		num_seg = pkt_hdr->buf_hdr.segcount;
-		ref_hdr = pkt_hdr->ref_hdr;
-		ODP_ASSERT(ref_count >= 1);
-
-		if (odp_likely((CONFIG_PACKET_MAX_SEGS == 1 || num_seg == 1) &&
-			       ref_count == 1)) {
-			ODP_ASSERT((packet_ref_count_set(pkt_hdr, 0), 1));
-			buffer_free_multi(&buf_hdr, 1);
-		} else {
-			free_bufs(pkt_hdr, 0, num_seg);
-		}
-
-		pkt_hdr = ref_hdr;
-	} while (pkt_hdr);
-}
-
 void odp_packet_free(odp_packet_t pkt)
 {
-	packet_free(packet_hdr(pkt));
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
+	odp_buffer_t hdl = buffer_handle(pkt_hdr);
+
+	int num_seg = pkt_hdr->buf_hdr.segcount;
+
+	if (odp_likely(CONFIG_PACKET_MAX_SEGS == 1 || num_seg == 1))
+		buffer_free_multi((odp_buffer_hdr_t **)&hdl, 1);
+	else
+		free_bufs(pkt_hdr, 0, num_seg);
 }
 
 void odp_packet_free_multi(const odp_packet_t pkt[], int num)
 {
-	odp_packet_hdr_t *pkt_hdr, *ref_hdr, *hdr;
-	int nbufs = num * CONFIG_PACKET_MAX_SEGS * 2;
-	odp_buffer_hdr_t *buf_hdr[nbufs];
-	int num_seg;
-	int i, j;
-	uint32_t ref_count;
-	int nfree = 0;
+	if (CONFIG_PACKET_MAX_SEGS == 1) {
+		buffer_free_multi((odp_buffer_hdr_t **)(uintptr_t)pkt, num);
+	} else {
+		odp_buffer_hdr_t *buf_hdr[num * CONFIG_PACKET_MAX_SEGS];
+		int i;
+		int j;
+		int bufs = 0;
 
-	for (i = 0; i < num; i++) {
-		pkt_hdr = packet_hdr(pkt[i]);
+		for (i = 0; i < num; i++) {
+			odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt[i]);
+			int num_seg = pkt_hdr->buf_hdr.segcount;
+			odp_buffer_hdr_t *hdr = &pkt_hdr->buf_hdr;
 
-		do {
-			num_seg = pkt_hdr->buf_hdr.segcount;
-			ref_hdr = pkt_hdr->ref_hdr;
+			buf_hdr[bufs] = hdr;
+			bufs++;
 
-			/* Make sure we have enough space for this pkt's segs */
-			if (nfree + num_seg > nbufs) {
-				buffer_free_multi(buf_hdr, nfree);
-				nfree = 0;
+			if (odp_likely(num_seg == 1))
+				continue;
+
+			for (j = 1; j < num_seg; j++) {
+				buf_hdr[bufs] = hdr->seg[j].hdr;
+				bufs++;
 			}
+		}
 
-			for (j = 0; j < num_seg; j++) {
-				hdr = pkt_hdr->buf_hdr.seg[j].hdr;
-				ref_count = packet_ref_count(hdr);
-				ODP_ASSERT(ref_count >= 1);
-
-				if (ref_count == 1 ||
-				    packet_ref_dec(hdr) == 1) {
-					ODP_ASSERT
-						((packet_ref_count_set(hdr, 0),
-						  1));
-					buf_hdr[nfree++] = &hdr->buf_hdr;
-				}
-			}
-
-			pkt_hdr = ref_hdr;
-		} while (pkt_hdr);
+		buffer_free_multi(buf_hdr, bufs);
 	}
-
-	if (nfree > 0)
-		buffer_free_multi(buf_hdr, nfree);
 }
 
 int odp_packet_reset(odp_packet_t pkt, uint32_t len)
@@ -695,9 +608,6 @@ int odp_packet_reset(odp_packet_t pkt, uint32_t len)
 
 	if (odp_unlikely(len > (pool->max_seg_len * num)))
 		return -1;
-
-	if (pkt_hdr->ref_hdr)
-		packet_free(pkt_hdr->ref_hdr);
 
 	reset_seg(pkt_hdr, 0, num);
 
@@ -732,47 +642,13 @@ odp_event_t odp_packet_to_event(odp_packet_t pkt)
 uint32_t odp_packet_buf_len(odp_packet_t pkt)
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-	uint32_t buf_len = 0;
 
-	do {
-		buf_len += pkt_hdr->buf_hdr.size * pkt_hdr->buf_hdr.segcount;
-		pkt_hdr  = pkt_hdr->ref_hdr;
-	} while (pkt_hdr);
-
-	return buf_len;
-}
-
-uint32_t odp_packet_unshared_len(odp_packet_t pkt)
-{
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-	uint32_t pkt_len = 0, offset = 0;
-
-	if (packet_ref_count(pkt_hdr) == 1)
-		pkt_hdr->unshared_len = pkt_hdr->frame_len;
-
-	do {
-		if (packet_ref_count(pkt_hdr) > 1) {
-			if (offset == 0)
-				pkt_len += pkt_hdr->unshared_len;
-			break;
-		}
-
-		pkt_len += pkt_hdr->frame_len - offset;
-		offset   = pkt_hdr->ref_offset;
-
-		if (pkt_hdr->ref_hdr)
-			offset += (pkt_hdr->ref_hdr->frame_len -
-				   pkt_hdr->ref_len);
-
-		pkt_hdr = pkt_hdr->ref_hdr;
-	} while (pkt_hdr);
-
-	return pkt_len;
+	return pkt_hdr->buf_hdr.size * pkt_hdr->buf_hdr.segcount;
 }
 
 void *odp_packet_tail(odp_packet_t pkt)
 {
-	odp_packet_hdr_t *pkt_hdr = packet_last_hdr(pkt, NULL);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
 	return packet_tail(pkt_hdr);
 }
@@ -968,13 +844,6 @@ int odp_packet_extend_head(odp_packet_t *pkt, uint32_t len,
 		segs = pkt_hdr->buf_hdr.segcount;
 
 		if (odp_unlikely((segs + num) > CONFIG_PACKET_MAX_SEGS)) {
-			/* Corner case: fail request if packet has
-			 * references since we cannot shuffle segments
-			 * since another thread may be accessing them
-			 * concurrently */
-			if (packet_ref_count(pkt_hdr) > 1)
-				return -1;
-
 			/* Cannot directly add new segments */
 			odp_packet_hdr_t *new_hdr;
 			int new_segs = 0;
@@ -1026,7 +895,6 @@ int odp_packet_extend_head(odp_packet_t *pkt, uint32_t len,
 
 			pkt_hdr->buf_hdr.segcount = segs;
 			pkt_hdr->frame_len        = frame_len;
-			pkt_hdr->unshared_len     = frame_len;
 			pkt_hdr->headroom         = offset + pool->headroom;
 			pkt_hdr->tailroom         = pool->tailroom;
 
@@ -1052,16 +920,11 @@ int odp_packet_extend_head(odp_packet_t *pkt, uint32_t len,
 		push_head(pkt_hdr, len);
 	}
 
-	if (data_ptr || seg_len) {
-		uint32_t seg_ln = 0;
-		void *data = packet_map(pkt_hdr, 0, &seg_ln, NULL);
+	if (data_ptr)
+		*data_ptr = packet_data(pkt_hdr);
 
-		if (data_ptr)
-			*data_ptr = data;
-
-		if (seg_len)
-			*seg_len = seg_ln;
-	}
+	if (seg_len)
+		*seg_len = packet_first_seg_len(pkt_hdr);
 
 	return ret;
 }
@@ -1073,8 +936,6 @@ void *odp_packet_pull_head(odp_packet_t pkt, uint32_t len)
 	if (len > pkt_hdr->frame_len)
 		return NULL;
 
-	ODP_ASSERT(len <= pkt_hdr->unshared_len);
-
 	pull_head(pkt_hdr, len);
 	return packet_data(pkt_hdr);
 }
@@ -1082,35 +943,15 @@ void *odp_packet_pull_head(odp_packet_t pkt, uint32_t len)
 int odp_packet_trunc_head(odp_packet_t *pkt, uint32_t len,
 			  void **data_ptr, uint32_t *seg_len_out)
 {
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(*pkt), *nxt_hdr;
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(*pkt);
 	uint32_t seg_len = packet_first_seg_len(pkt_hdr);
-	int ret = 0;
 
-	if (len > packet_len(pkt_hdr))
+	if (len > pkt_hdr->frame_len)
 		return -1;
 
-	ODP_ASSERT(len <= odp_packet_unshared_len(*pkt));
-
-	/* Special processing for references */
-	while (len >= pkt_hdr->frame_len && pkt_hdr->ref_hdr) {
-		ODP_ASSERT(packet_ref_count(pkt_hdr) == 1);
-		nxt_hdr = pkt_hdr->ref_hdr;
-		len -= pkt_hdr->frame_len;
-		len += pkt_hdr->ref_offset +
-			(nxt_hdr->frame_len - pkt_hdr->ref_len);
-		pkt_hdr->ref_hdr = NULL;
-		packet_free(pkt_hdr);
-		pkt_hdr = nxt_hdr;
-		seg_len = packet_first_seg_len(pkt_hdr);
-		*pkt = packet_handle(pkt_hdr);
-		ret = 1;
-	}
-
-	if (CONFIG_PACKET_MAX_SEGS == 1 ||
-	    len < seg_len ||
-	    pkt_hdr->buf_hdr.segcount == 1) {
+	if (len < seg_len) {
 		pull_head(pkt_hdr, len);
-	} else {
+	} else if (CONFIG_PACKET_MAX_SEGS != 1) {
 		int num = 0;
 		uint32_t pull_len = 0;
 
@@ -1125,28 +966,22 @@ int odp_packet_trunc_head(odp_packet_t *pkt, uint32_t len,
 		*pkt    = packet_handle(pkt_hdr);
 	}
 
-	if (data_ptr || seg_len_out) {
-		void *data_head = packet_map(pkt_hdr, 0, &seg_len, NULL);
+	if (data_ptr)
+		*data_ptr = packet_data(pkt_hdr);
 
-		if (data_ptr)
-			*data_ptr = data_head;
+	if (seg_len_out)
+		*seg_len_out = packet_first_seg_len(pkt_hdr);
 
-		if (seg_len_out)
-			*seg_len_out = seg_len;
-	}
-
-	return ret;
+	return 0;
 }
 
 void *odp_packet_push_tail(odp_packet_t pkt, uint32_t len)
 {
-	odp_packet_hdr_t *pkt_hdr = packet_last_hdr(pkt, NULL);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 	void *old_tail;
 
 	if (len > pkt_hdr->tailroom)
 		return NULL;
-
-	ODP_ASSERT(packet_ref_count(pkt_hdr) == 1);
 
 	old_tail = packet_tail(pkt_hdr);
 	push_tail(pkt_hdr, len);
@@ -1157,13 +992,11 @@ void *odp_packet_push_tail(odp_packet_t pkt, uint32_t len)
 int odp_packet_extend_tail(odp_packet_t *pkt, uint32_t len,
 			   void **data_ptr, uint32_t *seg_len_out)
 {
-	odp_packet_hdr_t *pkt_hdr = packet_last_hdr(*pkt, NULL);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(*pkt);
 	uint32_t frame_len = pkt_hdr->frame_len;
 	uint32_t tailroom  = pkt_hdr->tailroom;
 	uint32_t tail_off  = frame_len;
 	int ret = 0;
-
-	ODP_ASSERT(packet_ref_count(pkt_hdr) == 1);
 
 	if (len > tailroom) {
 		pool_t *pool = pkt_hdr->buf_hdr.pool_ptr;
@@ -1255,7 +1088,6 @@ void *odp_packet_pull_tail(odp_packet_t pkt, uint32_t len)
 	if (len > packet_last_seg_len(pkt_hdr))
 		return NULL;
 
-	ODP_ASSERT(packet_ref_count(pkt_hdr) == 1);
 	pull_tail(pkt_hdr, len);
 
 	return packet_tail(pkt_hdr);
@@ -1266,34 +1098,17 @@ int odp_packet_trunc_tail(odp_packet_t *pkt, uint32_t len,
 {
 	int last;
 	uint32_t seg_len;
-	uint32_t offset;
-	odp_packet_hdr_t *first_hdr = packet_hdr(*pkt);
-	odp_packet_hdr_t *pkt_hdr, *prev_hdr;
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(*pkt);
 
-	if (len > packet_len(first_hdr))
+	if (len > pkt_hdr->frame_len)
 		return -1;
 
-	pkt_hdr = packet_last_hdr(*pkt, &offset);
-
-	/* Special processing for references */
-	while (len >= pkt_hdr->frame_len - offset && first_hdr->ref_hdr) {
-		len -= (pkt_hdr->frame_len - offset);
-		prev_hdr = packet_prev_hdr(first_hdr, pkt_hdr, &offset);
-		ODP_ASSERT(packet_ref_count(prev_hdr) == 1);
-		prev_hdr->ref_hdr = NULL;
-		packet_free(pkt_hdr);
-		pkt_hdr = prev_hdr;
-	}
-
-	ODP_ASSERT(packet_ref_count(pkt_hdr) == 1);
 	last    = packet_last_seg(pkt_hdr);
 	seg_len = packet_seg_len(pkt_hdr, last);
 
-	if (CONFIG_PACKET_MAX_SEGS == 1 ||
-	    len < seg_len ||
-	    pkt_hdr->buf_hdr.segcount == 1) {
+	if (len < seg_len) {
 		pull_tail(pkt_hdr, len);
-	} else {
+	} else if (CONFIG_PACKET_MAX_SEGS != 1) {
 		int num = 0;
 		uint32_t pull_len = 0;
 
@@ -1440,46 +1255,6 @@ void odp_packet_ts_set(odp_packet_t pkt, odp_time_t timestamp)
 	pkt_hdr->p.input_flags.timestamp = 1;
 }
 
-int odp_packet_num_segs(odp_packet_t pkt)
-{
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-	uint32_t segcount = 0, i;
-	uint32_t seg_offset = 0, offset;
-
-	do {
-		segcount += pkt_hdr->buf_hdr.segcount - seg_offset;
-		offset    = pkt_hdr->ref_offset;
-		pkt_hdr   = pkt_hdr->ref_hdr;
-		if (pkt_hdr) {
-			for (i = 0, seg_offset = 0;
-			     i < pkt_hdr->buf_hdr.segcount;
-			     i++, seg_offset++) {
-				if (offset < pkt_hdr->buf_hdr.seg[i].len)
-					break;
-				offset -= pkt_hdr->buf_hdr.seg[i].len;
-			}
-		}
-	} while (pkt_hdr);
-
-	return segcount;
-}
-
-odp_packet_seg_t odp_packet_last_seg(odp_packet_t pkt)
-{
-	return _odp_packet_seg_from_ndx(odp_packet_num_segs(pkt) - 1);
-}
-
-odp_packet_seg_t odp_packet_next_seg(odp_packet_t pkt, odp_packet_seg_t seg)
-{
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-
-	if (odp_unlikely(_odp_packet_seg_to_ndx(seg) >=
-			 packet_last_seg(pkt_hdr)))
-		return ODP_PACKET_SEG_INVALID;
-
-	return seg + 1;
-}
-
 /*
  *
  * Segment level
@@ -1490,53 +1265,23 @@ odp_packet_seg_t odp_packet_next_seg(odp_packet_t pkt, odp_packet_seg_t seg)
 void *odp_packet_seg_data(odp_packet_t pkt, odp_packet_seg_t seg)
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-	uint32_t seg_offset = 0, offset = 0, i;
-	uint32_t seg_ndx = _odp_packet_seg_to_ndx(seg);
 
-	while (seg_ndx >= pkt_hdr->buf_hdr.segcount - seg_offset &&
-	       pkt_hdr->ref_hdr) {
-		seg_ndx -= (pkt_hdr->buf_hdr.segcount - seg_offset);
-		offset   = pkt_hdr->ref_offset;
-		pkt_hdr  = pkt_hdr->ref_hdr;
-		for (i = 0, seg_offset = 0;
-		     i < pkt_hdr->buf_hdr.segcount;
-		     i++, seg_offset++) {
-			if (offset < pkt_hdr->buf_hdr.seg[i].len)
-				break;
-			offset -= pkt_hdr->buf_hdr.seg[i].len;
-		}
-	}
-
-	if (odp_unlikely(seg_ndx + seg_offset >= pkt_hdr->buf_hdr.segcount))
+	if (odp_unlikely(_odp_packet_seg_to_ndx(seg) >=
+			 pkt_hdr->buf_hdr.segcount))
 		return NULL;
 
-	return packet_seg_data(pkt_hdr, seg_ndx + seg_offset) + offset;
+	return packet_seg_data(pkt_hdr, _odp_packet_seg_to_ndx(seg));
 }
 
 uint32_t odp_packet_seg_data_len(odp_packet_t pkt, odp_packet_seg_t seg)
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-	uint32_t seg_offset = 0, offset = 0, i;
-	uint32_t seg_ndx = _odp_packet_seg_to_ndx(seg);
 
-	while (seg_ndx >= pkt_hdr->buf_hdr.segcount - seg_offset &&
-	       pkt_hdr->ref_hdr) {
-		seg_ndx -= (pkt_hdr->buf_hdr.segcount - seg_offset);
-		offset   = pkt_hdr->ref_offset;
-		pkt_hdr  = pkt_hdr->ref_hdr;
-		for (i = 0, seg_offset = 0;
-		     i < pkt_hdr->buf_hdr.segcount;
-		     i++, seg_offset++) {
-			if (offset < pkt_hdr->buf_hdr.seg[i].len)
-				break;
-			offset -= pkt_hdr->buf_hdr.seg[i].len;
-		}
-	}
-
-	if (odp_unlikely(seg_ndx + seg_offset >= pkt_hdr->buf_hdr.segcount))
+	if (odp_unlikely(_odp_packet_seg_to_ndx(seg) >=
+			 pkt_hdr->buf_hdr.segcount))
 		return 0;
 
-	return packet_seg_len(pkt_hdr, seg_ndx + seg_offset) - offset;
+	return packet_seg_len(pkt_hdr, _odp_packet_seg_to_ndx(seg));
 }
 
 /*
@@ -1556,8 +1301,6 @@ int odp_packet_add_data(odp_packet_t *pkt_ptr, uint32_t offset, uint32_t len)
 
 	if (offset > pktlen)
 		return -1;
-
-	ODP_ASSERT(odp_packet_unshared_len(*pkt_ptr) >= offset);
 
 	newpkt = odp_packet_alloc(pool->pool_hdl, pktlen + len);
 
@@ -1582,14 +1325,12 @@ int odp_packet_rem_data(odp_packet_t *pkt_ptr, uint32_t offset, uint32_t len)
 {
 	odp_packet_t pkt = *pkt_ptr;
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-	uint32_t pktlen = packet_len(pkt_hdr);
+	uint32_t pktlen = pkt_hdr->frame_len;
 	pool_t *pool = pkt_hdr->buf_hdr.pool_ptr;
 	odp_packet_t newpkt;
 
-	if (offset + len > pktlen)
+	if (offset > pktlen || offset + len > pktlen)
 		return -1;
-
-	ODP_ASSERT(odp_packet_unshared_len(*pkt_ptr) >= offset + len);
 
 	newpkt = odp_packet_alloc(pool->pool_hdl, pktlen - len);
 
@@ -1623,8 +1364,6 @@ int odp_packet_align(odp_packet_t *pkt, uint32_t offset, uint32_t len,
 
 	if (align > ODP_CACHE_LINE_SIZE)
 		return -1;
-
-	ODP_ASSERT(odp_packet_has_ref(*pkt) == 0);
 
 	if (seglen >= len) {
 		misalign = align <= 1 ? 0 :
@@ -1665,13 +1404,10 @@ int odp_packet_concat(odp_packet_t *dst, odp_packet_t src)
 	uint32_t dst_len = dst_hdr->frame_len;
 	uint32_t src_len = src_hdr->frame_len;
 
-	ODP_ASSERT(packet_ref_count(dst_hdr) == 1);
-
 	/* Do a copy if resulting packet would be out of segments or packets
-	 * are from different pools or src is a reference. */
+	 * are from different pools. */
 	if (odp_unlikely((dst_segs + src_segs) > CONFIG_PACKET_MAX_SEGS) ||
-	    odp_unlikely(dst_pool != src_pool) ||
-	    odp_unlikely(packet_ref_count(src_hdr) > 1)) {
+	    odp_unlikely(dst_pool != src_pool)) {
 		if (odp_packet_extend_tail(dst, src_len, NULL, NULL) >= 0) {
 			(void)odp_packet_copy_from_pkt(*dst, dst_len,
 						       src, 0, src_len);
@@ -1686,9 +1422,8 @@ int odp_packet_concat(odp_packet_t *dst, odp_packet_t src)
 
 	add_all_segs(dst_hdr, src_hdr);
 
-	dst_hdr->frame_len    = dst_len + src_len;
-	dst_hdr->unshared_len = dst_len + src_len;
-	dst_hdr->tailroom     = src_hdr->tailroom;
+	dst_hdr->frame_len = dst_len + src_len;
+	dst_hdr->tailroom  = src_hdr->tailroom;
 
 	/* Data was not moved in memory */
 	return 0;
@@ -1701,7 +1436,6 @@ int odp_packet_split(odp_packet_t *pkt, uint32_t len, odp_packet_t *tail)
 	if (len >= pktlen || tail == NULL)
 		return -1;
 
-	ODP_ASSERT(odp_packet_unshared_len(*pkt) >= len);
 	*tail = odp_packet_copy_part(*pkt, len, pktlen - len,
 				     odp_packet_pool(*pkt));
 
@@ -1709,109 +1443,6 @@ int odp_packet_split(odp_packet_t *pkt, uint32_t len, odp_packet_t *tail)
 		return -1;
 
 	return odp_packet_trunc_tail(pkt, pktlen - len, NULL, NULL);
-}
-
-/*
- * References
- */
-
-static inline void packet_ref(odp_packet_hdr_t *pkt_hdr)
-{
-	uint32_t i;
-	odp_packet_hdr_t *hdr;
-
-	do {
-		for (i = 0; i < pkt_hdr->buf_hdr.segcount; i++) {
-			hdr = pkt_hdr->buf_hdr.seg[i].hdr;
-			packet_ref_inc(hdr);
-		}
-
-		pkt_hdr = pkt_hdr->ref_hdr;
-	} while (pkt_hdr);
-}
-
-static inline odp_packet_t packet_splice(odp_packet_hdr_t *pkt_hdr,
-					 uint32_t offset,
-					 odp_packet_hdr_t *ref_hdr)
-{
-	/* Catch attempted references to stale handles in debug builds */
-	ODP_ASSERT(packet_ref_count(pkt_hdr) > 0);
-
-	/* Splicing is from the last section of src pkt */
-	while (ref_hdr->ref_hdr)
-		ref_hdr = ref_hdr->ref_hdr;
-
-	/* Find section where splice begins */
-	while (offset >= pkt_hdr->frame_len && pkt_hdr->ref_hdr) {
-		offset   -= (pkt_hdr->frame_len - pkt_hdr->ref_offset);
-		offset   += (pkt_hdr->ref_hdr->frame_len - pkt_hdr->ref_len);
-		pkt_hdr   = pkt_hdr->ref_hdr;
-	}
-
-	ref_hdr->ref_hdr    = pkt_hdr;
-	ref_hdr->ref_offset = offset;
-	ref_hdr->ref_len    = pkt_hdr->frame_len;
-
-	if (packet_ref_count(pkt_hdr) == 1 || offset < pkt_hdr->unshared_len)
-		pkt_hdr->unshared_len = offset;
-
-	packet_ref(pkt_hdr);
-	return packet_handle(ref_hdr);
-}
-
-odp_packet_t odp_packet_ref_static(odp_packet_t pkt)
-{
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-
-	packet_ref(pkt_hdr);
-	pkt_hdr->unshared_len = 0;
-	return pkt;
-}
-
-odp_packet_t odp_packet_ref(odp_packet_t pkt, uint32_t offset)
-{
-	odp_packet_t hdr;
-	odp_packet_hdr_t *pkt_hdr;
-
-	if (pkt == ODP_PACKET_INVALID)
-		return ODP_PACKET_INVALID;
-
-	pkt_hdr = packet_hdr(pkt);
-	if (offset >= packet_len(pkt_hdr))
-		return ODP_PACKET_INVALID;
-
-	hdr = odp_packet_alloc(odp_packet_pool(pkt), 0);
-
-	if (hdr == ODP_PACKET_INVALID)
-		return ODP_PACKET_INVALID;
-
-	return packet_splice(pkt_hdr, offset, packet_hdr(hdr));
-}
-
-odp_packet_t odp_packet_ref_pkt(odp_packet_t pkt, uint32_t offset,
-				odp_packet_t hdr)
-{
-	odp_packet_hdr_t *pkt_hdr;
-
-	if (pkt == ODP_PACKET_INVALID ||
-	    hdr == ODP_PACKET_INVALID ||
-	    pkt == hdr)
-		return ODP_PACKET_INVALID;
-
-	ODP_ASSERT(odp_packet_has_ref(hdr) == 0);
-
-	pkt_hdr = packet_hdr(pkt);
-	if (offset >= packet_len(pkt_hdr))
-		return ODP_PACKET_INVALID;
-
-	return packet_splice(pkt_hdr, offset, packet_hdr(hdr));
-}
-
-int odp_packet_has_ref(odp_packet_t pkt)
-{
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-
-	return pkt_hdr->ref_hdr != NULL || packet_ref_count(pkt_hdr) > 1;
 }
 
 /*
@@ -1823,7 +1454,8 @@ int odp_packet_has_ref(odp_packet_t pkt)
 
 odp_packet_t odp_packet_copy(odp_packet_t pkt, odp_pool_t pool)
 {
-	uint32_t pktlen = odp_packet_len(pkt);
+	odp_packet_hdr_t *srchdr = packet_hdr(pkt);
+	uint32_t pktlen = srchdr->frame_len;
 	odp_packet_t newpkt = odp_packet_alloc(pool, pktlen);
 
 	if (newpkt != ODP_PACKET_INVALID) {
@@ -1862,7 +1494,7 @@ int odp_packet_copy_to_mem(odp_packet_t pkt, uint32_t offset,
 	uint8_t *dstaddr = (uint8_t *)dst;
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
-	if (offset + len > packet_len(pkt_hdr))
+	if (offset + len > pkt_hdr->frame_len)
 		return -1;
 
 	while (len > 0) {
@@ -1886,10 +1518,8 @@ int odp_packet_copy_from_mem(odp_packet_t pkt, uint32_t offset,
 	const uint8_t *srcaddr = (const uint8_t *)src;
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
-	if (offset + len > packet_len(pkt_hdr))
+	if (offset + len > pkt_hdr->frame_len)
 		return -1;
-
-	ODP_ASSERT(odp_packet_unshared_len(pkt) >= offset + len);
 
 	while (len > 0) {
 		mapaddr = packet_map(pkt_hdr, offset, &seglen, NULL);
@@ -1916,11 +1546,9 @@ int odp_packet_copy_from_pkt(odp_packet_t dst, uint32_t dst_offset,
 	uint32_t src_seglen = 0; /* GCC */
 	int overlap;
 
-	if (dst_offset + len > packet_len(dst_hdr) ||
-	    src_offset + len > packet_len(src_hdr))
+	if (dst_offset + len > dst_hdr->frame_len ||
+	    src_offset + len > src_hdr->frame_len)
 		return -1;
-
-	ODP_ASSERT(odp_packet_unshared_len(dst) >= dst_offset + len);
 
 	overlap = (dst_hdr == src_hdr &&
 		   ((dst_offset <= src_offset &&
@@ -2054,7 +1682,7 @@ void odp_packet_print(odp_packet_t pkt)
 	len += snprintf(&str[len], n - len,
 			"  l4_offset    %" PRIu32 "\n", hdr->p.l4_offset);
 	len += snprintf(&str[len], n - len,
-			"  frame_len    %" PRIu32 "\n", packet_len(hdr));
+			"  frame_len    %" PRIu32 "\n", hdr->frame_len);
 	len += snprintf(&str[len], n - len,
 			"  input        %" PRIu64 "\n",
 			odp_pktio_to_u64(hdr->input));
@@ -2456,6 +2084,80 @@ uint64_t odp_packet_to_u64(odp_packet_t hdl)
 uint64_t odp_packet_seg_to_u64(odp_packet_seg_t hdl)
 {
 	return _odp_pri(hdl);
+}
+
+odp_packet_t odp_packet_ref_static(odp_packet_t pkt)
+{
+	return odp_packet_copy(pkt, odp_packet_pool(pkt));
+}
+
+odp_packet_t odp_packet_ref(odp_packet_t pkt, uint32_t offset)
+{
+	odp_packet_t new;
+	int ret;
+
+	new = odp_packet_copy(pkt, odp_packet_pool(pkt));
+
+	if (new == ODP_PACKET_INVALID) {
+		ODP_ERR("copy failed\n");
+		return ODP_PACKET_INVALID;
+	}
+
+	ret = odp_packet_trunc_head(&new, offset, NULL, NULL);
+
+	if (ret < 0) {
+		ODP_ERR("trunk_head failed\n");
+		odp_packet_free(new);
+		return ODP_PACKET_INVALID;
+	}
+
+	return new;
+}
+
+odp_packet_t odp_packet_ref_pkt(odp_packet_t pkt, uint32_t offset,
+				odp_packet_t hdr)
+{
+	odp_packet_t new;
+	int ret;
+
+	new = odp_packet_copy(pkt, odp_packet_pool(pkt));
+
+	if (new == ODP_PACKET_INVALID) {
+		ODP_ERR("copy failed\n");
+		return ODP_PACKET_INVALID;
+	}
+
+	if (offset) {
+		ret = odp_packet_trunc_head(&new, offset, NULL, NULL);
+
+		if (ret < 0) {
+			ODP_ERR("trunk_head failed\n");
+			odp_packet_free(new);
+			return ODP_PACKET_INVALID;
+		}
+	}
+
+	ret = odp_packet_concat(&hdr, new);
+
+	if (ret < 0) {
+		ODP_ERR("concat failed\n");
+		odp_packet_free(new);
+		return ODP_PACKET_INVALID;
+	}
+
+	return hdr;
+}
+
+int odp_packet_has_ref(odp_packet_t pkt)
+{
+	(void)pkt;
+
+	return 0;
+}
+
+uint32_t odp_packet_unshared_len(odp_packet_t pkt)
+{
+	return odp_packet_len(pkt);
 }
 
 /* Include non-inlined versions of API functions */

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1579,11 +1579,13 @@ int _odp_packet_cmp_data(odp_packet_t pkt, uint32_t offset,
  * ********************************************************
  *
  */
-
 void odp_packet_print(odp_packet_t pkt)
 {
 	odp_packet_seg_t seg;
-	int max_len = 512;
+	seg_entry_t *seg_entry;
+	odp_packet_hdr_t *seg_hdr;
+	uint8_t idx;
+	int max_len = 1024;
 	char str[max_len];
 	int len = 0;
 	int n = max_len - 1;
@@ -1619,12 +1621,22 @@ void odp_packet_print(odp_packet_t pkt)
 	len += snprintf(&str[len], n - len,
 			"  num_segs     %i\n", odp_packet_num_segs(pkt));
 
+	seg_hdr = hdr;
+	idx = 0;
 	seg = odp_packet_first_seg(pkt);
 
 	while (seg != ODP_PACKET_SEG_INVALID) {
+		odp_buffer_hdr_t *buf_hdr;
+
+		seg_entry = seg_entry_next(&seg_hdr, &idx);
+		buf_hdr = seg_entry->hdr;
+
 		len += snprintf(&str[len], n - len,
-				"    seg_len    %" PRIu32 "\n",
-				odp_packet_seg_data_len(pkt, seg));
+				"    seg_len    %-4" PRIu32 "  seg_data %p ",
+				odp_packet_seg_data_len(pkt, seg),
+				odp_packet_seg_data(pkt, seg));
+		len += snprintf(&str[len], n - len, "ref_cnt %u\n",
+				buffer_ref(buf_hdr));
 
 		seg = odp_packet_next_seg(pkt, seg);
 	}

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -41,6 +41,9 @@ ODP_STATIC_ASSERT(CONFIG_POOL_CACHE_SIZE > (2 * CACHE_BURST),
 ODP_STATIC_ASSERT(CONFIG_PACKET_SEG_LEN_MIN >= 256,
 		  "ODP Segment size must be a minimum of 256 bytes");
 
+ODP_STATIC_ASSERT(CONFIG_PACKET_SEG_SIZE < 0xffff,
+		  "Segment size must be less than 64k (16 bit offsets)");
+
 /* Thread local variables */
 typedef struct pool_local_t {
 	pool_cache_t *cache[ODP_CONFIG_POOLS];

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -277,6 +277,8 @@ static void init_buffers(pool_t *pool)
 		buf_hdr->seg[0].data      = &data[offset];
 		buf_hdr->seg[0].len       = pool->data_size;
 
+		odp_atomic_init_u32(&buf_hdr->ref_cnt, 0);
+
 		/* Store base values for fast init */
 		buf_hdr->base_data = buf_hdr->seg[0].data;
 		buf_hdr->buf_end   = &data[offset + pool->data_size +

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -268,6 +268,9 @@ static void init_buffers(pool_t *pool)
 		/* Show user requested size through API */
 		buf_hdr->uarea_size = pool->params.pkt.uarea_size;
 		buf_hdr->segcount = 1;
+		buf_hdr->num_seg  = 1;
+		buf_hdr->next_seg = NULL;
+		buf_hdr->last_seg = buf_hdr;
 
 		/* Pointer to data start (of the first segment) */
 		buf_hdr->seg[0].hdr       = buf_hdr;

--- a/test/common_plat/validation/api/packet/packet.c
+++ b/test/common_plat/validation/api/packet/packet.c
@@ -2224,8 +2224,14 @@ void packet_test_ref(void)
 	CU_ASSERT(ref_pkt[0] != ODP_PACKET_INVALID);
 
 	if (odp_packet_has_ref(base_pkt) == 1) {
-		/* CU_ASSERT needs braces */
 		CU_ASSERT(odp_packet_has_ref(ref_pkt[0]) == 1);
+		CU_ASSERT(odp_packet_unshared_len(base_pkt) == 0);
+		CU_ASSERT(odp_packet_unshared_len(ref_pkt[0]) == 0);
+	} else {
+		CU_ASSERT(odp_packet_unshared_len(base_pkt) ==
+			  odp_packet_len(base_pkt));
+		CU_ASSERT(odp_packet_unshared_len(ref_pkt[0]) ==
+			  odp_packet_len(ref_pkt[0]));
 	}
 
 	CU_ASSERT(odp_packet_len(ref_pkt[0]) == odp_packet_len(base_pkt));

--- a/test/common_plat/validation/api/packet/packet.c
+++ b/test/common_plat/validation/api/packet/packet.c
@@ -1376,7 +1376,7 @@ void packet_test_concat_small(void)
 	int ret;
 	uint8_t *data;
 	uint32_t i;
-	uint32_t len = 32000;
+	uint32_t len = PACKET_POOL_NUM / 4;
 	uint8_t buf[len];
 
 	CU_ASSERT_FATAL(odp_pool_capability(&capa) == 0);

--- a/test/common_plat/validation/api/packet/packet.c
+++ b/test/common_plat/validation/api/packet/packet.c
@@ -2072,14 +2072,107 @@ void packet_test_ref(void)
 {
 	odp_packet_t base_pkt, segmented_base_pkt, hdr_pkt[4],
 		ref_pkt[4], refhdr_pkt[4], hdr_cpy;
+	odp_packet_t pkt, pkt2, pkt3, ref, ref2;
 	uint32_t pkt_len, segmented_pkt_len, hdr_len[4], offset[4], hr[4],
 		base_hr, ref_len[4];
-	int i;
+	int i, ret;
+	odp_pool_t pool;
 
+	/* Create references and compare data */
+	pool = odp_packet_pool(test_packet);
+
+	pkt = odp_packet_copy(test_packet, pool);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID)
+	ref = odp_packet_ref_static(pkt);
+	CU_ASSERT_FATAL(ref != ODP_PACKET_INVALID)
+	packet_compare_data(pkt, ref);
+	odp_packet_free(ref);
+	odp_packet_free(pkt);
+
+	pkt = odp_packet_copy(test_packet, pool);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID)
+	ref = odp_packet_ref(pkt, 0);
+	CU_ASSERT_FATAL(ref != ODP_PACKET_INVALID)
+	packet_compare_data(pkt, ref);
+	odp_packet_free(ref);
+	odp_packet_free(pkt);
+
+	pkt  = odp_packet_copy(test_packet, pool);
+	pkt3 = odp_packet_copy(test_packet, pool);
+	CU_ASSERT_FATAL(pkt  != ODP_PACKET_INVALID)
+	CU_ASSERT_FATAL(pkt3 != ODP_PACKET_INVALID)
+	ret = odp_packet_concat(&pkt3, pkt);
+	CU_ASSERT_FATAL(ret >= 0);
+
+	pkt  = odp_packet_copy(test_packet, pool);
+	pkt2 = odp_packet_copy(test_packet, pool);
+	CU_ASSERT_FATAL(pkt  != ODP_PACKET_INVALID)
+	CU_ASSERT_FATAL(pkt2 != ODP_PACKET_INVALID)
+	ref = odp_packet_ref_pkt(pkt, 0, pkt2);
+	CU_ASSERT_FATAL(ref != ODP_PACKET_INVALID)
+	packet_compare_data(pkt3, ref);
+	odp_packet_free(ref);
+	odp_packet_free(pkt);
+	odp_packet_free(pkt3);
+
+	/* Do the same for segmented packets */
+	pool = odp_packet_pool(segmented_test_packet);
+
+	pkt = odp_packet_copy(segmented_test_packet, pool);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID)
+	ref = odp_packet_ref_static(pkt);
+	CU_ASSERT_FATAL(ref != ODP_PACKET_INVALID)
+	packet_compare_data(pkt, ref);
+	odp_packet_free(ref);
+	odp_packet_free(pkt);
+
+	pkt = odp_packet_copy(segmented_test_packet, pool);
+	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID)
+	ref = odp_packet_ref(pkt, 0);
+	CU_ASSERT_FATAL(ref != ODP_PACKET_INVALID)
+	packet_compare_data(pkt, ref);
+	odp_packet_free(ref);
+	odp_packet_free(pkt);
+
+	/* Avoid to create too large packets with concat */
+	pool = odp_packet_pool(test_packet);
+
+	pkt  = odp_packet_copy(test_packet, pool);
+	pkt2 = odp_packet_copy(test_packet, pool);
+	pkt3 = odp_packet_copy(test_packet, pool);
+	CU_ASSERT_FATAL(pkt  != ODP_PACKET_INVALID)
+	CU_ASSERT_FATAL(pkt2 != ODP_PACKET_INVALID)
+	CU_ASSERT_FATAL(pkt3 != ODP_PACKET_INVALID)
+	ret = odp_packet_concat(&pkt3, pkt2);
+	CU_ASSERT_FATAL(ret >= 0);
+	ret = odp_packet_concat(&pkt3, pkt);
+	CU_ASSERT_FATAL(ret >= 0);
+
+	pkt  = odp_packet_copy(test_packet, pool);
+	pkt2 = odp_packet_copy(test_packet, pool);
+	CU_ASSERT_FATAL(pkt  != ODP_PACKET_INVALID)
+	CU_ASSERT_FATAL(pkt2 != ODP_PACKET_INVALID)
+	ref = odp_packet_ref_pkt(pkt, 0, pkt2);
+	CU_ASSERT_FATAL(ref != ODP_PACKET_INVALID)
+	pkt2 = odp_packet_copy(test_packet, pool);
+	CU_ASSERT_FATAL(pkt2 != ODP_PACKET_INVALID)
+	ref2 = odp_packet_ref_pkt(ref, 0, pkt2);
+	CU_ASSERT_FATAL(ref2 != ODP_PACKET_INVALID)
+	packet_compare_data(pkt3, ref2);
+
+	/* Try print function on a reference */
+	odp_packet_print(ref2);
+
+	odp_packet_free(ref);
+	odp_packet_free(ref2);
+	odp_packet_free(pkt);
+	odp_packet_free(pkt3);
+
+	/* Test has_ref, unshared_len, lengths, etc */
 	base_pkt = odp_packet_copy(test_packet, odp_packet_pool(test_packet));
-	base_hr = odp_packet_headroom(base_pkt);
-	pkt_len  = odp_packet_len(test_packet);
 	CU_ASSERT_FATAL(base_pkt != ODP_PACKET_INVALID);
+	base_hr = odp_packet_headroom(base_pkt);
+	pkt_len = odp_packet_len(test_packet);
 
 	segmented_base_pkt =
 		odp_packet_copy(segmented_test_packet,


### PR DESCRIPTION
Current zero copy reference implementation introduced multiple issues:
  * segment pointers and length were not set correctly, but were
    left to NULL
  * reference counting has a race condition which causes random
    assert failures also with non-reference packets
  * there's larger than expected performance drop with
    non-reference packets
  * the first segment of a reference was zero bytes long, which
    is possible by the API but is unusual for users

This patch set re-implements segmentation, so that zero-copy references may be implemented correctly, efficiently and so that non-reference packets do not see much difference in performance or complexity.

Non-reference packet performance (l2fwd packet rate vs current master) is increased 5-15% depending on CPU count, which brings performance close to what it was before.
