### PR TITLE
[PATCH v2] travis: doxygen 1.8.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -247,8 +247,8 @@ jobs:
                           # doxygen does not trap on warnings, check for them here.
                           - ./bootstrap
                           - ./configure
-                          - make doxygen-doc |tee doxygen.log
-                          - fgrep -rvq warning ./doxygen.log
+                          - make doxygen-doc 2>&1 |tee doxygen.log
+                          - fgrep -rq warning ./doxygen.log && false
                 - stage: test
                   env: TEST=checkpatch
                   compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ cache:
                 - dpdk
                 - netmap
                 - $HOME/cunit-install
+                - $HOME/doxygen-install
 
 env:
         - CONF=""
@@ -237,13 +238,17 @@ jobs:
                   install:
                           - true
                   script:
-                          - wget https://github.com/doxygen/doxygen/archive/Release_1_8_13.tar.gz
-                          - tar xpvf Release_1_8_13.tar.gz
-                          - pushd doxygen-Release_1_8_13
-                          - cmake -DCMAKE_INSTALL_PREFIX=/usr .
-                          - sudo make install
-                          - popd
+                          - |
+                            if [ ! -f "$HOME/doxygen-install/bin/doxygen" ]; then
+                              wget https://github.com/doxygen/doxygen/archive/Release_1_8_13.tar.gz
+                              tar xpvf Release_1_8_13.tar.gz
+                              pushd doxygen-Release_1_8_13
+                              cmake -DCMAKE_INSTALL_PREFIX=$HOME/doxygen-install .
+                              make install
+                              popd
+                            fi
 
+                          - export PATH=$HOME/doxygen-install/bin:$PATH
                           # doxygen does not trap on warnings, check for them here.
                           - ./bootstrap
                           - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ addons:
                 packages:
                         - gcc
                         - clang-3.8
-                        - automake autoconf libtool libssl-dev graphviz mscgen doxygen
+                        - automake autoconf libtool libssl-dev graphviz mscgen
                         - libpcap-dev
 #        coverity_scan:
 #                project:
@@ -237,6 +237,13 @@ jobs:
                   install:
                           - true
                   script:
+                          - wget https://github.com/doxygen/doxygen/archive/Release_1_8_13.tar.gz
+                          - tar xpvf Release_1_8_13.tar.gz
+                          - pushd doxygen-Release_1_8_13
+                          - cmake -DCMAKE_INSTALL_PREFIX=/usr .
+                          - sudo make install
+                          - popd
+
                           # doxygen does not trap on warnings, check for them here.
                           - ./bootstrap
                           - ./configure


### PR DESCRIPTION
Update doxygen to 1.8.13

After we fix warnings we can threat warnings as errors. That option is available only in later doxygen releases.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>