### PR TITLE
[PATCH v1] tests: fix disabling of validation tests

### DIFF
--- a/test/common_plat/m4/validation.m4
+++ b/test/common_plat/m4/validation.m4
@@ -24,7 +24,7 @@ AS_IF([test "x$test_vald" = "xyes" -a "x$cunit_support" = "xno"],
       [test "x$test_vald" = "xcheck" -a "x$cunit_support" = "xno"],
       [AC_MSG_WARN([CUnit was not found, disabling validation testsuite])
        test_vald=no],
-      [test_vald=yes])
+      [test "x$test_vald" != "xno"], [test_vald=yes])
 
 AM_CONDITIONAL([cunit_support], [test "x$cunit_support" = "xyes"])
 AM_CONDITIONAL([test_vald], [test "x$test_vald" = "xyes"])


### PR DESCRIPTION
Fix for the fix...
[b4d17b1f6807 tests: fix validation tests being skipped by default]
attempted to fix tests being disabled by default, but in attempt to do
so just forced them to be enabled even if they are forcibly disabled by
configure option. Update conditions to really enable testsuite if it was
not disabled.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>