### PR TITLE
[PATCH v4] linux-gen: Use /proc/cpuinfo, if sysfs is not available to get cpu info.

### DIFF
--- a/platform/linux-generic/arch/default/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/default/odp_sysinfo_parse.c
@@ -26,3 +26,8 @@ int cpuinfo_parser(FILE *file ODP_UNUSED, system_info_t *sysinfo)
 void sys_info_print_arch(void)
 {
 }
+
+uint64_t odp_cpu_arch_hz_current(int id ODP_UNUSED)
+{
+	return 0;
+}

--- a/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/mips64/odp_sysinfo_parse.c
@@ -63,3 +63,8 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 void sys_info_print_arch(void)
 {
 }
+
+uint64_t odp_cpu_arch_hz_current(int id ODP_UNUSED)
+{
+	return 0;
+}

--- a/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/powerpc/odp_sysinfo_parse.c
@@ -62,3 +62,8 @@ int cpuinfo_parser(FILE *file, system_info_t *sysinfo)
 void sys_info_print_arch(void)
 {
 }
+
+uint64_t odp_cpu_arch_hz_current(int id ODP_UNUSED)
+{
+	return 0;
+}

--- a/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
@@ -46,7 +46,7 @@ void sys_info_print_arch(void)
 	cpu_flags_print_all();
 }
 
-uint64_t odp_cpu_arch_hz_current(int id ODP_UNUSED)
+uint64_t odp_cpu_arch_hz_current(int id)
 {
 	char str[1024];
 	FILE *file;

--- a/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
@@ -45,3 +45,39 @@ void sys_info_print_arch(void)
 {
 	cpu_flags_print_all();
 }
+
+uint64_t odp_cpu_arch_hz_current(int id ODP_UNUSED)
+{
+	char str[1024];
+	FILE *file;
+	int cpu;
+	char *pos;
+	double mhz = 0.0;
+
+	file = fopen("/proc/cpuinfo", "rt");
+
+	/* find the correct processor instance */
+	while (fgets(str, sizeof(str), file) != NULL) {
+		pos = strstr(str, "processor");
+		if (pos) {
+			if (sscanf(pos, "processor : %d", &cpu) == 1)
+				if (cpu == id)
+					break;
+		}
+	}
+
+	/* extract the cpu current speed */
+	while (fgets(str, sizeof(str), file) != NULL) {
+		pos = strstr(str, "cpu MHz");
+		if (pos) {
+			if (sscanf(pos, "cpu MHz : %lf", &mhz) == 1)
+				break;
+		}
+	}
+
+	fclose(file);
+	if (mhz)
+		return (uint64_t)(mhz * 1000000.0);
+
+	return 0;
+}

--- a/platform/linux-generic/include/odp_internal.h
+++ b/platform/linux-generic/include/odp_internal.h
@@ -133,6 +133,7 @@ int _odp_ishm_term_local(void);
 int cpuinfo_parser(FILE *file, system_info_t *sysinfo);
 uint64_t odp_cpufreq_id(const char *filename, int id);
 uint64_t odp_cpu_hz_current(int id);
+uint64_t odp_cpu_arch_hz_current(int id);
 void sys_info_print_arch(void);
 
 #ifdef __cplusplus

--- a/platform/linux-generic/odp_system_info.c
+++ b/platform/linux-generic/odp_system_info.c
@@ -385,7 +385,12 @@ int odp_system_info_term(void)
  */
 uint64_t odp_cpu_hz_current(int id)
 {
-	return odp_cpufreq_id("cpuinfo_cur_freq", id);
+	uint64_t cur_hz = odp_cpufreq_id("cpuinfo_cur_freq", id);
+
+	if (!cur_hz)
+		cur_hz = odp_cpu_arch_hz_current(id);
+
+	return cur_hz;
 }
 
 uint64_t odp_cpu_hz(void)


### PR DESCRIPTION
PR#171 broke some of the functionality we had on getting cpu speed.
This patch reverts parts of that commit adding a fallback when
/sys/devices/system/cpu/cpuX/cpufreq/ is not available.

Solves https://bugs.linaro.org/show_bug.cgi?id=3249

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>