### PR TITLE
[PATCH 2.0 v1] Modular framework/subsystems symbols visibility 

### DIFF
--- a/frameworks/modular/odp_module.h
+++ b/frameworks/modular/odp_module.h
@@ -38,6 +38,11 @@
 
 #ifndef ODP_MODULE_H_
 #define ODP_MODULE_H_
+#include <odp/visibility_begin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stdbool.h>
 #include <odp/api/rwlock.h>
@@ -293,4 +298,9 @@ int __subsystem_register_module(
 	__subsystem_set_active(&__subsystem(name), base);	\
 })
 
+#ifdef __cplusplus
+}
+#endif
+
+#include <odp/visibility_end.h>
 #endif

--- a/platform/linux-generic/include/odp_buffer_subsystem.h
+++ b/platform/linux-generic/include/odp_buffer_subsystem.h
@@ -8,6 +8,7 @@
 
 #ifndef ODP_BUFFER_SUBSYSTEM_H_
 #define ODP_BUFFER_SUBSYSTEM_H_
+#include <odp/visibility_begin.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,5 +59,6 @@ typedef ODP_MODULE_CLASS(buffer) {
 }
 #endif
 
+#include <odp/visibility_end.h>
 #endif
 

--- a/platform/linux-generic/include/odp_pktio_ops_subsystem.h
+++ b/platform/linux-generic/include/odp_pktio_ops_subsystem.h
@@ -8,6 +8,11 @@
 
 #ifndef ODP_PKTIO_OPS_SUBSYSTEM_H_
 #define ODP_PKTIO_OPS_SUBSYSTEM_H_
+#include <odp/visibility_begin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <odp_module.h>
 #include <odp/api/packet_io.h>
@@ -87,4 +92,9 @@ typedef ODP_MODULE_CLASS(pktio_ops) {
 #define odp_ops_data(_p, _mod) \
 	((pktio_ops_ ## _mod ## _data_t *)(uintptr_t)_p->s.ops_data)
 
+#ifdef __cplusplus
+}
+#endif
+
+#include <odp/visibility_end.h>
 #endif

--- a/platform/linux-generic/include/odp_pool_subsystem.h
+++ b/platform/linux-generic/include/odp_pool_subsystem.h
@@ -8,6 +8,7 @@
 
 #ifndef ODP_POOL_SUBSYSTEM_H_
 #define ODP_POOL_SUBSYSTEM_H_
+#include <odp/visibility_begin.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,4 +48,5 @@ typedef ODP_MODULE_CLASS(pool) {
 }
 #endif
 
+#include <odp/visibility_end.h>
 #endif

--- a/platform/linux-generic/include/odp_queue_subsystem.h
+++ b/platform/linux-generic/include/odp_queue_subsystem.h
@@ -8,6 +8,7 @@
 
 #ifndef ODP_QUEUE_SUBSYSTEM_H
 #define ODP_QUEUE_SUBSYSTEM_H
+#include <odp/visibility_begin.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -74,4 +75,5 @@ typedef ODP_MODULE_CLASS(queue) {
 }
 #endif
 
+#include <odp/visibility_end.h>
 #endif

--- a/platform/linux-generic/include/odp_schedule_subsystem.h
+++ b/platform/linux-generic/include/odp_schedule_subsystem.h
@@ -8,6 +8,11 @@
 
 #ifndef ODP_SCHEDULE_SUBSYSTEM_H_
 #define ODP_SCHEDULE_SUBSYSTEM_H_
+#include <odp/visibility_begin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* API header files */
 #include <odp/api/align.h>
@@ -77,4 +82,9 @@ typedef ODP_MODULE_CLASS(schedule) {
 	odp_api_proto(schedule, schedule_resume) schedule_resume;
 } odp_schedule_module_t;
 
+#ifdef __cplusplus
+}
+#endif
+
+#include <odp/visibility_end.h>
 #endif  /* ODP_SCHEDULE_SUBSYSTEM_H_ */


### PR DESCRIPTION
Make modular framework/subsystems symbols visible

Signed-off-by: Bogdan Pricope <bogdan.pricope@linaro.org>