### PR TITLE
[PATCH API-NEXT v4] api: pool subparameters

### DIFF
--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -195,113 +195,110 @@ typedef struct odp_pool_param_t {
 	/** Pool type */
 	int type;
 
-	/** Variant parameters for different pool types */
-	union {
-		/** Parameters for buffer pools */
-		struct {
-			/** Number of buffers in the pool */
-			uint32_t num;
+	/** Parameters for buffer pools */
+	struct {
+		/** Number of buffers in the pool */
+		uint32_t num;
 
-			/** Buffer size in bytes. The maximum number of bytes
-			    application will store in each buffer. */
-			uint32_t size;
+		/** Buffer size in bytes. The maximum number of bytes
+		 *  application will store in each buffer.
+		 */
+		uint32_t size;
 
-			/** Minimum buffer alignment in bytes. Valid values are
-			    powers of two. Use 0 for default alignment.
-			    Default will always be a multiple of 8. */
-			uint32_t align;
-		} buf;
+		/** Minimum buffer alignment in bytes. Valid values are
+		 *  powers of two. Use 0 for default alignment.
+		 *  Default will always be a multiple of 8.
+		 */
+		uint32_t align;
+	} buf;
 
-		/** Parameters for packet pools */
-		struct {
-			/** Minimum number of 'len' byte packets.
-			 *
-			 *  The pool must contain at least this many packets
-			 *  that are 'len' bytes or smaller. An implementation
-			 *  may round up the value, as long as the 'max_num'
-			 *  parameter below is not violated. The maximum value
-			 *  for this field is defined by pool capability
-			 *  pkt.max_num.
-			 */
-			uint32_t num;
+	/** Parameters for packet pools */
+	struct {
+		/** Minimum number of 'len' byte packets.
+		 *
+		 *  The pool must contain at least this many packets that are
+		 *  'len' bytes or smaller. An implementation may round up the
+		 *  value, as long as the 'max_num' parameter below is not
+		 *  violated. The maximum value for this field is defined by
+		 *  pool capability pkt.max_num.
+		 */
+		uint32_t num;
 
-			/** Maximum number of packets.
-			 *
-			 *  This is the maximum number of packets of any length
-			 *  that can be allocated from the pool. The maximum
-			 *  value is defined by pool capability pkt.max_num.
-			 *  Use 0 when there's no requirement for the maximum
-			 *  number of packets. The default value is 0.
-			 */
-			uint32_t max_num;
+		/** Maximum number of packets.
+		 *
+		 *  This is the maximum number of packets of any length that can
+		 *  be allocated from the pool. The maximum value is defined by
+		 *  pool capability pkt.max_num. Use 0 when there's no
+		 *  requirement for the maximum number of packets. The default
+		 *  value is 0.
+		 */
+		uint32_t max_num;
 
-			/** Minimum length of 'num' packets.
-			 *
-			 *  The pool must contain at least 'num' packets up to
-			 *  this packet length (1 ... 'len' bytes). The maximum
-			 *  value for this field is defined by pool capability
-			 *  pkt.max_len. Use 0 for default.
-			 */
-			uint32_t len;
+		/** Minimum length of 'num' packets.
+		 *
+		 *  The pool must contain at least 'num' packets up to this
+		 *  packet length (1 ... 'len' bytes). The maximum value for
+		 *  this field is defined by pool capability pkt.max_len.
+		 *  Use 0 for default.
+		 */
+		uint32_t len;
 
-			/** Maximum packet length that will be allocated from
-			    the pool. The maximum value is defined by pool
-			    capability pkt.max_len. Use 0 for default (the
-			    pool maximum). */
-			uint32_t max_len;
+		/** Maximum packet length that will be allocated from
+		 *  the pool. The maximum value is defined by pool capability
+		 *  pkt.max_len. Use 0 for default (the pool maximum).
+		 */
+		uint32_t max_len;
 
-			/** Minimum number of packet data bytes that are stored
-			    in the first segment of a packet. The maximum value
-			    is defined by pool capability pkt.max_seg_len.
-			    Use 0 for default. */
-			uint32_t seg_len;
+		/** Minimum number of packet data bytes that are stored in the
+		 *  first segment of a packet. The maximum value is defined by
+		 *  pool capability pkt.max_seg_len. Use 0 for default.
+		 */
+		uint32_t seg_len;
 
-			/** User area size in bytes. The maximum value is
-			    defined by pool capability pkt.max_uarea_size.
-			    Specify as 0 if no user area is needed. */
-			uint32_t uarea_size;
+		/** User area size in bytes. The maximum value is defined by
+		 *  pool capability pkt.max_uarea_size. Specify as 0 if no user
+		 *  area is needed.
+		 */
+		uint32_t uarea_size;
 
-			/** Minimum Headroom size in bytes. Each newly allocated
-			    packet from the pool must have at least this much
-			    headroom. The maximum value is defined by pool
-			    capability pkt.max_headroom.
-			    Use zero if headroom is not needed. */
-			uint32_t headroom;
+		/** Minimum headroom size in bytes. Each newly allocated
+		 *  packet from the pool must have at least this much headroom.
+		 *  The maximum value is defined by pool capability
+		 *  pkt.max_headroom. Use zero if headroom is not needed.
+		 */
+		uint32_t headroom;
 
-			/** Number of subparameters
-			 *
-			 *  The number of subparameter table entries used.
-			 *  The maximum value is defined by pool
-			 *  capability pkt.max_num_subparam. The default value
-			 *  is 0.
-			 */
-			uint8_t num_subparam;
+		/** Number of subparameters
+		 *
+		 *  The number of subparameter table entries used. The maximum
+		 *  value is defined by pool capability pkt.max_num_subparam.
+		 *  The default value is 0.
+		 */
+		uint8_t num_subparam;
 
-			/** Subparameter table
-			 *
-			 *  Subparameters continue pool configuration with
-			 *  additional packet length requirements. The first
-			 *  table entry follows the num/len specification above.
-			 *  So that, sub[0].len > 'len', and sub[0].num refers
-			 *  to packet lengths between 'len' + 1 and sub[0].len.
-			 *  Similarly, sub[1] follows sub[0] specification, and
-			 *  so on.
-			 *
-			 *  Each requirement is supported separately and may be
-			 *  rounded up, as long as the 'max_num' parameter is
-			 *  not violated. It's implementation specific if some
-			 *  requirements are supported simultaneously (e.g.
-			 *  due to subpool design).
-			 */
-			odp_pool_pkt_subparam_t sub[ODP_POOL_MAX_SUBPARAMS];
-		} pkt;
+		/** Subparameter table
+		 *
+		 *  Subparameters continue pool configuration with additional
+		 *  packet length requirements. The first table entry follows
+		 *  the num/len specification above. So that, sub[0].len > 'len'
+		 *  and sub[0].num refers to packet lengths between 'len' + 1
+		 *  and sub[0].len. Similarly, sub[1] follows sub[0]
+		 *  specification, and so on.
+		 *
+		 *  Each requirement is supported separately and may be rounded
+		 *  up, as long as the 'max_num' parameter is not violated. It's
+		 *  implementation specific if some requirements are supported
+		 *  simultaneously (e.g. due to subpool design).
+		 */
+		odp_pool_pkt_subparam_t sub[ODP_POOL_MAX_SUBPARAMS];
+	} pkt;
 
-		/** Parameters for timeout pools */
-		struct {
-			/** Number of timeouts in the pool */
-			uint32_t num;
-		} tmo;
-	};
+	/** Parameters for timeout pools */
+	struct {
+		/** Number of timeouts in the pool */
+		uint32_t num;
+	} tmo;
+
 } odp_pool_param_t;
 
 /** Packet pool*/

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -41,6 +41,9 @@ extern "C" {
  * Maximum pool name length in chars including null char
  */
 
+/** Maximum number of packet pool subparameters */
+#define ODP_POOL_MAX_SUBPARAMS  7
+
 /**
  * Pool capabilities
  */
@@ -134,6 +137,12 @@ typedef struct odp_pool_capability_t {
 		 * The value of zero means that limited only by the available
 		 * memory size for the pool. */
 		uint32_t max_uarea_size;
+
+		/** Maximum number of subparameters
+		 *
+		 *  Maximum number of packet pool subparameters. Valid range is
+		 *  0 ... ODP_POOL_MAX_SUBPARAMS. */
+		uint8_t max_num_subparam;
 	} pkt;
 
 	/** Timeout pool capabilities  */
@@ -161,6 +170,18 @@ typedef struct odp_pool_capability_t {
  * @retval <0 on failure
  */
 int odp_pool_capability(odp_pool_capability_t *capa);
+
+/**
+ * Packet pool subparameters
+ */
+typedef struct odp_pool_pkt_subparam_t {
+	/** Number of 'len' byte packets. */
+	uint32_t num;
+
+	/** Packet length in bytes */
+	uint32_t len;
+
+} odp_pool_pkt_subparam_t;
 
 /**
  * Pool parameters
@@ -246,6 +267,33 @@ typedef struct odp_pool_param_t {
 			    capability pkt.max_headroom.
 			    Use zero if headroom is not needed. */
 			uint32_t headroom;
+
+			/** Number of subparameters
+			 *
+			 *  The number of subparameter table entries used.
+			 *  The maximum value is defined by pool
+			 *  capability pkt.max_num_subparam. The default value
+			 *  is 0.
+			 */
+			uint8_t num_subparam;
+
+			/** Subparameter table
+			 *
+			 *  Subparameters continue pool configuration with
+			 *  additional packet length requirements. The first
+			 *  table entry follows the num/len specification above.
+			 *  So that, sub[0].len > 'len', and sub[0].num refers
+			 *  to packet lengths between 'len' + 1 and sub[0].len.
+			 *  Similarly, sub[1] follows sub[0] specification, and
+			 *  so on.
+			 *
+			 *  Each requirement is supported separately and may be
+			 *  rounded up, as long as the 'max_num' parameter is
+			 *  not violated. It's implementation specific if some
+			 *  requirements are supported simultaneously (e.g.
+			 *  due to subpool design).
+			 */
+			odp_pool_pkt_subparam_t sub[ODP_POOL_MAX_SUBPARAMS];
 		} pkt;
 
 		/** Parameters for timeout pools */

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -164,10 +164,11 @@ int odp_pool_capability(odp_pool_capability_t *capa);
 
 /**
  * Pool parameters
- * Used to communicate pool creation options.
- * @note A single thread may not be able to allocate all 'num' elements
- * from the pool at any particular time, as other threads or hardware
- * blocks are allowed to keep some for caching purposes.
+ *
+ * A note for all pool types: a single thread may not be able to allocate all
+ * 'num' elements from the pool at any particular time, as implementations are
+ * allowed to store some elements (per thread and HW engine) for caching
+ * purposes.
  */
 typedef struct odp_pool_param_t {
 	/** Pool type */
@@ -192,17 +193,34 @@ typedef struct odp_pool_param_t {
 
 		/** Parameters for packet pools */
 		struct {
-			/** The number of packets that the pool must provide
-			    that are packet length 'len' bytes or smaller.
-			    The maximum value is defined by pool capability
-			    pkt.max_num. */
+			/** Minimum number of 'len' byte packets.
+			 *
+			 *  The pool must contain at least this many packets
+			 *  that are 'len' bytes or smaller. An implementation
+			 *  may round up the value, as long as the 'max_num'
+			 *  parameter below is not violated. The maximum value
+			 *  for this field is defined by pool capability
+			 *  pkt.max_num.
+			 */
 			uint32_t num;
 
-			/** Minimum packet length that the pool must provide
-			    'num' packets. The number of packets may be less
-			    than 'num' when packets are larger than 'len'.
-			    The maximum value is defined by pool capability
-			    pkt.max_len. Use 0 for default. */
+			/** Maximum number of packets.
+			 *
+			 *  This is the maximum number of packets of any length
+			 *  that can be allocated from the pool. The maximum
+			 *  value is defined by pool capability pkt.max_num.
+			 *  Use 0 when there's no requirement for the maximum
+			 *  number of packets. The default value is 0.
+			 */
+			uint32_t max_num;
+
+			/** Minimum length of 'num' packets.
+			 *
+			 *  The pool must contain at least 'num' packets up to
+			 *  this packet length (1 ... 'len' bytes). The maximum
+			 *  value for this field is defined by pool capability
+			 *  pkt.max_len. Use 0 for default.
+			 */
 			uint32_t len;
 
 			/** Maximum packet length that will be allocated from

--- a/include/odp/api/spec/pool.h
+++ b/include/odp/api/spec/pool.h
@@ -358,24 +358,42 @@ odp_pool_t odp_pool_lookup(const char *name);
  * Used to get information about a pool.
  */
 typedef struct odp_pool_info_t {
-	const char *name;          /**< pool name */
-	odp_pool_param_t params;   /**< pool parameters */
+	/** Pool name */
+	const char *name;
+
+	/** Copy of pool parameters */
+	odp_pool_param_t params;
+
+	/** Additional info for packet pools */
+	struct {
+		/** Maximum number of packets of any length
+		 *
+		 *  This is the maximum number of packets that can be allocated
+		 *  from the pool at anytime. Application can use this e.g.
+		 *  to prepare enough per packet contexts.
+		 */
+		uint32_t max_num;
+
+	} pkt;
 
 	/** Minimum data address.
-	 * This is the minimum address that application accessible
-	 * data of any object (event) allocated from the pool may
-	 * locate. When there's no application accessible data
-	 * (e.g. ODP_POOL_TIMEOUT pools), the value may be zero.
+	 *
+	 *  This is the minimum address that application accessible
+	 *  data of any object (event) allocated from the pool may
+	 *  locate. When there's no application accessible data
+	 *  (e.g. ODP_POOL_TIMEOUT pools), the value may be zero.
 	 */
 	uintptr_t min_data_addr;
 
 	/** Maximum data address.
-	 * This is the maximum address that application accessible
-	 * data of any object (event) allocated from the pool may
-	 * locate. When there's no application accessible data
-	 * (e.g. ODP_POOL_TIMEOUT pools), the value may be zero.
+	 *
+	 *  This is the maximum address that application accessible
+	 *  data of any object (event) allocated from the pool may
+	 *  locate. When there's no application accessible data
+	 *  (e.g. ODP_POOL_TIMEOUT pools), the value may be zero.
 	 */
 	uintptr_t max_data_addr;
+
 } odp_pool_info_t;
 
 /**
@@ -389,7 +407,6 @@ typedef struct odp_pool_info_t {
  * @retval 0 Success
  * @retval -1 Failure.  Info could not be retrieved.
  */
-
 int odp_pool_info(odp_pool_t pool, odp_pool_info_t *info);
 
 /**

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -701,6 +701,9 @@ int odp_pool_info(odp_pool_t pool_hdl, odp_pool_info_t *info)
 	info->name = pool->name;
 	info->params = pool->params;
 
+	if (pool->params.type == ODP_POOL_PACKET)
+		info->pkt.max_num = pool->num;
+
 	return 0;
 }
 

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -16,11 +16,11 @@
 static const int default_buffer_size = 1500;
 static const int default_buffer_num = 1000;
 
-static void pool_create_destroy(odp_pool_param_t *params)
+static void pool_create_destroy(odp_pool_param_t *param)
 {
 	odp_pool_t pool;
 
-	pool = odp_pool_create(NULL, params);
+	pool = odp_pool_create(NULL, param);
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 	CU_ASSERT(odp_pool_to_u64(pool) !=
 		  odp_pool_to_u64(ODP_POOL_INVALID));
@@ -29,42 +29,41 @@ static void pool_create_destroy(odp_pool_param_t *params)
 
 void pool_test_create_destroy_buffer(void)
 {
-	odp_pool_param_t params = {
-			.buf = {
-				.size  = default_buffer_size,
-				.align = ODP_CACHE_LINE_SIZE,
-				.num   = default_buffer_num,
-			},
-			.type = ODP_POOL_BUFFER,
-	};
+	odp_pool_param_t param;
 
-	pool_create_destroy(&params);
+	odp_pool_param_init(&param);
+
+	param.type      = ODP_POOL_BUFFER,
+	param.buf.size  = default_buffer_size;
+	param.buf.align = ODP_CACHE_LINE_SIZE;
+	param.buf.num   = default_buffer_num;
+
+	pool_create_destroy(&param);
 }
 
 void pool_test_create_destroy_packet(void)
 {
-	odp_pool_param_t params = {
-			.pkt = {
-				.seg_len = 0,
-				.len = default_buffer_size,
-				.num   = default_buffer_num,
-			},
-			.type = ODP_POOL_PACKET,
-	};
+	odp_pool_param_t param;
 
-	pool_create_destroy(&params);
+	odp_pool_param_init(&param);
+
+	param.type    = ODP_POOL_PACKET;
+	param.pkt.len = default_buffer_size;
+	param.pkt.num = default_buffer_num;
+
+	pool_create_destroy(&param);
 }
 
 void pool_test_create_destroy_timeout(void)
 {
-	odp_pool_param_t params = {
-			.tmo = {
-				.num   = default_buffer_num,
-			},
-			.type = ODP_POOL_TIMEOUT,
-	};
+	odp_pool_param_t param;
 
-	pool_create_destroy(&params);
+	odp_pool_param_init(&param);
+
+	param.type    = ODP_POOL_TIMEOUT;
+	param.tmo.num = default_buffer_num;
+
+	pool_create_destroy(&param);
 }
 
 void pool_test_lookup_info_print(void)
@@ -72,16 +71,16 @@ void pool_test_lookup_info_print(void)
 	odp_pool_t pool;
 	const char pool_name[] = "pool_for_lookup_test";
 	odp_pool_info_t info;
-	odp_pool_param_t params = {
-			.buf = {
-				.size  = default_buffer_size,
-				.align = ODP_CACHE_LINE_SIZE,
-				.num  = default_buffer_num,
-			},
-			.type  = ODP_POOL_BUFFER,
-	};
+	odp_pool_param_t param;
 
-	pool = odp_pool_create(pool_name, &params);
+	odp_pool_param_init(&param);
+
+	param.type      = ODP_POOL_BUFFER;
+	param.buf.size  = default_buffer_size;
+	param.buf.align = ODP_CACHE_LINE_SIZE;
+	param.buf.num   = default_buffer_num;
+
+	pool = odp_pool_create(pool_name, &param);
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 
 	pool = odp_pool_lookup(pool_name);
@@ -89,10 +88,10 @@ void pool_test_lookup_info_print(void)
 
 	CU_ASSERT_FATAL(odp_pool_info(pool, &info) == 0);
 	CU_ASSERT(strncmp(pool_name, info.name, sizeof(pool_name)) == 0);
-	CU_ASSERT(params.buf.size <= info.params.buf.size);
-	CU_ASSERT(params.buf.align <= info.params.buf.align);
-	CU_ASSERT(params.buf.num <= info.params.buf.num);
-	CU_ASSERT(params.type == info.params.type);
+	CU_ASSERT(param.buf.size <= info.params.buf.size);
+	CU_ASSERT(param.buf.align <= info.params.buf.align);
+	CU_ASSERT(param.buf.num <= info.params.buf.num);
+	CU_ASSERT(param.type == info.params.type);
 
 	odp_pool_print(pool);
 

--- a/test/validation/api/pool/pool.c
+++ b/test/validation/api/pool/pool.c
@@ -191,12 +191,40 @@ void pool_test_alloc_packet_subparam(void)
 	CU_ASSERT(odp_pool_destroy(pool) == 0);
 }
 
+void pool_test_info_packet(void)
+{
+	odp_pool_t pool;
+	odp_pool_info_t info;
+	odp_pool_param_t param;
+	const char pool_name[] = "test_pool_name";
+
+	odp_pool_param_init(&param);
+
+	param.type     = ODP_POOL_PACKET;
+	param.pkt.num  = PKT_NUM;
+	param.pkt.len  = PKT_LEN;
+
+	pool = odp_pool_create(pool_name, &param);
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	CU_ASSERT_FATAL(odp_pool_info(pool, &info) == 0);
+
+	CU_ASSERT(strncmp(pool_name, info.name, sizeof(pool_name)) == 0);
+	CU_ASSERT(info.params.type    == ODP_POOL_PACKET);
+	CU_ASSERT(info.params.pkt.num == param.pkt.num);
+	CU_ASSERT(info.params.pkt.len == param.pkt.len);
+	CU_ASSERT(info.pkt.max_num    >= param.pkt.num);
+
+	CU_ASSERT(odp_pool_destroy(pool) == 0);
+}
+
 odp_testinfo_t pool_suite[] = {
 	ODP_TEST_INFO(pool_test_create_destroy_buffer),
 	ODP_TEST_INFO(pool_test_create_destroy_packet),
 	ODP_TEST_INFO(pool_test_create_destroy_timeout),
 	ODP_TEST_INFO(pool_test_alloc_packet),
 	ODP_TEST_INFO(pool_test_alloc_packet_subparam),
+	ODP_TEST_INFO(pool_test_info_packet),
 	ODP_TEST_INFO(pool_test_lookup_info_print),
 	ODP_TEST_INFO_NULL,
 };

--- a/test/validation/api/pool/pool.h
+++ b/test/validation/api/pool/pool.h
@@ -16,6 +16,7 @@ void pool_test_create_destroy_timeout(void);
 void pool_test_lookup_info_print(void);
 void pool_test_alloc_packet(void);
 void pool_test_alloc_packet_subparam(void);
+void pool_test_info_packet(void);
 
 /* test arrays: */
 extern odp_testinfo_t pool_suite[];

--- a/test/validation/api/pool/pool.h
+++ b/test/validation/api/pool/pool.h
@@ -13,8 +13,9 @@
 void pool_test_create_destroy_buffer(void);
 void pool_test_create_destroy_packet(void);
 void pool_test_create_destroy_timeout(void);
-void pool_test_create_destroy_buffer_shm(void);
 void pool_test_lookup_info_print(void);
+void pool_test_alloc_packet(void);
+void pool_test_alloc_packet_subparam(void);
 
 /* test arrays: */
 extern odp_testinfo_t pool_suite[];


### PR DESCRIPTION
Added packet pool parameters for more fine grained pool
configuration. The basic usage of the parameters is not changed,
except that implementation may now round up 'num' by default.
Application can limit the round up with new 'max_num' parameter.
If application does not limit max_num (but is still interested on 
max_num value), it can check the new info.pkt.max_num.

The new specification allows implementation to use sub-pools, 
also application is able to request e.g. this kind of pool:

               ^
                |
max_num | - - - - - - - -
                |
                |   *
NUM        |   * *
                |   * * *
                | * * * * *
                | * * * * * *
               +--------------->
              LEN
