### PR TITLE
[PATCH API-NEXT v1] api: ipsec: rename odp_ipsec_mtu_update to follow odp_ipsec_sa_* pattern

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -710,7 +710,7 @@ typedef struct odp_ipsec_sa_param_t {
 			 *
 			 *  This is the maximum length of IP packets that
 			 *  outbound IPSEC operations may produce. The value may
-			 *  be updated later with odp_ipsec_mtu_update().
+			 *  be updated later with odp_ipsec_sa_mtu_update().
 			 */
 			uint32_t mtu;
 
@@ -1477,7 +1477,7 @@ int odp_ipsec_status(odp_ipsec_status_t *status, odp_event_t event);
  * @retval 0      On success
  * @retval <0     On failure
  */
-int odp_ipsec_mtu_update(odp_ipsec_sa_t sa, uint32_t mtu);
+int odp_ipsec_sa_mtu_update(odp_ipsec_sa_t sa, uint32_t mtu);
 
 /**
  * Get user defined SA context pointer

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -147,7 +147,7 @@ int odp_ipsec_status(odp_ipsec_status_t *status, odp_event_t event)
 	return -1;
 }
 
-int odp_ipsec_mtu_update(odp_ipsec_sa_t sa, uint32_t mtu)
+int odp_ipsec_sa_mtu_update(odp_ipsec_sa_t sa, uint32_t mtu)
 {
 	(void)sa;
 	(void)mtu;


### PR DESCRIPTION
All SA-related functions use odp_ipsec_sa_ prefix, except
odp_ipsec_mtu_update(). Rename this function to follow this pattern.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>