### PR TITLE
[PATCH v1] linux-gen: Cleanup on printing system information

### DIFF
--- a/example/classifier/odp_classifier.c
+++ b/example/classifier/odp_classifier.c
@@ -879,18 +879,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
  */
 static void print_info(char *progname, appl_args_t *appl_args)
 {
-	printf("\n"
-			"ODP system info\n"
-			"---------------\n"
-			"ODP API version: %s\n"
-			"CPU model:       %s\n"
-			"CPU freq (hz):   %"PRIu64"\n"
-			"Cache line size: %i\n"
-			"CPU count:       %i\n"
-			"\n",
-			odp_version_api_str(), odp_cpu_model_str(),
-			odp_cpu_hz_max(), odp_sys_cache_line_size(),
-			odp_cpu_count());
+	odp_sys_info_print();
 
 	printf("Running ODP appl: \"%s\"\n"
 			"-----------------\n"

--- a/example/generator/odp_generator.c
+++ b/example/generator/odp_generator.c
@@ -1480,17 +1480,7 @@ static void print_info(char *progname, appl_args_t *appl_args)
 {
 	int i;
 
-	printf("\n"
-	       "ODP system info\n"
-	       "---------------\n"
-	       "ODP API version: %s\n"
-	       "CPU model:       %s\n"
-	       "CPU freq (hz):   %"PRIu64"\n"
-	       "Cache line size: %i\n"
-	       "CPU count:       %i\n"
-	       "\n",
-	       odp_version_api_str(), odp_cpu_model_str(), odp_cpu_hz_max(),
-	       odp_sys_cache_line_size(), odp_cpu_count());
+	odp_sys_info_print();
 
 	printf("Running ODP appl: \"%s\"\n"
 	       "-----------------\n"

--- a/example/ipsec/odp_ipsec.c
+++ b/example/ipsec/odp_ipsec.c
@@ -1540,17 +1540,7 @@ static void print_info(char *progname, appl_args_t *appl_args)
 {
 	int i;
 
-	printf("\n"
-	       "ODP system info\n"
-	       "---------------\n"
-	       "ODP API version: %s\n"
-	       "CPU model:       %s\n"
-	       "CPU freq (hz):   %"PRIu64"\n"
-	       "Cache line size: %i\n"
-	       "CPU count:       %i\n"
-	       "\n",
-	       odp_version_api_str(), odp_cpu_model_str(), odp_cpu_hz_max(),
-	       odp_sys_cache_line_size(), odp_cpu_count());
+	odp_sys_info_print();
 
 	printf("Running ODP appl: \"%s\"\n"
 	       "-----------------\n"

--- a/example/l3fwd/odp_l3fwd.c
+++ b/example/l3fwd/odp_l3fwd.c
@@ -652,19 +652,7 @@ static void print_info(char *progname, app_args_t *args)
 {
 	int i;
 
-	printf("\n"
-	       "ODP system info\n"
-	       "---------------\n"
-	       "ODP API version: %s\n"
-	       "ODP impl name:	 %s\n"
-	       "CPU model:       %s\n"
-	       "CPU freq (hz):   %" PRIu64 "\n"
-	       "Cache line size: %i\n"
-	       "CPU count:       %i\n"
-	       "\n",
-	       odp_version_api_str(), odp_version_impl_name(),
-	       odp_cpu_model_str(), odp_cpu_hz_max(),
-	       odp_sys_cache_line_size(), odp_cpu_count());
+	odp_sys_info_print();
 
 	printf("Running ODP appl: \"%s\"\n"
 	       "-----------------\n"

--- a/example/packet/odp_pktio.c
+++ b/example/packet/odp_pktio.c
@@ -673,17 +673,7 @@ static void print_info(char *progname, appl_args_t *appl_args)
 {
 	int i;
 
-	printf("\n"
-	       "ODP system info\n"
-	       "---------------\n"
-	       "ODP API version: %s\n"
-	       "CPU model:       %s\n"
-	       "CPU freq (hz):   %"PRIu64"\n"
-	       "Cache line size: %i\n"
-	       "CPU count:       %i\n"
-	       "\n",
-	       odp_version_api_str(), odp_cpu_model_str(), odp_cpu_hz_max(),
-	       odp_sys_cache_line_size(), odp_cpu_count());
+	odp_sys_info_print();
 
 	printf("Running ODP appl: \"%s\"\n"
 	       "-----------------\n"

--- a/example/switch/odp_switch.c
+++ b/example/switch/odp_switch.c
@@ -847,19 +847,7 @@ static void print_info(char *progname, appl_args_t *appl_args)
 {
 	unsigned i;
 
-	printf("\n"
-	       "ODP system info\n"
-	       "---------------\n"
-	       "ODP API version: %s\n"
-	       "ODP impl name:   %s\n"
-	       "CPU model:       %s\n"
-	       "CPU freq (hz):   %" PRIu64 "\n"
-	       "Cache line size: %i\n"
-	       "CPU count:       %i\n"
-	       "\n",
-	       odp_version_api_str(), odp_version_impl_name(),
-	       odp_cpu_model_str(), odp_cpu_hz_max(),
-	       odp_sys_cache_line_size(), odp_cpu_count());
+	odp_sys_info_print();
 
 	printf("Running ODP appl: \"%s\"\n"
 	       "-----------------\n"

--- a/example/timer/odp_timer_test.c
+++ b/example/timer/odp_timer_test.c
@@ -363,15 +363,7 @@ int main(int argc, char *argv[])
 	}
 
 	printf("\n");
-	printf("ODP system info\n");
-	printf("---------------\n");
-	printf("ODP API version: %s\n",        odp_version_api_str());
-	printf("CPU model:       %s\n",        odp_cpu_model_str());
-	printf("CPU freq (hz):   %"PRIu64"\n", odp_cpu_hz_max());
-	printf("Cache line size: %i\n",        odp_sys_cache_line_size());
-	printf("Max CPU count:   %i\n",        odp_cpu_count());
-
-	printf("\n");
+	odp_sys_info_print();
 
 	/* Reserve memory for test_globals_t from shared mem */
 	shm = odp_shm_reserve("shm_test_globals", sizeof(test_globals_t),

--- a/test/common_plat/performance/odp_bench_packet.c
+++ b/test/common_plat/performance/odp_bench_packet.c
@@ -1372,19 +1372,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
  */
 static void print_info(char *progname, appl_args_t *appl_args ODP_UNUSED)
 {
-	printf("\n"
-	       "ODP system info\n"
-	       "---------------\n"
-	       "ODP API version: %s\n"
-	       "ODP impl name:   %s\n"
-	       "CPU model:       %s\n"
-	       "CPU freq (hz):   %" PRIu64 "\n"
-	       "Cache line size: %i\n"
-	       "CPU count:       %i\n"
-	       "\n",
-	       odp_version_api_str(), odp_version_impl_name(),
-	       odp_cpu_model_str(), odp_cpu_hz_max(),
-	       odp_sys_cache_line_size(), odp_cpu_count());
+	odp_sys_info_print();
 
 	printf("Running ODP appl: \"%s\"\n"
 	       "-----------------\n", progname);

--- a/test/common_plat/performance/odp_l2fwd.c
+++ b/test/common_plat/performance/odp_l2fwd.c
@@ -1336,19 +1336,7 @@ static void print_info(char *progname, appl_args_t *appl_args)
 {
 	int i;
 
-	printf("\n"
-	       "ODP system info\n"
-	       "---------------\n"
-	       "ODP API version: %s\n"
-	       "ODP impl name:   %s\n"
-	       "CPU model:       %s\n"
-	       "CPU freq (hz):   %" PRIu64 "\n"
-	       "Cache line size: %i\n"
-	       "CPU count:       %i\n"
-	       "\n",
-	       odp_version_api_str(), odp_version_impl_name(),
-	       odp_cpu_model_str(), odp_cpu_hz_max(),
-	       odp_sys_cache_line_size(), odp_cpu_count());
+	odp_sys_info_print();
 
 	printf("Running ODP appl: \"%s\"\n"
 	       "-----------------\n"

--- a/test/common_plat/performance/odp_pktio_ordered.c
+++ b/test/common_plat/performance/odp_pktio_ordered.c
@@ -1034,19 +1034,7 @@ static void print_info(char *progname, appl_args_t *appl_args)
 {
 	int i;
 
-	printf("\n"
-	       "ODP system info\n"
-	       "---------------\n"
-	       "ODP API version: %s\n"
-	       "ODP impl name:   %s\n"
-	       "CPU model:       %s\n"
-	       "CPU freq (hz):   %" PRIu64 "\n"
-	       "Cache line size: %i\n"
-	       "CPU count:       %i\n"
-	       "\n",
-	       odp_version_api_str(), odp_version_impl_name(),
-	       odp_cpu_model_str(), odp_cpu_hz_max(),
-	       odp_sys_cache_line_size(), odp_cpu_count());
+	odp_sys_info_print();
 
 	printf("Running ODP appl: \"%s\"\n"
 	       "-----------------\n"

--- a/test/common_plat/performance/odp_scheduling.c
+++ b/test/common_plat/performance/odp_scheduling.c
@@ -831,17 +831,7 @@ int main(int argc, char *argv[])
 	}
 
 	printf("\n");
-	printf("ODP system info\n");
-	printf("---------------\n");
-	printf("ODP API version:  %s\n",        odp_version_api_str());
-	printf("ODP impl name:    %s\n",        odp_version_impl_name());
-	printf("ODP impl details: %s\n",        odp_version_impl_str());
-	printf("CPU model:        %s\n",        odp_cpu_model_str());
-	printf("CPU freq (hz):    %" PRIu64 "\n", odp_cpu_hz_max());
-	printf("Cache line size:  %i\n",        odp_sys_cache_line_size());
-	printf("Max CPU count:    %i\n",        odp_cpu_count());
-
-	printf("\n");
+	odp_sys_info_print();
 
 	/* Get default worker cpumask */
 	num_workers = odp_cpumask_default_worker(&cpumask, args.cpu_count);

--- a/test/linux-generic/pktio_ipc/ipc_common.c
+++ b/test/linux-generic/pktio_ipc/ipc_common.c
@@ -139,13 +139,7 @@ void parse_args(int argc, char *argv[])
  */
 void print_info(char *progname)
 {
-	printf("\n"
-	       "ODP system info\n"
-	       "---------------\n"
-	       "ODP API version: %s\n"
-	       "CPU model:       %s\n"
-	       "\n",
-	       odp_version_api_str(), odp_cpu_model_str());
+	odp_sys_info_print();
 
 	printf("Running ODP appl: \"%s\"\n"
 	       "-----------------\n"


### PR DESCRIPTION
Use unified odp_sys_info_print() instead of copying the same code
on every example.

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>