### PR TITLE
[PATCH v2] linux-gen: crypto: fix openssl_lock pointer type

### DIFF
--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -83,9 +83,9 @@ typedef struct odp_crypto_global_s odp_crypto_global_t;
 
 struct odp_crypto_global_s {
 	odp_spinlock_t                lock;
-	odp_ticketlock_t **openssl_lock;
 	odp_crypto_generic_session_t *free;
-	odp_crypto_generic_session_t  sessions[0];
+	odp_crypto_generic_session_t  sessions[MAX_SESSIONS];
+	odp_ticketlock_t              openssl_lock[0];
 };
 
 static odp_crypto_global_t *global;
@@ -961,11 +961,9 @@ static void ODP_UNUSED openssl_lock(int mode, int n,
 				    int line ODP_UNUSED)
 {
 	if (mode & CRYPTO_LOCK)
-		odp_ticketlock_lock((odp_ticketlock_t *)
-				    &global->openssl_lock[n]);
+		odp_ticketlock_lock(&global->openssl_lock[n]);
 	else
-		odp_ticketlock_unlock((odp_ticketlock_t *)
-				      &global->openssl_lock[n]);
+		odp_ticketlock_unlock(&global->openssl_lock[n]);
 }
 
 int
@@ -977,8 +975,7 @@ odp_crypto_init_global(void)
 	int nlocks = CRYPTO_num_locks();
 
 	/* Calculate the memory size we need */
-	mem_size  = sizeof(*global);
-	mem_size += (MAX_SESSIONS * sizeof(odp_crypto_generic_session_t));
+	mem_size  = sizeof(odp_crypto_global_t);
 	mem_size += nlocks * sizeof(odp_ticketlock_t);
 
 	/* Allocate our globally shared memory */
@@ -998,12 +995,8 @@ odp_crypto_init_global(void)
 	odp_spinlock_init(&global->lock);
 
 	if (nlocks > 0) {
-		global->openssl_lock =
-			(odp_ticketlock_t **)&global->sessions[MAX_SESSIONS];
-
 		for (idx = 0; idx < nlocks; idx++)
-			odp_ticketlock_init((odp_ticketlock_t *)
-					    &global->openssl_lock[idx]);
+			odp_ticketlock_init(&global->openssl_lock[idx]);
 
 		CRYPTO_THREADID_set_callback(openssl_thread_id);
 		CRYPTO_set_locking_callback(openssl_lock);


### PR DESCRIPTION
Wrong pointer type (pointer to pointer) to openssl_lock array
caused data overlapping when running on other than 64-bit
machines.

Fixed pointer type and simplified global data structure to
contain only one dynamically sized array (openssl locks).
Session array was already fixed size but was not defined as
such.

Signed-off-by: Petri Savolainen <petri.savolainen@linaro.org>
Signed-off-by: Viktor Tikkanen <viktor.tikkanen@nokia.com>