### PR TITLE
[PATCH API-NEXT v1] api: pktio: clarify odp_pktio_config() restrictions

### DIFF
--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -605,7 +605,8 @@ unsigned odp_pktio_max_index(void);
  * interface setup sequence. Use odp_pktio_capability() to query configuration
  * capabilities. Use odp_pktio_config_init() to initialize
  * configuration options into their default values. Default values are used
- * when 'config' pointer is NULL.
+ * when 'config' pointer is NULL. Attempting to configure options that are
+ * not supported, as indicated by odp_pktio_capability(), will be rejected.
  *
  * @param pktio    Packet IO handle
  * @param config   Packet IO interface configuration. Uses defaults


### PR DESCRIPTION
Add clarification that odp_pktio_config() cannot be used to
configure options that are not supported, as indicated by
odp_pktio_capability().

Signed-off-by: Bill Fischofer <bill.fischofer@linaro.org>