### PR TITLE
[PATCH API-NEXT v2] api: shm: shm block level print

### DIFF
--- a/include/odp/api/spec/shared_memory.h
+++ b/include/odp/api/spec/shared_memory.h
@@ -209,11 +209,20 @@ void *odp_shm_addr(odp_shm_t shm);
  */
 int odp_shm_info(odp_shm_t shm, odp_shm_info_t *info);
 
-
 /**
  * Print all shared memory blocks
  */
 void odp_shm_print_all(void);
+
+/**
+ * Print shared memory block info
+ *
+ * Print implementation defined information about the specified shared memory
+ * block to the ODP log. The information is intended to be used for debugging.
+ *
+ * @param shm        Block handle
+ */
+void odp_shm_print(odp_shm_t shm);
 
 /**
  * Get printable value for an odp_shm_t

--- a/include/odp/api/spec/shared_memory.h
+++ b/include/odp/api/spec/shared_memory.h
@@ -50,6 +50,7 @@ extern "C" {
  */
 #define ODP_SHM_SW_ONLY		0x1 /**< Application SW only, no HW access   */
 #define ODP_SHM_PROC		0x2 /**< Share with external processes       */
+
 /**
  * Single virtual address
  *
@@ -58,6 +59,7 @@ extern "C" {
  * of ODP thread type (e.g. pthread vs. process (or fork process time)).
  */
 #define ODP_SHM_SINGLE_VA	0x4
+
 /**
  * Export memory
  *
@@ -70,11 +72,20 @@ extern "C" {
  * Shared memory block info
  */
 typedef struct odp_shm_info_t {
-	const char *name;      /**< Block name */
-	void       *addr;      /**< Block address */
-	uint64_t    size;      /**< Block size in bytes */
-	uint64_t    page_size; /**< Memory page size */
-	uint32_t    flags;     /**< ODP_SHM_* flags */
+	/** Block name */
+	const char *name;
+
+	/** Block address */
+	void       *addr;
+
+	/** Block size in bytes */
+	uint64_t    size;
+
+	/** Memory page size */
+	uint64_t    page_size;
+
+	/** ODP_SHM_* flags */
+	uint32_t    flags;
 } odp_shm_info_t;
 
 /**
@@ -116,11 +127,10 @@ int odp_shm_capability(odp_shm_capability_t *capa);
 /**
  * Reserve a contiguous block of shared memory
  *
- * @param[in] name   Name of the block (maximum ODP_SHM_NAME_LEN - 1 chars)
- * @param[in] size   Block size in bytes
- * @param[in] align  Block alignment in bytes
- * @param[in] flags  Shared memory parameter flags (ODP_SHM_*).
- *                   Default value is 0.
+ * @param name   Name of the block (maximum ODP_SHM_NAME_LEN - 1 chars)
+ * @param size   Block size in bytes
+ * @param align  Block alignment in bytes
+ * @param flags  Shared memory parameter flags (ODP_SHM_*). Default value is 0.
  *
  * @return Handle of the reserved block
  * @retval ODP_SHM_INVALID on failure
@@ -131,10 +141,10 @@ odp_shm_t odp_shm_reserve(const char *name, uint64_t size, uint64_t align,
 /**
  * Free a contiguous block of shared memory
  *
- * Frees a previously reserved block of shared memory.
- * @note Freeing memory that is in use will result in UNDEFINED behavior
+ * Frees a previously reserved block of shared memory. Freeing memory that is
+ * in use will result in UNDEFINED behavior
  *
- * @param[in] shm Block handle
+ * @param shm    Block handle
  *
  * @retval 0 on success
  * @retval <0 on failure
@@ -144,7 +154,7 @@ int odp_shm_free(odp_shm_t shm);
 /**
  * Lookup for a block of shared memory
  *
- * @param[in] name   Name of the block
+ * @param name   Name of the block
  *
  * @return A handle to the block if it is found by name
  * @retval ODP_SHM_INVALID on failure
@@ -177,20 +187,21 @@ odp_shm_t odp_shm_import(const char *remote_name,
 /**
  * Shared memory block address
  *
- * @param[in] shm   Block handle
+ * @param shm    Block handle
  *
  * @return Memory block address
  * @retval NULL on failure
  */
 void *odp_shm_addr(odp_shm_t shm);
 
