### PR TITLE
[PATCH API-NEXT v1] linux-gen: fix api-next merge conflict

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -195,22 +195,6 @@ noinst_HEADERS = \
 		  ${srcdir}/include/protocols/thash.h \
 		  ${srcdir}/include/protocols/udp.h
 
-if ARCH_IS_ARM
-noinst_HEADERS += ${srcdir}/arch/arm/odp_atomic.h \
-		  ${srcdir}/arch/arm/odp_cpu.h \
-		  ${srcdir}/arch/arm/odp_cpu_idling.h \
-		  ${srcdir}/arch/arm/odp_llsc.h
-endif
-if ARCH_IS_MIPS64
-noinst_HEADERS += ${srcdir}/arch/mips64/odp_cpu.h
-endif
-if ARCH_IS_POWERPC
-noinst_HEADERS += ${srcdir}/arch/powerpc/odp_cpu.h
-endif
-if ARCH_IS_X86
-noinst_HEADERS += ${srcdir}/arch/x86/odp_cpu.h
-endif
-
 __LIB__libodp_linux_la_SOURCES = \
 			   _fdserver.c \
 			   _ishm.c \


### PR DESCRIPTION
automerging of commit "052d268793"
    linux-gen: deduplicate arch-specific files
was wrong, fix it here.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>