### PR TITLE
[PATCH v3] linux-gen: pool: select packet pool segment size at runtime

### DIFF
--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -71,7 +71,7 @@ struct odp_buffer_hdr_t {
 	/* --- 40 bytes --- */
 
 	/* Segments */
-	seg_entry_t seg[CONFIG_PACKET_MAX_SEGS];
+	seg_entry_t seg[CONFIG_PACKET_SEGS_PER_HDR];
 
 	/* Burst counts */
 	uint8_t   burst_num;
@@ -122,8 +122,8 @@ struct odp_buffer_hdr_t {
 	uint8_t data[0];
 } ODP_ALIGNED_CACHE;
 
-ODP_STATIC_ASSERT(CONFIG_PACKET_MAX_SEGS < 256,
-		  "CONFIG_PACKET_MAX_SEGS_TOO_LARGE");
+ODP_STATIC_ASSERT(CONFIG_PACKET_SEGS_PER_HDR < 256,
+		  "CONFIG_PACKET_SEGS_PER_HDR_TOO_LARGE");
 
 ODP_STATIC_ASSERT(BUFFER_BURST_SIZE < 256, "BUFFER_BURST_SIZE_TOO_LARGE");
 

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -75,7 +75,22 @@ extern "C" {
 /*
  * Maximum number of segments per packet
  */
-#define CONFIG_PACKET_MAX_SEGS 6
+#define CONFIG_PACKET_MAX_SEGS 255
+
+/*
+ * Packet segmentation disabled
+ */
+#define CONFIG_PACKET_SEG_DISABLED (CONFIG_PACKET_MAX_SEGS == 1)
+
+/*
+ * Number of segments stored in a packet header
+ */
+#define CONFIG_PACKET_SEGS_PER_HDR 6
+
+/*
+ * Maximum packet data length in bytes
+ */
+#define CONFIG_PACKET_MAX_LEN (64 * 1024)
 
 /*
  * Maximum packet segment size including head- and tailrooms

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -194,6 +194,7 @@ static inline seg_entry_t *seg_entry_last(odp_packet_hdr_t *hdr)
  */
 static inline void packet_init(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 {
+	pool_t *pool = pool_entry_from_hdl(pkt_hdr->buf_hdr.pool_hdl);
 	uint32_t seg_len;
 	int num = pkt_hdr->buf_hdr.segcount;
 
@@ -203,7 +204,7 @@ static inline void packet_init(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 	} else {
 		seg_entry_t *last;
 
-		seg_len = len - ((num - 1) * CONFIG_PACKET_MAX_SEG_LEN);
+		seg_len = len - ((num - 1) * pool->seg_len);
 
 		/* Last segment data length */
 		last      = seg_entry_last(pkt_hdr);
@@ -226,8 +227,7 @@ static inline void packet_init(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 	pkt_hdr->frame_len = len;
 	pkt_hdr->shared_len = 0;
 	pkt_hdr->headroom  = CONFIG_PACKET_HEADROOM;
-	pkt_hdr->tailroom  = CONFIG_PACKET_MAX_SEG_LEN - seg_len +
-			     CONFIG_PACKET_TAILROOM;
+	pkt_hdr->tailroom  = pool->seg_len - seg_len + CONFIG_PACKET_TAILROOM;
 
 	pkt_hdr->input = ODP_PKTIO_INVALID;
 }

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -197,7 +197,7 @@ static inline void packet_init(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 	uint32_t seg_len;
 	int num = pkt_hdr->buf_hdr.segcount;
 
-	if (odp_likely(CONFIG_PACKET_MAX_SEGS == 1 || num == 1)) {
+	if (odp_likely(CONFIG_PACKET_SEG_DISABLED || num == 1)) {
 		seg_len = len;
 		pkt_hdr->buf_hdr.seg[0].len = len;
 	} else {

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -60,9 +60,8 @@ typedef struct pool_t {
 	uint32_t         align;
 	uint32_t         headroom;
 	uint32_t         tailroom;
-	uint32_t         data_size;
+	uint32_t         seg_len;
 	uint32_t         max_len;
-	uint32_t         max_seg_len;
 	uint32_t         uarea_size;
 	uint32_t         block_size;
 	uint32_t         shm_size;

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2151,7 +2151,10 @@ odp_packet_t odp_packet_ref(odp_packet_t pkt, uint32_t offset)
 	link_hdr->buf_hdr.seg[0].len  = seg->len  - seg_offset;
 	buffer_ref_inc(seg->hdr);
 
-	for (i = 1; i < num_copy; i++) {
+	/* The 'CONFIG_PACKET_SEGS_PER_HDR > 1' condition is required to fix an
+	 * invalid error ('array subscript is above array bounds') thrown by
+	 * gcc (5.4.0). */
+	for (i = 1; CONFIG_PACKET_SEGS_PER_HDR > 1 && i < num_copy; i++) {
 		/* Update link header reference count */
 		if (idx == 0 && seg_is_link(hdr))
 			buffer_ref_inc((odp_buffer_hdr_t *)hdr);

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -476,8 +476,8 @@ static inline odp_packet_hdr_t *add_segments(odp_packet_hdr_t *pkt_hdr,
 	if (new_hdr == NULL)
 		return NULL;
 
-	seg_len = len - ((num - 1) * pool->max_seg_len);
-	offset  = pool->max_seg_len - seg_len;
+	seg_len = len - ((num - 1) * pool->seg_len);
+	offset  = pool->seg_len - seg_len;
 
 	if (head) {
 		/* add into the head*/
@@ -906,7 +906,7 @@ int odp_packet_reset(odp_packet_t pkt, uint32_t len)
 	pool_t *pool = pkt_hdr->buf_hdr.pool_ptr;
 	int num = pkt_hdr->buf_hdr.segcount;
 
-	if (odp_unlikely(len > (pool->max_seg_len * num)))
+	if (odp_unlikely(len > (pool->seg_len * num)))
 		return -1;
 
 	reset_seg(pkt_hdr, 0, num);

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -386,8 +386,8 @@ static odp_pool_t pool_create(const char *name, odp_pool_param_t *params,
 		tailroom    = CONFIG_PACKET_TAILROOM;
 		num         = params->pkt.num;
 		uarea_size  = params->pkt.uarea_size;
-		seg_len   = CONFIG_PACKET_MAX_SEG_LEN;
-		max_len     = CONFIG_PACKET_MAX_SEGS * seg_len;
+		seg_len     = CONFIG_PACKET_MAX_SEG_LEN;
+		max_len     = CONFIG_PACKET_MAX_LEN;
 		break;
 
 	case ODP_POOL_TIMEOUT:
@@ -882,7 +882,7 @@ int odp_pool_capability(odp_pool_capability_t *capa)
 
 	/* Packet pools */
 	capa->pkt.max_pools        = ODP_CONFIG_POOLS;
-	capa->pkt.max_len          = CONFIG_PACKET_MAX_SEGS * max_seg_len;
+	capa->pkt.max_len          = CONFIG_PACKET_MAX_LEN;
 	capa->pkt.max_num	   = CONFIG_POOL_MAX_NUM;
 	capa->pkt.min_headroom     = CONFIG_PACKET_HEADROOM;
 	capa->pkt.min_tailroom     = CONFIG_PACKET_TAILROOM;

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -174,7 +174,7 @@ static struct rte_mempool *mbuf_pool_create(const char *name,
 	}
 
 	num = pool_entry->num;
-	data_room_size = pool_entry->max_seg_len + CONFIG_PACKET_HEADROOM;
+	data_room_size = pool_entry->seg_len + CONFIG_PACKET_HEADROOM;
 	elt_size = sizeof(struct rte_mbuf) + (unsigned)data_room_size;
 	mbp_priv.mbuf_data_room_size = data_room_size;
 	mbp_priv.mbuf_priv_size = 0;
@@ -231,7 +231,7 @@ static int pool_dequeue_bulk(struct rte_mempool *mp, void **obj_table,
 	int pkts;
 	int i;
 
-	pkts = packet_alloc_multi(pool, pool_entry->max_seg_len, packet_tbl,
+	pkts = packet_alloc_multi(pool, pool_entry->seg_len, packet_tbl,
 				  num);
 
 	if (odp_unlikely(pkts != (int)num)) {
@@ -1230,7 +1230,7 @@ static int dpdk_open(odp_pktio_t id ODP_UNUSED,
 
 	data_room = rte_pktmbuf_data_room_size(pkt_dpdk->pkt_pool) -
 			RTE_PKTMBUF_HEADROOM;
-	pkt_dpdk->data_room = RTE_MIN(pool_entry->max_seg_len, data_room);
+	pkt_dpdk->data_room = RTE_MIN(pool_entry->seg_len, data_room);
 
 	/* Mbuf chaining not yet supported */
 	 pkt_dpdk->mtu = RTE_MIN(pkt_dpdk->mtu, pkt_dpdk->data_room);

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -350,7 +350,7 @@ static int netmap_open(odp_pktio_t id ODP_UNUSED, pktio_entry_t *pktio_entry,
 	pkt_nm->pool = pool;
 
 	/* max frame len taking into account the l2-offset */
-	pkt_nm->max_frame_len = CONFIG_PACKET_MAX_SEG_LEN;
+	pkt_nm->max_frame_len = pool_entry_from_hdl(pool)->max_len;
 
 	/* allow interface to be opened with or without the 'netmap:' prefix */
 	prefix = "netmap:";

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -357,7 +357,7 @@ static void mmap_fill_ring(struct ring *ring, odp_pool_t pool_hdl, int fanout)
 	pool = pool_entry_from_hdl(pool_hdl);
 
 	/* Frame has to capture full packet which can fit to the pool block.*/
-	ring->req.tp_frame_size = (pool->headroom + pool->data_size +
+	ring->req.tp_frame_size = (pool->headroom + pool->seg_len +
 				   pool->tailroom + TPACKET_HDRLEN +
 				   TPACKET_ALIGNMENT + + (pz - 1)) & (-pz);
 


### PR DESCRIPTION
This patch set modifies packet pool implementation to select segment size at runtime based on the pool parameters. After this patch set an application is able to create multiple packet pools with varying segment sizes.

V2:
- Added CONFIG_PACKET_SEG_DISABLED checks (Bill)

V3:
- Document gcc bug fix (Bill)
