### PR TITLE
[PATCH v3] Doxygen fix and hooking into make distcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,6 +138,19 @@ before_install:
         - export PKG_CONFIG_PATH="$HOME/cunit-install/$CROSS_ARCH/lib/pkgconfig:${PKG_CONFIG_PATH}"
         - find $HOME/cunit-install
 
+          # Updated Doxygen
+        - |
+          if [ ! -f "$HOME/doxygen-install/bin/doxygen" ]; then
+                wget https://github.com/doxygen/doxygen/archive/Release_1_8_13.tar.gz
+                tar xpvf Release_1_8_13.tar.gz
+                pushd doxygen-Release_1_8_13
+                cmake -DCMAKE_INSTALL_PREFIX=$HOME/doxygen-install .
+                make install
+                popd
+          fi
+        - export PATH=$HOME/doxygen-install/bin:$PATH
+
+
 install:
         - echo 1000 | sudo tee /proc/sys/vm/nr_hugepages
         - sudo mkdir -p /mnt/huge
@@ -249,17 +262,6 @@ jobs:
                   install:
                           - true
                   script:
-                          - |
-                            if [ ! -f "$HOME/doxygen-install/bin/doxygen" ]; then
-                              wget https://github.com/doxygen/doxygen/archive/Release_1_8_13.tar.gz
-                              tar xpvf Release_1_8_13.tar.gz
-                              pushd doxygen-Release_1_8_13
-                              cmake -DCMAKE_INSTALL_PREFIX=$HOME/doxygen-install .
-                              make install
-                              popd
-                            fi
-
-                          - export PATH=$HOME/doxygen-install/bin:$PATH
                           - ./bootstrap
                           - ./configure
                           # doxygen does not trap on warnings, check for them here.

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,4 +20,4 @@ SUBDIRS = \
 
 @DX_RULES@
 
-EXTRA_DIST = bootstrap $(DX_CONFIG) CHANGELOG config/README
+EXTRA_DIST = bootstrap CHANGELOG config/README

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,3 +21,9 @@ SUBDIRS = \
 @DX_RULES@
 
 EXTRA_DIST = bootstrap CHANGELOG config/README
+
+distcheck-hook:
+	if test -n "$(DX_CLEANFILES)" ; \
+	then \
+		$(MAKE) doxygen-doc ; \
+	fi

--- a/configure.ac
+++ b/configure.ac
@@ -219,9 +219,7 @@ DX_INIT_DOXYGEN($PACKAGE_NAME,
 		${srcdir}/doc/helper-guide/Doxyfile,
 		${builddir}/doc/helper-guide/output,
 		${srcdir}/doc/platform-api-guide/Doxyfile,
-		${builddir}/doc/platform-api-guide/output,
-		${srcdir}/doc/driver-api-guide/Doxyfile,
-		${builddir}/doc/driver-api-guide/output)
+		${builddir}/doc/platform-api-guide/output)
 
 ##########################################################################
 # Enable/disable ODP_DEBUG

--- a/doc/application-api-guide/Makefile.am
+++ b/doc/application-api-guide/Makefile.am
@@ -1,4 +1,5 @@
 EXTRA_DIST = \
+	     Doxyfile \
 	     api_guide_lines.dox \
 	     examples.dox \
 	     odp.dox \


### PR DESCRIPTION
- Fix one leftover from drv API removal.
- Hook doxygen-doc into distcheck to check that distribution contains all necessary files.