-
 /**
  * Shared memory block info
- * @note This is the only shared memory API function which accepts invalid
- * shm handles (any bit value) without causing undefined behavior.
  *
- * @param[in]  shm   Block handle
+ * Get information about the specified shared memory block. This is the only
+ * shared memory API function which accepts invalid shm handles (any bit value)
+ * without causing undefined behavior.
+ *
+ * @param      shm   Block handle
  * @param[out] info  Block info pointer for output
  *
  * @retval 0 on success
@@ -207,15 +218,15 @@ void odp_shm_print_all(void);
 /**
  * Get printable value for an odp_shm_t
  *
- * @param hdl  odp_shm_t handle to be printed
- * @return     uint64_t value that can be used to print/display this
- *             handle
+ * This routine is intended to be used for diagnostic purposes to enable
+ * applications to generate a printable value that represents an odp_shm_t
+ * handle.
  *
- * @note This routine is intended to be used for diagnostic purposes
- * to enable applications to generate a printable value that represents
- * an odp_shm_t handle.
+ * @param shm    Block handle
+ *
+ * @return uint64_t value that can be used to print this handle
  */
-uint64_t odp_shm_to_u64(odp_shm_t hdl);
+uint64_t odp_shm_to_u64(odp_shm_t shm);
 
 /**
  * @}

--- a/platform/linux-generic/_ishm.c
+++ b/platform/linux-generic/_ishm.c
@@ -1837,3 +1837,52 @@ int _odp_ishm_status(const char *title)
 	odp_spinlock_unlock(&ishm_tbl->lock);
 	return nb_blocks;
 }
+
+void _odp_ishm_print(int block_index)
+{
+	ishm_block_t *block;
+	const char *str;
+
+	odp_spinlock_lock(&ishm_tbl->lock);
+
+	if ((block_index < 0) ||
+	    (block_index >= ISHM_MAX_NB_BLOCKS) ||
+	    (ishm_tbl->block[block_index].len == 0)) {
+		odp_spinlock_unlock(&ishm_tbl->lock);
+		ODP_ERR("Request for info on an invalid block\n");
+		return;
+	}
+
+	block = &ishm_tbl->block[block_index];
+
+	ODP_PRINT("\nSHM block info\n--------------\n");
+	ODP_PRINT(" name:       %s\n",   block->name);
+	ODP_PRINT(" file:       %s\n",   block->filename);
+	ODP_PRINT(" expt:       %s\n",   block->exptname);
+	ODP_PRINT(" user_flags: 0x%x\n", block->user_flags);
+	ODP_PRINT(" flags:      0x%x\n", block->flags);
+	ODP_PRINT(" user_len:   %lu\n",  block->user_len);
+	ODP_PRINT(" start:      %p\n",   block->start);
+	ODP_PRINT(" len:        %lu\n",  block->len);
+
+	switch (block->huge) {
+	case HUGE:
+		str = "huge";
+		break;
+	case NORMAL:
+		str = "normal";
+		break;
+	case EXTERNAL:
+		str = "external";
+		break;
+	default:
+		str = "??";
+	}
+
+	ODP_PRINT(" page type:  %s\n", str);
+	ODP_PRINT(" seq:        %lu\n",  block->seq);
+	ODP_PRINT(" refcnt:     %lu\n",  block->refcnt);
+	ODP_PRINT("\n");
+
+	odp_spinlock_unlock(&ishm_tbl->lock);
+}

--- a/platform/linux-generic/include/_ishm_internal.h
+++ b/platform/linux-generic/include/_ishm_internal.h
@@ -45,6 +45,7 @@ void *_odp_ishm_address(int block_index);
 int   _odp_ishm_info(int block_index, _odp_ishm_info_t *info);
 int   _odp_ishm_status(const char *title);
 int _odp_ishm_cleanup_files(const char *dirpath);
+void _odp_ishm_print(int block_index);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -116,6 +116,11 @@ void odp_shm_print_all(void)
 	_odp_ishm_status("Memory allocation status:");
 }
 
+void odp_shm_print(odp_shm_t shm)
+{
+	_odp_ishm_print(from_handle(shm));
+}
+
 uint64_t odp_shm_to_u64(odp_shm_t hdl)
 {
 	return _odp_pri(hdl);

--- a/test/validation/api/shmem/shmem.c
+++ b/test/validation/api/shmem/shmem.c
@@ -152,6 +152,8 @@ void shmem_test_basic(void)
 	odp_cunit_thread_create(run_test_basic_thread, &thrdarg);
 	CU_ASSERT(odp_cunit_thread_exit(&thrdarg) >= 0);
 
+	odp_shm_print(shm);
+
 	CU_ASSERT(0 == odp_shm_free(shm));
 }
 


### PR DESCRIPTION
Add SHM block level debug print function. This is similar to e.g. odp_pool_print(). All SHM blocks print function (odp_shm_print_all()) cannot print as much details on every block. Cleaned also SHM header file and odp_shm_print_all() implementation while touching the files.