### PR TITLE
[PATCH CLOUD-DEV v2] linux-gen: buffer: remove meta data of odp_buffer_hdr_t

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -276,9 +276,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   pool/generic.c \
 			   pool/subsystem.c \
 			   odp_pkt_queue.c \
-			   odp_queue.c \
 			   odp_queue_if.c \
-			   odp_queue_scalable.c \
 			   odp_rwlock.c \
 			   odp_rwlock_recursive.c \
 			   odp_schedule_if.c \
@@ -326,6 +324,12 @@ if ARCH_IS_X86
 __LIB__libodp_linux_la_SOURCES += arch/x86/cpu_flags.c \
 				  arch/x86/odp_cpu_arch.c \
 				  arch/x86/odp_sysinfo_parse.c
+endif
+
+if ODP_SCHEDULE_SCALABLE
+__LIB__libodp_linux_la_SOURCES += odp_queue_scalable.c
+else
+__LIB__libodp_linux_la_SOURCES += odp_queue.c
 endif
 
 if HAVE_PCAP

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -50,10 +50,6 @@ struct odp_buffer_hdr_t {
 	/* Pool type */
 	int8_t    type;
 
-	/* Burst counts */
-	uint8_t   burst_num;
-	uint8_t   burst_first;
-
 	/* Segment count */
 	uint8_t   segcount;
 
@@ -63,9 +59,6 @@ struct odp_buffer_hdr_t {
 		uint8_t  *data;
 		uint32_t  len;
 	} seg[CONFIG_PACKET_MAX_SEGS];
-
-	/* Next buf in a list */
-	struct odp_buffer_hdr_t *next;
 
 	/* User context pointer or u64 */
 	union {
@@ -86,9 +79,17 @@ struct odp_buffer_hdr_t {
 	/* Event subtype. Should be ODP_EVENT_NO_SUBTYPE except packets. */
 	int8_t    event_subtype;
 
+#ifndef ODP_SCHEDULE_SCALABLE
+	/* Burst counts */
+	uint8_t   burst_num;
+	uint8_t   burst_first;
+
+	/* Next buf in a list */
+	struct odp_buffer_hdr_t *next;
+
 	/* Burst table */
 	struct odp_buffer_hdr_t *burst[BUFFER_BURST_SIZE];
-
+#endif
 	/* Used only if _ODP_PKTIO_IPC is set.
 	 * ipc mapped process can not walk over pointers,
 	 * offset has to be used */


### PR DESCRIPTION
Removes 152 bytes for linux-generic from odp_buffer_hdr_t.
The size of the meta data was 6 cache lines for linux-generic.
With this change the size of the meta data is 4 cache lines for
linux-generic.

Signed-off-by: Kevin Wang <kevin.wang@arm.com>