### PR TITLE
[PATCH v1] test: l2fwd script: run generator on a single core

### DIFF
--- a/test/common_plat/performance/odp_l2fwd_run.sh
+++ b/test/common_plat/performance/odp_l2fwd_run.sh
@@ -66,12 +66,10 @@ run_l2fwd()
 		exit 1
 	fi
 
-	# Max 4 workers
-	# @todo: ensure that generator and l2fwd workers are not allocated to
-	# the same CPUs
+	# Run generator with one worker
 	(odp_generator${EXEEXT} --interval $FLOOD_MODE -I $IF0 \
 			--srcip 192.168.0.1 --dstip 192.168.0.2 \
-			-m u -w 4 2>&1 > /dev/null) \
+			-m u -w 1 2>&1 > /dev/null) \
 			2>&1 > /dev/null &
 
 	GEN_PID=$!


### PR DESCRIPTION
Run packet generator on a single core to minimize the penalty from running
generator and l2fwd applications on overlapping cores (both use
odp_cpumask_default_worker()). On a generic server this change increases
packet rate by ~40X.

Fixes https://bugs.linaro.org/show_bug.cgi?id=2407

Signed-off-by: Matias Elo <matias.elo@nokia.com>