### PR TITLE
[PATCH API-NEXT v1] api: packet: print data

### DIFF
--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1561,13 +1561,26 @@ void odp_packet_shaper_len_adjust_set(odp_packet_t pkt, int8_t adj);
  */
 
 /**
- * Print packet to the console
+ * Print packet debug information
  *
- * Print all packet debug information to the console.
+ * Print all packet debug information to the ODP log.
  *
  * @param pkt  Packet handle
  */
 void odp_packet_print(odp_packet_t pkt);
+
+/**
+ * Print packet data
+ *
+ * Print packet debug information with packet data to the ODP log. Operation
+ * prints 'len' bytes of packet data starting from 'offset' byte. Offset plus
+ * length must not exceed packet length (odp_packet_len()).
+ *
+ * @param pkt     Packet handle
+ * @param offset  Byte offset into the packet
+ * @param len     Number of bytes to print
+ */
+void odp_packet_print_data(odp_packet_t pkt, uint32_t offset, uint32_t len);
 
 /**
  * Perform full packet validity check

--- a/platform/linux-generic/include/odp_debug_internal.h
+++ b/platform/linux-generic/include/odp_debug_internal.h
@@ -81,7 +81,7 @@ extern "C" {
  * specifically for dumping internal data.
  */
 #define ODP_PRINT(fmt, ...) \
-	odp_global_data.log_fn(ODP_LOG_PRINT, " " fmt, ##__VA_ARGS__)
+	odp_global_data.log_fn(ODP_LOG_PRINT, fmt, ##__VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1739,9 +1739,68 @@ void odp_packet_print(odp_packet_t pkt)
 		seg = odp_packet_next_seg(pkt, seg);
 	}
 
-	str[len] = '\0';
+	ODP_PRINT("%s\n", str);
+}
 
-	ODP_PRINT("\n%s\n", str);
+void odp_packet_print_data(odp_packet_t pkt, uint32_t offset,
+			   uint32_t byte_len)
+{
+	odp_packet_hdr_t *hdr = packet_hdr(pkt);
+	uint32_t bytes_per_row = 16;
+	int num_rows = (byte_len + bytes_per_row - 1) / bytes_per_row;
+	int max_len = 256 + (3 * byte_len) + (3 * num_rows);
+	char str[max_len];
+	int len = 0;
+	int n = max_len - 1;
+	uint32_t data_len = odp_packet_len(pkt);
+	pool_t *pool = hdr->buf_hdr.pool_ptr;
+
+	len += snprintf(&str[len], n - len, "Packet\n------\n");
+	len += snprintf(&str[len], n - len,
+			"  pool index    %" PRIu32 "\n", pool->pool_idx);
+	len += snprintf(&str[len], n - len,
+			"  buf index     %" PRIu32 "\n", hdr->buf_hdr.index);
+	len += snprintf(&str[len], n - len,
+			"  segcount      %" PRIu16 "\n", hdr->buf_hdr.segcount);
+	len += snprintf(&str[len], n - len,
+			"  data len      %" PRIu32 "\n", data_len);
+	len += snprintf(&str[len], n - len,
+			"  data ptr      %p\n", odp_packet_data(pkt));
+	len += snprintf(&str[len], n - len,
+			"  print offset  %" PRIu32 "\n", offset);
+	len += snprintf(&str[len], n - len,
+			"  print length  %" PRIu32 "\n", byte_len);
+
+	if (offset + byte_len > data_len) {
+		len += snprintf(&str[len], n - len, " BAD OFFSET OR LEN\n");
+		ODP_PRINT("%s\n", str);
+		return;
+	}
+
+	while (byte_len) {
+		uint32_t copy_len;
+		uint8_t data[bytes_per_row];
+		uint32_t i;
+
+		if (byte_len > bytes_per_row)
+			copy_len = bytes_per_row;
+		else
+			copy_len = byte_len;
+
+		odp_packet_copy_to_mem(pkt, offset, copy_len, data);
+
+		len += snprintf(&str[len], n - len, " ");
+
+		for (i = 0; i < copy_len; i++)
+			len += snprintf(&str[len], n - len, " %02x", data[i]);
+
+		len += snprintf(&str[len], n - len, "\n");
+
+		byte_len -= copy_len;
+		offset   += copy_len;
+	}
+
+	ODP_PRINT("%s\n", str);
 }
 
 int odp_packet_is_valid(odp_packet_t pkt)

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -554,7 +554,10 @@ void packet_test_prefetch(void)
 void packet_test_debug(void)
 {
 	CU_ASSERT(odp_packet_is_valid(test_packet) == 1);
+	printf("\n\n");
 	odp_packet_print(test_packet);
+	odp_packet_print_data(test_packet, 0, 100);
+	odp_packet_print_data(test_packet, 14, 20);
 }
 
 void packet_test_context(void)
@@ -2152,7 +2155,10 @@ void packet_test_ref(void)
 	packet_compare_data(pkt3, ref2);
 
 	/* Try print function on a reference */
+	printf("\n\n");
 	odp_packet_print(ref2);
+	odp_packet_print_data(ref2, 0, 100);
+	odp_packet_print_data(ref2, 14, 20);
 
 	odp_packet_free(ref);
 	odp_packet_free(ref2);


### PR DESCRIPTION
Added debug print function which includes packet payload bytes.
Printing starts from an offset, so it's easy to e.g. limit print to IPv4 header bytes only:
odp_packet_print_data(pkt, l3_offset(pkt), 20)
