### PR TITLE
[PATCH v7] linux-gen: system: correctly set CPU frequency

### DIFF
--- a/platform/linux-generic/arch/arm/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/arm/odp_sysinfo_parse.c
@@ -23,11 +23,6 @@ int cpuinfo_parser(FILE *file ODP_UNUSED, system_info_t *sysinfo)
 	return 0;
 }
 
-uint64_t odp_cpu_hz_current(int id ODP_UNUSED)
-{
-	return 0;
-}
-
 void sys_info_print_arch(void)
 {
 }

--- a/platform/linux-generic/arch/default/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/default/odp_sysinfo_parse.c
@@ -23,11 +23,6 @@ int cpuinfo_parser(FILE *file ODP_UNUSED, system_info_t *sysinfo)
 	return 0;
 }
 
-uint64_t odp_cpu_hz_current(int id ODP_UNUSED)
-{
-	return 0;
-}
-
 void sys_info_print_arch(void)
 {
 }

--- a/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
@@ -60,11 +60,6 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 	return 0;
 }
 
-uint64_t odp_cpu_hz_current(int id ODP_UNUSED)
-{
-	return 0;
-}
-
 void sys_info_print_arch(void)
 {
 }

--- a/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
@@ -59,11 +59,6 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 	return 0;
 }
 
-uint64_t odp_cpu_hz_current(int id ODP_UNUSED)
-{
-	return 0;
-}
-
 void sys_info_print_arch(void)
 {
 }

--- a/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
@@ -41,42 +41,6 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 	return 0;
 }
 
-uint64_t odp_cpu_hz_current(int id)
-{
-	char str[1024];
-	FILE *file;
-	int cpu;
-	char *pos;
-	double mhz = 0.0;
-
-	file = fopen("/proc/cpuinfo", "rt");
-
-	/* find the correct processor instance */
-	while (fgets(str, sizeof(str), file) != NULL) {
-		pos = strstr(str, "processor");
-		if (pos) {
-			if (sscanf(pos, "processor : %d", &cpu) == 1)
-				if (cpu == id)
-					break;
-		}
-	}
-
-	/* extract the cpu current speed */
-	while (fgets(str, sizeof(str), file) != NULL) {
-		pos = strstr(str, "cpu MHz");
-		if (pos) {
-			if (sscanf(pos, "cpu MHz : %lf", &mhz) == 1)
-				break;
-		}
-	}
-
-	fclose(file);
-	if (mhz)
-		return (uint64_t)(mhz * 1000000.0);
-
-	return 0;
-}
-
 void sys_info_print_arch(void)
 {
 	cpu_flags_print_all();

--- a/platform/linux-generic/include/odp_internal.h
+++ b/platform/linux-generic/include/odp_internal.h
@@ -131,6 +131,7 @@ int _odp_ishm_term_global(void);
 int _odp_ishm_term_local(void);
 
 int cpuinfo_parser(FILE *file, system_info_t *sysinfo);
+uint64_t odp_cpufreq_id(const char *filename, int id);
 uint64_t odp_cpu_hz_current(int id);
 void sys_info_print_arch(void);
 

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -261,6 +261,30 @@ static char *get_hugepage_dir(uint64_t hugepage_sz)
 }
 
 /*
+ * Analysis of /sys/devices/system/cpu/cpu%d/cpufreq/ files
+ */
+uint64_t odp_cpufreq_id(const char *filename, int id)
+{
+	char path[256], buffer[256], *endptr = NULL;
+	FILE *file;
+	uint64_t ret = 0;
+
+	snprintf(path, sizeof(path),
+		 "/sys/devices/system/cpu/cpu%d/cpufreq/%s", id, filename);
+
+	file = fopen(path, "r");
+	if (file == NULL)
+		return ret;
+
+	if (fgets(buffer, sizeof(buffer), file) != NULL)
+		ret = strtoull(buffer, &endptr, 0) * 1000;
+
+	fclose(file);
+
+	return ret;
+}
+
+/*
  * Analysis of /sys/devices/system/cpu/ files
  */
 static int systemcpu(system_info_t *sysinfo)
@@ -310,6 +334,7 @@ static int system_hp(hugepage_info_t *hugeinfo)
  */
 int odp_system_info_init(void)
 {
+	int i;
 	FILE  *file;
 
 	memset(&odp_global_data.system_info, 0, sizeof(system_info_t));
@@ -325,6 +350,13 @@ int odp_system_info_init(void)
 	cpuinfo_parser(file, &odp_global_data.system_info);
 
 	fclose(file);
+
+	for (i = 0; i < MAX_CPU_NUMBER; i++) {
+		uint64_t cpu_hz_max = odp_cpufreq_id("cpuinfo_max_freq", i);
+
+		if (cpu_hz_max)
+			odp_global_data.system_info.cpu_hz_max[i] = cpu_hz_max;
+	}
 
 	if (systemcpu(&odp_global_data.system_info)) {
 		ODP_ERR("systemcpu failed\n");
@@ -351,6 +383,11 @@ int odp_system_info_term(void)
  * Public access functions
  *************************
  */
+uint64_t odp_cpu_hz_current(int id)
+{
+	return odp_cpufreq_id("cpuinfo_cur_freq", id);
+}
+
 uint64_t odp_cpu_hz(void)
 {
 	int id = sched_getcpu();


### PR DESCRIPTION
When CPU frequency info under /sys is available,
use the real value instead of default value.

Signed-off-by: Kelvin Cheung <keguang.zhang@gmail.com>
Signed-off-by: Keguang Zhang <keguang.zhang@spreadtrum.com>