### PR TITLE
[PATCH v3] travis: fix netmap module loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,13 +167,15 @@ install:
 
 #	Netmap pktio
         - |
-          if [ -z "$CROSS_ARCH" -a ! -f "netmap/LINUX/netmap.ko" ]; then
-            git -c advice.detachedHead=false clone -q --depth=1 --single-branch --branch=v11.2 https://github.com/luigirizzo/netmap.git
-            pushd netmap/LINUX
-            ./configure
-            make
-            sudo insmod ./netmap.ko
-            popd
+          if [ -z "$CROSS_ARCH" ]; then
+            if [ ! -f "netmap/LINUX/netmap.ko" ]; then
+              git -c advice.detachedHead=false clone -q --depth=1 --single-branch --branch=v11.2 https://github.com/luigirizzo/netmap.git
+              pushd netmap/LINUX
+              ./configure
+              make
+              popd
+            fi
+            sudo insmod ./netmap/LINUX/netmap.ko
           fi
 
 script:


### PR DESCRIPTION
Travis script will insmod netmap.ko only it was rebuilt during this
session, which is wrong. Split the ifs, so that module loading does not
depend on the cache contents.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>