### PR TITLE
[PATCH v1] configure: "best effort" approach for CUnit and validation tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -214,7 +214,6 @@ AM_CONDITIONAL([test_installdir], [test "x$testdir" != "xno"])
 # Set conditionals as computed within platform specific files
 ##########################################################################
 AM_CONDITIONAL([SDK_INSTALL_PATH_], [test "x${SDK_INSTALL_PATH_}" = "x1"])
-AM_CONDITIONAL([cunit_support], [test x$cunit_support = xyes ])
 AM_CONDITIONAL([HAVE_DOXYGEN], [test "x${DOXYGEN}" = "xdoxygen"])
 AM_CONDITIONAL([user_guide], [test "x${user_guides}" = "xyes" ])
 AM_CONDITIONAL([HAVE_MSCGEN], [test "x${MSCGEN}" = "xmscgen"])

--- a/test/common_plat/m4/validation.m4
+++ b/test/common_plat/m4/validation.m4
@@ -4,21 +4,29 @@
 AC_ARG_ENABLE([test_vald],
     [AS_HELP_STRING([--enable-test-vald], [run test in test/validation])],
     [test_vald=$enableval],
-    [test_vald=yes])
-AM_CONDITIONAL([test_vald], [test x$test_vald = xyes ])
+    [test_vald=check])
 
 ##########################################################################
 # Check for CUnit availability
 ##########################################################################
 cunit_support=$test_vald
-AS_IF([test "x$cunit_support" = "xyes"],
-      [PKG_CHECK_MODULES([CUNIT], [cunit], [],
+AS_IF([test "x$cunit_support" != "xno"],
+      [PKG_CHECK_MODULES([CUNIT], [cunit], [cunit_support=yes],
       [AC_MSG_WARN([pkg-config could not find CUnit, guessing])
-    AC_CHECK_HEADERS([CUnit/Basic.h], [],
-        [AC_MSG_ERROR(["can't find CUnit headers"])])
-    AC_CHECK_LIB([cunit],[CU_get_error], [CUNIT_LIBS="-lcunit"],
-        [AC_MSG_ERROR([CUnit libraries required])])
+    cunit_support=yes
+    AC_CHECK_HEADERS([CUnit/Basic.h], [], [cunit_support=no])
+    AC_CHECK_LIB([cunit], [CU_get_error], [CUNIT_LIBS="-lcunit"],
+		 [cunit_support=no])
 ])])
+
+AS_IF([test "x$test_vald" = "xyes" -a "x$cunit_support" = "xno"],
+      [AC_MSG_ERROR([Validation testsuite requested, but CUnit was not found])],
+      [test "x$test_vald" = "xcheck" -a "x$cunit_support" = "xno"],
+      [AC_MSG_WARN([CUnit was not found, disabling validation testsuite])
+       test_vald=no])
+
+AM_CONDITIONAL([cunit_support], [test "x$cunit_support" = "xyes"])
+AM_CONDITIONAL([test_vald], [test "x$test_vald" = "xyes"])
 
 AC_SUBST([CUNIT_CFLAGS])
 AC_SUBST([CUNIT_LIBS])


### PR DESCRIPTION
Allow configure to succeed (by disabling validation testsuite), if CUnit
library was not found or if user did not specify --enable-test-vald
explicitly).

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>