### PR TITLE
[PATCH v1] linux-gen: drop unused _odp_packet_cmp_data() function

### DIFF
--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -321,9 +321,6 @@ int _odp_cls_parse(odp_packet_hdr_t *pkt_hdr, const uint8_t *parseptr);
 int _odp_packet_set_data(odp_packet_t pkt, uint32_t offset,
 			 uint8_t c, uint32_t len);
 
-int _odp_packet_cmp_data(odp_packet_t pkt, uint32_t offset,
-			 const void *s, uint32_t len);
-
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1642,32 +1642,6 @@ int _odp_packet_set_data(odp_packet_t pkt, uint32_t offset,
 	return 0;
 }
 
-int _odp_packet_cmp_data(odp_packet_t pkt, uint32_t offset,
-			 const void *s, uint32_t len)
-{
-	const uint8_t *ptr = s;
-	void *mapaddr;
-	uint32_t seglen = 0; /* GCC */
-	uint32_t cmplen;
-	int ret;
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-
-	ODP_ASSERT(offset + len <= pkt_hdr->frame_len);
-
-	while (len > 0) {
-		mapaddr = packet_map(pkt_hdr, offset, &seglen, NULL);
-		cmplen = len > seglen ? seglen : len;
-		ret = memcmp(mapaddr, ptr, cmplen);
-		if (ret != 0)
-			return ret;
-		offset  += cmplen;
-		len     -= cmplen;
-		ptr     += cmplen;
-	}
-
-	return 0;
-}
-
 /*
  *
  * Debugging


### PR DESCRIPTION
Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>

This is to fix https://bugs.linaro.org/show_bug.cgi?id=3241