### PR TITLE
[PATCH v17] add sample shippable.yml and Dockerfile for Aarch64 builds

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -1,0 +1,45 @@
+language: c
+
+compiler:
+  - gcc
+  - clang
+
+env:
+  matrix:
+    - CONF=""
+    # - CONF="--disable-abi-compat"
+    # - CONF="--enable-schedule-sp"
+    # - CONF="--enable-schedule-iquery"
+    # - CONF="--enable-dpdk-zero-copy"
+    # - CROSS_ARCH="arm64"
+    # - CROSS_ARCH="armhf" CFLAGS="-march=armv7-a"
+    # - CROSS_ARCH="powerpc"
+    # - CROSS_ARCH="i386"
+  global:
+    # - PLACEHOLDER=""
+
+build:
+  pre_ci:
+    # use Dockerfile to install additional CI dependencies
+    - docker build -t=odp/dev ./scripts
+
+  # use image built in 'pre_ci' for CI job
+  pre_ci_boot:
+    image_name: odp/dev
+    image_tag: latest
+    pull: false
+    options:
+
+  ci:
+    - echo 1000 | sudo tee /proc/sys/vm/nr_hugepages
+    - sudo mkdir -p /mnt/huge
+    - sudo mount -t hugetlbfs nodev /mnt/huge
+    - mkdir -p /dev/shm/odp
+    - ./bootstrap
+    - ./configure --disable-test-perf
+    - make
+    - sudo env ODP_SHM_DIR=/dev/shm/odp make check
+
+  on_failure:
+    - cat config.log
+    - find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,24 @@
+FROM drydockaarch64/u16:v5.10.1
+
+RUN if $(sudo update-alternatives --list gcc); \
+      then sudo update-alternatives --remove-all gcc; \
+    fi
+
+RUN sudo apt-get update && sudo apt-get install -yy \
+  autoconf \
+  automake \
+  ccache \
+  clang-3.8 \
+  gcc-4.8 \
+  graphviz \
+  kmod \
+  mscgen \
+  libcunit1-dev \
+  libpcap-dev \
+  libssl-dev \
+  libtool \
+  linux-headers-`uname -r` \
+  ruby-dev
+
+RUN sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 10
+RUN sudo ln -s /usr/bin/clang-3.8 /usr/bin/clang


### PR DESCRIPTION
Adds shippable.yml config file for testing ODP builds on Aarch64 hardware using Shippable. This CI config also uses a Dockerfile to install additional dependencies on top of the standard Shippable Aarch64 image.