### PR TITLE
[PATCH API-NEXT v1] api: ipsec: move pipeline SA param to inbound substructrure

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -633,14 +633,6 @@ typedef struct odp_ipsec_sa_param_t {
 	/** SPI value */
 	uint32_t spi;
 
-	/** Select pipelined destination for resulting events
-	 *
-	 *  Asynchronous and inline modes generate events. Select where
-	 *  those events are sent. Inbound SAs may choose to use pipelined
-	 *  classification. The default value is ODP_IPSEC_PIPELINE_NONE.
-	 */
-	odp_ipsec_pipeline_t pipeline;
-
 	/** Destination queue for IPSEC events
 	 *
 	 *  Operations in asynchronous or inline mode enqueue resulting events
@@ -689,6 +681,15 @@ typedef struct odp_ipsec_sa_param_t {
 			 *  anti-replay service.
 			 */
 			uint32_t antireplay_ws;
+
+			/** Select pipelined destination for resulting events
+			 *
+			 * Asynchronous and inline modes generate events.
+			 * Select where those events are sent. Inbound SAs may
+			 * choose to use pipelined classification. The default
+			 * value is ODP_IPSEC_PIPELINE_NONE.
+			 */
+			odp_ipsec_pipeline_t pipeline;
 
 			/** Classifier destination CoS for resulting packets
 			 *


### PR DESCRIPTION
SA param pipeline is related only to inbound configuration. If at some
point it will be possible to configure destination for outbound
operation, it will be done through a separate param. Move pipeline into
inbound params substructure.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>