### PR TITLE
[PATCH API-NEXT v1] linux-generic: fix GCC7 build error in sched_cb_pktin_poll_one

### DIFF
--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -702,12 +702,13 @@ int sched_cb_pktin_poll_one(int pktio_index,
 		if (odp_unlikely(pkt_hdr->p.input_flags.dst_queue)) {
 			queue = pkt_hdr->dst_queue;
 			buf_hdr = packet_to_buf_hdr(pkt);
-			if (queue_fn->enq_multi(queue, &buf_hdr, 1) < 0)
+			if (queue_fn->enq_multi(queue, &buf_hdr, 1) < 0) {
 				/* Queue full? */
 				odp_packet_free(pkt);
 				__atomic_fetch_add(&entry->s.stats.in_discards,
 						   1,
 						   __ATOMIC_RELAXED);
+			}
 		} else {
 			evt_tbl[num_rx++] = odp_packet_to_event(pkt);
 		}


### PR DESCRIPTION
Resolve Bug https://bugs.linaro.org/show_bug.cgi?id=3246 by
adding missing curly braces around if-clause.

For builds which don't flag this as an error, the resulting
build would be functional but with degraded performance.

Signed-off-by: Ola Liljedahl <ola.liljedahl@arm.com>
Reviewed-by: Honnappa Nagarahalli <honnappa.nagarahalli@arm.com>