### PR TITLE
[PATCH API-NEXT v4] api: ones complement metadata

### DIFF
--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1437,6 +1437,26 @@ void odp_packet_l3_chksum_insert(odp_packet_t pkt, int insert);
 void odp_packet_l4_chksum_insert(odp_packet_t pkt, int insert);
 
 /**
+ * Ones' complement sum of packet data
+ *
+ * Returns 16-bit ones' complement sum that was calculated over a portion of
+ * packet data during a packet processing operation (e.g. packet input or
+ * IPSEC offload). The data range is output with 'range' parameter, and usually
+ * includes IP payload (L4 headers and payload). When 'range.length' is zero,
+ * the sum has not been calculated. In case of odd number of bytes,
+ * calculation uses a zero byte as padding at the end. The sum may be used as
+ * part of e.g. UDP/TCP checksum checking, especially with IP fragments.
+ *
+ * @param      pkt    Packet handle
+ * @param[out] range  Data range of the sum (output). The calculation started
+ *                    from range.offset and included range.length bytes. When
+ *                    range.length is zero, the sum has not been calculated.
+ *
+ * @return Ones' complement sum over the data range
+ */
+uint16_t odp_packet_ones_comp(odp_packet_t pkt, odp_packet_data_range_t *range);
+
+/**
  * Packet flow hash value
  *
  * Returns the hash generated from the packet header. Use

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1284,6 +1284,14 @@ int odp_packet_l4_offset_set(odp_packet_t pkt, uint32_t offset)
 	return 0;
 }
 
+uint16_t odp_packet_ones_comp(odp_packet_t pkt, odp_packet_data_range_t *range)
+{
+	(void)pkt;
+	range->length = 0;
+	range->offset = 0;
+	return 0;
+}
+
 void odp_packet_flow_hash_set(odp_packet_t pkt, uint32_t flow_hash)
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -503,6 +503,7 @@ void packet_test_basic_metadata(void)
 {
 	odp_packet_t pkt = test_packet;
 	odp_time_t ts;
+	odp_packet_data_range_t range;
 
 	CU_ASSERT_PTR_NOT_NULL(odp_packet_head(pkt));
 	CU_ASSERT_PTR_NOT_NULL(odp_packet_data(pkt));
@@ -511,6 +512,11 @@ void packet_test_basic_metadata(void)
 	/* Packet was allocated by application so shouldn't have valid pktio. */
 	CU_ASSERT(odp_packet_input(pkt) == ODP_PKTIO_INVALID);
 	CU_ASSERT(odp_packet_input_index(pkt) < 0);
+
+	/* Packet was not received from a packet IO, shouldn't have ones
+	 * complement calculated. */
+	odp_packet_ones_comp(pkt, &range);
+	CU_ASSERT(range.length == 0);
 
 	odp_packet_flow_hash_set(pkt, UINT32_MAX);
 	CU_ASSERT(odp_packet_has_flow_hash(pkt));


### PR DESCRIPTION
Added packet metadata for ones complement sum over IP
payload in a packet. Some NICs calculate the sum
during packet input (at least for IP fragments) and
store the value into the packet descriptor. This offloads
L4 checksum calculation for IP fragments as SW does not
need sum all payload data, but just combine pre-calculated
sums from packet descriptors and remove extra header fields
from the sum.