### PR TITLE
[PATCH v1] doc: helper: add missing doxygen to avoid warnings

### DIFF
--- a/helper/include/odp/helper/ip.h
+++ b/helper/include/odp/helper/ip.h
@@ -95,6 +95,17 @@ typedef struct ODP_PACKED {
 ODP_STATIC_ASSERT(sizeof(odph_ipv4hdr_t) == ODPH_IPV4HDR_LEN,
 		  "ODPH_IPV4HDR_T__SIZE_ERROR");
 
+/**
+ * Calculate IPv4 header checksum
+ *
+ * @param pkt         The packet to be checksummed
+ * @param offset      Offset into pkt of start of IP header
+ * @param ip          Pointer to IPv4 header to be checksummed
+ * @param[out] chksum Field to receive checksum results
+ *
+ * @retval 0  On success
+ * @retval <0 On failure
+ */
 static inline int odph_ipv4_csum(odp_packet_t pkt,
 				 uint32_t offset,
 				 odph_ipv4hdr_t *ip,

--- a/helper/include/odph_list_internal.h
+++ b/helper/include/odph_list_internal.h
@@ -18,18 +18,30 @@
 extern "C" {
 #endif
 
+/** List object */
 typedef struct odph_list_object {
-	struct odph_list_object *next, *prev;
+	/** Next element in list */
+	struct odph_list_object *next;
+
+	/** Previous element in list */
+	struct odph_list_object *prev;
 } odph_list_object;
 
+/** Head of list */
 typedef odph_list_object odph_list_head;
 
+/**
+ * @internal Intiailize list head element
+ *
+ * @param list List object to be initialized
+ */
 static inline void ODPH_INIT_LIST_HEAD(odph_list_object *list)
 {
 	list->next = list;
 	list->prev = list;
 }
 
+/** @internal Inline function @param new @param prev @param next */
 static inline void __odph_list_add(odph_list_object *new,
 				   odph_list_object *prev,
 				   odph_list_object *next)
@@ -40,17 +52,20 @@ static inline void __odph_list_add(odph_list_object *new,
 	prev->next = new;
 }
 
+/** @internal Inline function @param new @param head */
 static inline void odph_list_add(odph_list_object *new, odph_list_object *head)
 {
 	__odph_list_add(new, head, head->next);
 }
 
+/** @internal Inline function @param new @param head */
 static inline void odph_list_add_tail(struct odph_list_object *new,
 				      odph_list_object *head)
 {
 	__odph_list_add(new, head->prev, head);
 }
 
+/** @internal Inline function @param prev @param next */
 static inline void __odph_list_del(struct odph_list_object *prev,
 				   odph_list_object *next)
 {
@@ -58,20 +73,24 @@ static inline void __odph_list_del(struct odph_list_object *prev,
 	prev->next = next;
 }
 
+/** @internal Inline function @param entry */
 static inline void odph_list_del(struct odph_list_object *entry)
 {
 	__odph_list_del(entry->prev, entry->next);
 	ODPH_INIT_LIST_HEAD(entry);
 }
 
+/** @internal Inline function @param head @return */
 static inline int odph_list_empty(const struct odph_list_object *head)
 {
 	return head->next == head;
 }
 
+/** @internal */
 #define container_of(ptr, type, list_node) \
 		((type *)(void *)((char *)ptr - offsetof(type, list_node)))
 
+/** @internal */
 #define ODPH_LIST_FOR_EACH(pos, list_head, type, list_node) \
 	for (pos = container_of((list_head)->next, type, list_node); \
 		&pos->list_node != (list_head); \
@@ -82,4 +101,3 @@ static inline int odph_list_empty(const struct odph_list_object *head)
 #endif
 
 #endif
-


### PR DESCRIPTION
The latest version of Doxygen requires every struct and field to be
documented, so add missing documentation to helper files to avoid
superfluous warnings.

This resolves Bug https://bugs.linaro.org/show_bug.cgi?id=3238

Signed-off-by: Bill Fischofer <bill.fischofer@linaro.org>