### PR TITLE
[PATCH 2.0 v6] linux-gen: buffer: remove burst metadata from odp_buffer_hdr_t

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -261,16 +261,9 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_pkt_queue.c \
 			   odp_queue_if.c \
 			   queue/subsystem.c \
-			   queue/generic.c \
-			   queue/scalable.c \
 			   odp_rwlock.c \
 			   odp_rwlock_recursive.c \
 			   odp_schedule_if.c \
-			   schedule/generic.c \
-			   schedule/iquery.c \
-			   schedule/scalable.c \
-			   schedule/scalable_ordered.c \
-			   schedule/sp.c \
 			   schedule/subsystem.c \
 			   odp_shared_memory.c \
 			   odp_sorted_list.c \
@@ -359,19 +352,29 @@ endif
 pool/generic.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
 buffer/generic.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
 if ODP_SCHEDULE_SCALABLE
+__LIB__libodp_linux_la_SOURCES += schedule/scalable.c \
+				  schedule/scalable_ordered.c
 schedule/scalable.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
 else
+if ODP_SCHEDULE_SP
+__LIB__libodp_linux_la_SOURCES += schedule/sp.c
+schedule/sp.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
+else
+if ODP_SCHEDULE_IQUERY
+__LIB__libodp_linux_la_SOURCES += schedule/iquery.c
+schedule/iquery.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
+else
+__LIB__libodp_linux_la_SOURCES += schedule/generic.c
 schedule/generic.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
 endif
-if ODP_SCHEDULE_SP
-schedule/sp.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
 endif
-if ODP_SCHEDULE_IQUERY
-schedule/iquery.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
 endif
+
 if ODP_SCHEDULE_SCALABLE
+__LIB__libodp_linux_la_SOURCES += queue/scalable.c
 queue/scalable.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
 else
+__LIB__libodp_linux_la_SOURCES += queue/generic.c
 queue/generic.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
 endif
 

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -73,6 +73,7 @@ struct odp_buffer_hdr_t {
 	/* Segments */
 	seg_entry_t seg[CONFIG_PACKET_SEGS_PER_HDR];
 
+#ifndef ODP_SCHEDULE_SCALABLE
 	/* Burst counts */
 	uint8_t   burst_num;
 	uint8_t   burst_first;
@@ -82,7 +83,7 @@ struct odp_buffer_hdr_t {
 
 	/* Burst table */
 	struct odp_buffer_hdr_t *burst[BUFFER_BURST_SIZE];
-
+#endif
 	/* --- Mostly read only data --- */
 
 	/* User context pointer or u64 */


### PR DESCRIPTION
The total packet meta data size was 7 cache lines for Linux-generic.
With this change the size of the meta data is 4 cache lines for
Linux-generic.
Make scalable scheduler as the default scheduler.