### PR TITLE
[PATCH v1] travis: typo to call dynamic executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -200,7 +200,7 @@ script:
         - echo "Static link.."
         - ${CC} ${CFLAGS} ${OLDPWD}/example/hello/odp_hello.c -o odp_hello_inst_static `PKG_CONFIG_PATH=${HOME}/odp-install/lib/pkgconfig:${PKG_CONFIG_PATH} pkg-config --cflags --libs libodp-linux --static` -static
         - if [ -z "$CROSS_ARCH" ] ; then
-          LD_LIBRARY_PATH="${HOME}/odp-install/lib:$LD_LIBRARY_PATH" ./odp_hello_inst ;
+          LD_LIBRARY_PATH="${HOME}/odp-install/lib:$LD_LIBRARY_PATH" ./odp_hello_inst_dynamic ;
           ./odp_hello_inst_static ;
           fi
         - popd


### PR DESCRIPTION
we changed name for dynamic executable on compile
line but did not change it on execute line.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>