### PR TITLE
[PATCH v3] travis: build dpdk for general cpu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,6 +159,8 @@ install:
             make config T=${TARGET} O=${TARGET}
             pushd ${TARGET}
             sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config
+            cat .config |grep RTE_MACHINE
+            sed -ri 's,(CONFIG_RTE_MACHINE=).*,\1"snb",' .config
             popd
             make install T=${TARGET} EXTRA_CFLAGS="-fPIC"
             rm -r ./doc ./${TARGET}/app ./${TARGET}/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ cache:
         ccache: true
         pip: true
         directories:
-                - dpdk
+                #- dpdk
                 - netmap
                 - $HOME/cunit-install
                 - $HOME/doxygen-install


### PR DESCRIPTION
v2: define RTE_MACHINE in install stage, not on configure. There is really works.
---
1)
    disable cpu optimisations for code run in Travis env.
    By default dpdk uses -march=corei7-avx with generates
    specific instructions and execution fails with:
    Please check that RTE_MACHINE is set correctly.
    More info here:
    https://github.com/Linaro/odp/pull/218

2) disabling dpdk caching in Travis for now.