### PR TITLE
[PATCH v1] tests: fix validation tests being skipped by default

### DIFF
--- a/test/common_plat/m4/validation.m4
+++ b/test/common_plat/m4/validation.m4
@@ -23,7 +23,8 @@ AS_IF([test "x$test_vald" = "xyes" -a "x$cunit_support" = "xno"],
       [AC_MSG_ERROR([Validation testsuite requested, but CUnit was not found])],
       [test "x$test_vald" = "xcheck" -a "x$cunit_support" = "xno"],
       [AC_MSG_WARN([CUnit was not found, disabling validation testsuite])
-       test_vald=no])
+       test_vald=no],
+      [test_vald=yes])
 
 AM_CONDITIONAL([cunit_support], [test "x$cunit_support" = "xyes"])
 AM_CONDITIONAL([test_vald], [test "x$test_vald" = "xyes"])


### PR DESCRIPTION
After [d091f2176a28 configure: "best effort" approach for CUnit and
validation tests] by default validation tests will get skipped by
default because test_vald variable will remain set to check instead of
yes. Update it to yes, if it was not set and CUnit was found.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>