### PR TITLE
[PATCH v1] linux-generic: packet: add missing doxygen from inline func

### DIFF
--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -157,6 +157,7 @@ static inline void _odp_packet_prefetch(odp_packet_t pkt, uint32_t offset,
 	(void)pkt; (void)offset; (void)len;
 }
 
+/** @internal Inline function @param pkt @return */
 static inline odp_buffer_t packet_to_buffer(odp_packet_t pkt)
 {
 	return (odp_buffer_t)pkt;


### PR DESCRIPTION
Add missing doxygen for internal function packet_to_buffer
to avoid warnings under latest doxygen.

This fixes Bug https://bugs.linaro.org/show_bug.cgi?id=3262

Signed-off-by: Bill Fischofer <bill.fischofer@linaro.org>