### PR TITLE
[PATCH 2.0 v1] linux-gen: pktio: remove extra indirection for accessing pktio_entry fields

### DIFF
--- a/platform/linux-generic/include/odp_classification_internal.h
+++ b/platform/linux-generic/include/odp_classification_internal.h
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-
 /**
  * @file
  *
@@ -37,7 +36,7 @@ Start function for Packet Classifier
 This function calls Classifier module internal functions for a given packet and
 selects destination queue and packet pool based on selected PMR and CoS.
 **/
-int cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
+int cls_classify_packet(odp_pktio_entry_t *entry, const uint8_t *base,
 			uint16_t pkt_len, uint32_t seg_len, odp_pool_t *pool,
 			odp_packet_hdr_t *pkt_hdr);
 
@@ -47,7 +46,7 @@ Packet IO classifier init
 This function does initialization of classifier object associated with pktio.
 This function should be called during pktio initialization.
 **/
-int pktio_classifier_init(pktio_entry_t *pktio);
+int pktio_classifier_init(odp_pktio_entry_t *pktio);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-
 /**
  * @file
  *
@@ -33,7 +32,7 @@ extern "C" {
 
 #define PKTIO_MAX_QUEUES 64
 /* Forward declaration */
-typedef union pktio_entry_u pktio_entry_t;
+typedef struct pktio_entry odp_pktio_entry_t;
 #include <odp_pktio_ops_subsystem.h>
 
 #define PKTIO_NAME_LEN 256
@@ -99,10 +98,12 @@ struct pktio_entry {
 	} out_queue[PKTIO_MAX_QUEUES];
 };
 
-union pktio_entry_u {
-	struct pktio_entry s;
-	uint8_t pad[ROUNDUP_CACHE_LINE(sizeof(struct pktio_entry))];
-};
+typedef union pktio_entry_u {
+	odp_pktio_entry_t s;
+	uint8_t pad[ROUNDUP_CACHE_LINE(sizeof(odp_pktio_entry_t))];
+} pktio_entry_t;
+
+#define ODP_PKTIO_ENTRY(_p) ((odp_pktio_entry_t *)(uintptr_t)_p)
 
 typedef struct {
 	odp_spinlock_t lock;
@@ -116,7 +117,7 @@ static inline int pktio_to_id(odp_pktio_t pktio)
 	return _odp_typeval(pktio) - 1;
 }
 
-static inline pktio_entry_t *get_pktio_entry(odp_pktio_t pktio)
+static inline odp_pktio_entry_t *get_pktio_entry(odp_pktio_t pktio)
 {
 	if (odp_unlikely(pktio == ODP_PKTIO_INVALID))
 		return NULL;
@@ -127,17 +128,17 @@ static inline pktio_entry_t *get_pktio_entry(odp_pktio_t pktio)
 		return NULL;
 	}
 
-	return pktio_entry_ptr[pktio_to_id(pktio)];
+	return ODP_PKTIO_ENTRY(pktio_entry_ptr[pktio_to_id(pktio)]);
 }
 
-static inline int pktio_cls_enabled(pktio_entry_t *entry)
+static inline int pktio_cls_enabled(odp_pktio_entry_t *entry)
 {
-	return entry->s.cls_enabled;
+	return entry->cls_enabled;
 }
 
-static inline void pktio_cls_enabled_set(pktio_entry_t *entry, int ena)
+static inline void pktio_cls_enabled_set(odp_pktio_entry_t *entry, int ena)
 {
-	entry->s.cls_enabled = ena;
+	entry->cls_enabled = ena;
 }
 
 int pktin_poll_one(int pktio_index,

--- a/platform/linux-generic/include/odp_pktio_ops_subsystem.h
+++ b/platform/linux-generic/include/odp_pktio_ops_subsystem.h
@@ -22,36 +22,36 @@ ODP_SUBSYSTEM_DECLARE(pktio_ops);
 
 /* Subsystem APIs declarations */
 ODP_SUBSYSTEM_API(pktio_ops, int, open, odp_pktio_t,
-		  pktio_entry_t *, const char *, odp_pool_t);
-ODP_SUBSYSTEM_API(pktio_ops, int, close, pktio_entry_t *);
-ODP_SUBSYSTEM_API(pktio_ops, int, start, pktio_entry_t *);
-ODP_SUBSYSTEM_API(pktio_ops, int, stop, pktio_entry_t *);
-ODP_SUBSYSTEM_API(pktio_ops, int, stats, pktio_entry_t *,
+		  odp_pktio_entry_t *, const char *, odp_pool_t);
+ODP_SUBSYSTEM_API(pktio_ops, int, close, odp_pktio_entry_t *);
+ODP_SUBSYSTEM_API(pktio_ops, int, start, odp_pktio_entry_t *);
+ODP_SUBSYSTEM_API(pktio_ops, int, stop, odp_pktio_entry_t *);
+ODP_SUBSYSTEM_API(pktio_ops, int, stats, odp_pktio_entry_t *,
 		  odp_pktio_stats_t *stats);
-ODP_SUBSYSTEM_API(pktio_ops, int, stats_reset, pktio_entry_t *);
-ODP_SUBSYSTEM_API(pktio_ops, uint64_t, pktin_ts_res, pktio_entry_t *);
+ODP_SUBSYSTEM_API(pktio_ops, int, stats_reset, odp_pktio_entry_t *);
+ODP_SUBSYSTEM_API(pktio_ops, uint64_t, pktin_ts_res, odp_pktio_entry_t *);
 ODP_SUBSYSTEM_API(pktio_ops, odp_time_t, pktin_ts_from_ns,
-		  pktio_entry_t *, uint64_t ns);
-ODP_SUBSYSTEM_API(pktio_ops, int, recv, pktio_entry_t *,
+		  odp_pktio_entry_t *, uint64_t ns);
+ODP_SUBSYSTEM_API(pktio_ops, int, recv, odp_pktio_entry_t *,
 		  int index, odp_packet_t packets[], int count);
-ODP_SUBSYSTEM_API(pktio_ops, int, send, pktio_entry_t *,
+ODP_SUBSYSTEM_API(pktio_ops, int, send, odp_pktio_entry_t *,
 		  int index, const odp_packet_t packets[], int count);
-ODP_SUBSYSTEM_API(pktio_ops, uint32_t, mtu_get, pktio_entry_t *);
+ODP_SUBSYSTEM_API(pktio_ops, uint32_t, mtu_get, odp_pktio_entry_t *);
 ODP_SUBSYSTEM_API(pktio_ops, int, promisc_mode_set,
-		  pktio_entry_t *, int enable);
-ODP_SUBSYSTEM_API(pktio_ops, int, promisc_mode_get, pktio_entry_t *);
-ODP_SUBSYSTEM_API(pktio_ops, int, mac_get, pktio_entry_t *, void *);
-ODP_SUBSYSTEM_API(pktio_ops, int, mac_set, pktio_entry_t *, const void *);
-ODP_SUBSYSTEM_API(pktio_ops, int, link_status, pktio_entry_t *);
-ODP_SUBSYSTEM_API(pktio_ops, int, capability, pktio_entry_t *,
+		  odp_pktio_entry_t *, int enable);
+ODP_SUBSYSTEM_API(pktio_ops, int, promisc_mode_get, odp_pktio_entry_t *);
+ODP_SUBSYSTEM_API(pktio_ops, int, mac_get, odp_pktio_entry_t *, void *);
+ODP_SUBSYSTEM_API(pktio_ops, int, mac_set, odp_pktio_entry_t *, const void *);
+ODP_SUBSYSTEM_API(pktio_ops, int, link_status, odp_pktio_entry_t *);
+ODP_SUBSYSTEM_API(pktio_ops, int, capability, odp_pktio_entry_t *,
 		  odp_pktio_capability_t *);
-ODP_SUBSYSTEM_API(pktio_ops, int, config, pktio_entry_t *,
+ODP_SUBSYSTEM_API(pktio_ops, int, config, odp_pktio_entry_t *,
 		  const odp_pktio_config_t *);
 ODP_SUBSYSTEM_API(pktio_ops, int, input_queues_config,
-		  pktio_entry_t *, const odp_pktin_queue_param_t *);
+		  odp_pktio_entry_t *, const odp_pktin_queue_param_t *);
 ODP_SUBSYSTEM_API(pktio_ops, int, output_queues_config,
-		  pktio_entry_t *, const odp_pktout_queue_param_t *);
-ODP_SUBSYSTEM_API(pktio_ops, void, print, pktio_entry_t *);
+		  odp_pktio_entry_t *, const odp_pktout_queue_param_t *);
+ODP_SUBSYSTEM_API(pktio_ops, void, print, odp_pktio_entry_t *);
 
 /* Declare subsystem init and term routines */
 ODP_SUBSYSTEM_API(pktio_ops, int, init_global, bool);
@@ -90,7 +90,7 @@ typedef ODP_MODULE_CLASS(pktio_ops) {
 
 /* Extract pktio ops data from pktio entry structure */
 #define odp_ops_data(_p, _mod) \
-	((pktio_ops_ ## _mod ## _data_t *)(uintptr_t)_p->s.ops_data)
+	((pktio_ops_ ## _mod ## _data_t *)(uintptr_t)_p->ops_data)
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -43,14 +43,14 @@ static pktio_table_t *pktio_tbl;
 /* pktio pointer entries ( for inlines) */
 void *pktio_entry_ptr[ODP_CONFIG_PKTIO_ENTRIES];
 
-static inline pktio_entry_t *pktio_entry_by_index(int index)
+static inline odp_pktio_entry_t *pktio_entry_by_index(int index)
 {
-	return pktio_entry_ptr[index];
+	return ODP_PKTIO_ENTRY(pktio_entry_ptr[index]);
 }
 
 int odp_pktio_init_global(void)
 {
-	pktio_entry_t *pktio_entry;
+	odp_pktio_entry_t *pktio_entry;
 	int i;
 	odp_shm_t shm;
 
@@ -67,14 +67,13 @@ int odp_pktio_init_global(void)
 	odp_spinlock_init(&pktio_tbl->lock);
 
 	for (i = 0; i < ODP_CONFIG_PKTIO_ENTRIES; ++i) {
-		pktio_entry = &pktio_tbl->entries[i];
-
-		odp_ticketlock_init(&pktio_entry->s.rxl);
-		odp_ticketlock_init(&pktio_entry->s.txl);
-		odp_spinlock_init(&pktio_entry->s.cls.l2_cos_table.lock);
-		odp_spinlock_init(&pktio_entry->s.cls.l3_cos_table.lock);
-
+		pktio_entry = ODP_PKTIO_ENTRY(&pktio_tbl->entries[i]);
 		pktio_entry_ptr[i] = pktio_entry;
+
+		odp_ticketlock_init(&pktio_entry->rxl);
+		odp_ticketlock_init(&pktio_entry->txl);
+		odp_spinlock_init(&pktio_entry->cls.l2_cos_table.lock);
+		odp_spinlock_init(&pktio_entry->cls.l3_cos_table.lock);
 	}
 
 	return odp_pktio_ops_init_global(true);
@@ -85,45 +84,45 @@ int odp_pktio_init_local(void)
 	return odp_pktio_ops_init_local(true);
 }
 
-static inline int is_free(pktio_entry_t *entry)
+static inline int is_free(odp_pktio_entry_t *entry)
 {
-	return (entry->s.state == PKTIO_STATE_FREE);
+	return (entry->state == PKTIO_STATE_FREE);
 }
 
-static void lock_entry(pktio_entry_t *entry)
+static void lock_entry(odp_pktio_entry_t *entry)
 {
-	odp_ticketlock_lock(&entry->s.rxl);
-	odp_ticketlock_lock(&entry->s.txl);
+	odp_ticketlock_lock(&entry->rxl);
+	odp_ticketlock_lock(&entry->txl);
 }
 
-static void unlock_entry(pktio_entry_t *entry)
+static void unlock_entry(odp_pktio_entry_t *entry)
 {
-	odp_ticketlock_unlock(&entry->s.txl);
-	odp_ticketlock_unlock(&entry->s.rxl);
+	odp_ticketlock_unlock(&entry->txl);
+	odp_ticketlock_unlock(&entry->rxl);
 }
 
-static void init_in_queues(pktio_entry_t *entry)
-{
-	int i;
-
-	for (i = 0; i < PKTIO_MAX_QUEUES; i++) {
-		entry->s.in_queue[i].queue = ODP_QUEUE_INVALID;
-		entry->s.in_queue[i].queue_int = QUEUE_NULL;
-		entry->s.in_queue[i].pktin = PKTIN_INVALID;
-	}
-}
-
-static void init_out_queues(pktio_entry_t *entry)
+static void init_in_queues(odp_pktio_entry_t *entry)
 {
 	int i;
 
 	for (i = 0; i < PKTIO_MAX_QUEUES; i++) {
-		entry->s.out_queue[i].queue  = ODP_QUEUE_INVALID;
-		entry->s.out_queue[i].pktout = PKTOUT_INVALID;
+		entry->in_queue[i].queue = ODP_QUEUE_INVALID;
+		entry->in_queue[i].queue_int = QUEUE_NULL;
+		entry->in_queue[i].pktin = PKTIN_INVALID;
 	}
 }
 
-static void init_pktio_entry(pktio_entry_t *entry)
+static void init_out_queues(odp_pktio_entry_t *entry)
+{
+	int i;
+
+	for (i = 0; i < PKTIO_MAX_QUEUES; i++) {
+		entry->out_queue[i].queue  = ODP_QUEUE_INVALID;
+		entry->out_queue[i].pktout = PKTOUT_INVALID;
+	}
+}
+
+static void init_pktio_entry(odp_pktio_entry_t *entry)
 {
 	pktio_cls_enabled_set(entry, 0);
 
@@ -135,17 +134,17 @@ static void init_pktio_entry(pktio_entry_t *entry)
 
 static odp_pktio_t alloc_lock_pktio_entry(void)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int i;
 
 	for (i = 0; i < ODP_CONFIG_PKTIO_ENTRIES; ++i) {
-		entry = &pktio_tbl->entries[i];
+		entry = ODP_PKTIO_ENTRY(&pktio_tbl->entries[i]);
 		if (is_free(entry)) {
 			lock_entry(entry);
 			if (is_free(entry)) {
 				odp_pktio_t hdl;
 
-				entry->s.state = PKTIO_STATE_ACTIVE;
+				entry->state = PKTIO_STATE_ACTIVE;
 				init_pktio_entry(entry);
 				hdl = _odp_cast_scalar(odp_pktio_t, i + 1);
 				return hdl; /* return with entry locked! */
@@ -161,7 +160,7 @@ static odp_pktio_t setup_pktio_entry(const char *name, odp_pool_t pool,
 				     const odp_pktio_param_t *param)
 {
 	odp_pktio_t hdl;
-	pktio_entry_t *pktio_entry;
+	odp_pktio_entry_t *pktio_entry;
 	pktio_ops_module_t *mod;
 
 	if (strlen(name) >= PKTIO_NAME_LEN - 1) {
@@ -182,32 +181,33 @@ static odp_pktio_t setup_pktio_entry(const char *name, odp_pool_t pool,
 	if (!pktio_entry)
 		return ODP_PKTIO_INVALID;
 
-	pktio_entry->s.ops = NULL; /* Reset stale ops */
-	pktio_entry->s.pool = pool;
-	memcpy(&pktio_entry->s.param, param, sizeof(odp_pktio_param_t));
-	pktio_entry->s.handle = hdl;
-	pktio_entry->s.stats_type = STATS_UNSUPPORTED;
+	pktio_entry->ops = NULL; /* Reset stale ops */
+	pktio_entry->pool = pool;
+	memcpy(&pktio_entry->param, param, sizeof(odp_pktio_param_t));
+	pktio_entry->handle = hdl;
+	pktio_entry->stats_type = STATS_UNSUPPORTED;
 
-	odp_pktio_config_init(&pktio_entry->s.config);
+	odp_pktio_config_init(&pktio_entry->config);
 
 	odp_subsystem_lock(read, pktio_ops);
 	odp_subsystem_foreach_module(pktio_ops, mod) {
-		if (0 == mod->open(hdl, pktio_entry, name, pool)) {
-			pktio_entry->s.ops = mod;
+		if (0 == mod->open(hdl, pktio_entry,
+				   name, pool)) {
+			pktio_entry->ops = mod;
 			ODP_DBG("%s uses %s\n", name, mod->base.name);
 			break;
 		}
 	}
 	odp_subsystem_unlock(read, pktio_ops);
 
-	if (pktio_entry->s.ops == NULL) {
-		pktio_entry->s.state = PKTIO_STATE_FREE;
+	if (pktio_entry->ops == NULL) {
+		pktio_entry->state = PKTIO_STATE_FREE;
 		hdl = ODP_PKTIO_INVALID;
 		ODP_ERR("Unable to init any I/O type.\n");
 	} else {
-		snprintf(pktio_entry->s.name,
-			 sizeof(pktio_entry->s.name), "%s", name);
-		pktio_entry->s.state = PKTIO_STATE_OPENED;
+		snprintf(pktio_entry->name,
+			 sizeof(pktio_entry->name), "%s", name);
+		pktio_entry->state = PKTIO_STATE_OPENED;
 	}
 
 	unlock_entry(pktio_entry);
@@ -255,68 +255,68 @@ odp_pktio_t odp_pktio_open(const char *name, odp_pool_t pool,
 	return hdl;
 }
 
-static int _pktio_close(pktio_entry_t *entry)
+static int _pktio_close(odp_pktio_entry_t *entry)
 {
 	int ret;
-	int state = entry->s.state;
+	int state = entry->state;
 
 	if (state != PKTIO_STATE_OPENED &&
 	    state != PKTIO_STATE_STOPPED &&
 	    state != PKTIO_STATE_STOP_PENDING)
 		return -1;
 
-	ret = entry->s.ops->close(entry);
+	ret = entry->ops->close(entry);
 	if (ret)
 		return -1;
 
 	if (state == PKTIO_STATE_STOP_PENDING)
-		entry->s.state = PKTIO_STATE_CLOSE_PENDING;
+		entry->state = PKTIO_STATE_CLOSE_PENDING;
 	else
-		entry->s.state = PKTIO_STATE_FREE;
+		entry->state = PKTIO_STATE_FREE;
 
 	return 0;
 }
 
-static void destroy_in_queues(pktio_entry_t *entry, int num)
+static void destroy_in_queues(odp_pktio_entry_t *entry, int num)
 {
 	int i;
 
 	for (i = 0; i < num; i++) {
-		if (entry->s.in_queue[i].queue != ODP_QUEUE_INVALID) {
-			odp_queue_destroy(entry->s.in_queue[i].queue);
-			entry->s.in_queue[i].queue = ODP_QUEUE_INVALID;
-			entry->s.in_queue[i].queue_int = QUEUE_NULL;
+		if (entry->in_queue[i].queue != ODP_QUEUE_INVALID) {
+			odp_queue_destroy(entry->in_queue[i].queue);
+			entry->in_queue[i].queue = ODP_QUEUE_INVALID;
+			entry->in_queue[i].queue_int = QUEUE_NULL;
 		}
 	}
 }
 
-static void destroy_out_queues(pktio_entry_t *entry, int num)
+static void destroy_out_queues(odp_pktio_entry_t *entry, int num)
 {
 	int i, rc;
 
 	for (i = 0; i < num; i++) {
-		if (entry->s.out_queue[i].queue != ODP_QUEUE_INVALID) {
-			rc = odp_queue_destroy(entry->s.out_queue[i].queue);
+		if (entry->out_queue[i].queue != ODP_QUEUE_INVALID) {
+			rc = odp_queue_destroy(entry->out_queue[i].queue);
 			ODP_ASSERT(rc == 0);
-			entry->s.out_queue[i].queue = ODP_QUEUE_INVALID;
+			entry->out_queue[i].queue = ODP_QUEUE_INVALID;
 		}
 	}
 }
 
-static void flush_in_queues(pktio_entry_t *entry)
+static void flush_in_queues(odp_pktio_entry_t *entry)
 {
 	odp_pktin_mode_t mode;
 	int num, i;
 	int max_pkts = 16;
 	odp_packet_t packets[max_pkts];
 
-	mode = entry->s.param.in_mode;
-	num  = entry->s.num_in_queue;
+	mode = entry->param.in_mode;
+	num  = entry->num_in_queue;
 
 	if (mode == ODP_PKTIN_MODE_DIRECT) {
 		for (i = 0; i < num; i++) {
 			int ret;
-			odp_pktin_queue_t pktin = entry->s.in_queue[i].pktin;
+			odp_pktin_queue_t pktin = entry->in_queue[i].pktin;
 
 			while ((ret = odp_pktin_recv(pktin, packets,
 						     max_pkts))) {
@@ -333,28 +333,28 @@ static void flush_in_queues(pktio_entry_t *entry)
 
 int odp_pktio_close(odp_pktio_t hdl)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int res;
 
 	entry = get_pktio_entry(hdl);
 	if (entry == NULL)
 		return -1;
 
-	if (entry->s.state == PKTIO_STATE_STARTED) {
+	if (entry->state == PKTIO_STATE_STARTED) {
 		ODP_DBG("Missing odp_pktio_stop() before close.\n");
 		return -1;
 	}
 
-	if (entry->s.state == PKTIO_STATE_STOPPED)
+	if (entry->state == PKTIO_STATE_STOPPED)
 		flush_in_queues(entry);
 
 	lock_entry(entry);
 
-	destroy_in_queues(entry, entry->s.num_in_queue);
-	destroy_out_queues(entry, entry->s.num_out_queue);
+	destroy_in_queues(entry, entry->num_in_queue);
+	destroy_out_queues(entry, entry->num_out_queue);
 
-	entry->s.num_in_queue  = 0;
-	entry->s.num_out_queue = 0;
+	entry->num_in_queue  = 0;
+	entry->num_out_queue = 0;
 
 	odp_spinlock_lock(&pktio_tbl->lock);
 	res = _pktio_close(entry);
@@ -369,7 +369,7 @@ int odp_pktio_close(odp_pktio_t hdl)
 
 int odp_pktio_config(odp_pktio_t hdl, const odp_pktio_config_t *config)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	odp_pktio_capability_t capa;
 	odp_pktio_config_t default_config;
 	int res = 0;
@@ -402,16 +402,16 @@ int odp_pktio_config(odp_pktio_t hdl, const odp_pktio_config_t *config)
 	}
 
 	lock_entry(entry);
-	if (entry->s.state == PKTIO_STATE_STARTED) {
+	if (entry->state == PKTIO_STATE_STARTED) {
 		unlock_entry(entry);
-		ODP_DBG("pktio %s: not stopped\n", entry->s.name);
+		ODP_DBG("pktio %s: not stopped\n", entry->name);
 		return -1;
 	}
 
-	entry->s.config = *config;
+	entry->config = *config;
 
-	if (entry->s.ops->config)
-		res = entry->s.ops->config(entry, config);
+	if (entry->ops->config)
+		res = entry->ops->config(entry, config);
 
 	unlock_entry(entry);
 
@@ -420,7 +420,7 @@ int odp_pktio_config(odp_pktio_t hdl, const odp_pktio_config_t *config)
 
 int odp_pktio_start(odp_pktio_t hdl)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	odp_pktin_mode_t mode;
 	int res = 0;
 
@@ -429,30 +429,30 @@ int odp_pktio_start(odp_pktio_t hdl)
 		return -1;
 
 	lock_entry(entry);
-	if (entry->s.state == PKTIO_STATE_STARTED) {
+	if (entry->state == PKTIO_STATE_STARTED) {
 		unlock_entry(entry);
 		return -1;
 	}
-	if (entry->s.ops->start)
-		res = entry->s.ops->start(entry);
+	if (entry->ops->start)
+		res = entry->ops->start(entry);
 	if (!res)
-		entry->s.state = PKTIO_STATE_STARTED;
+		entry->state = PKTIO_STATE_STARTED;
 
 	unlock_entry(entry);
 
-	mode = entry->s.param.in_mode;
+	mode = entry->param.in_mode;
 
 	if (mode == ODP_PKTIN_MODE_SCHED) {
 		unsigned i;
-		unsigned num = entry->s.num_in_queue;
+		unsigned num = entry->num_in_queue;
 		int index[num];
 		odp_queue_t odpq[num];
 
 		for (i = 0; i < num; i++) {
 			index[i] = i;
-			odpq[i] = entry->s.in_queue[i].queue;
+			odpq[i] = entry->in_queue[i].queue;
 
-			if (entry->s.in_queue[i].queue == ODP_QUEUE_INVALID) {
+			if (entry->in_queue[i].queue == ODP_QUEUE_INVALID) {
 				ODP_ERR("No input queue\n");
 				return -1;
 			}
@@ -464,31 +464,31 @@ int odp_pktio_start(odp_pktio_t hdl)
 	return res;
 }
 
-static int _pktio_stop(pktio_entry_t *entry)
+static int _pktio_stop(odp_pktio_entry_t *entry)
 {
 	int res = 0;
-	odp_pktin_mode_t mode = entry->s.param.in_mode;
+	odp_pktin_mode_t mode = entry->param.in_mode;
 
-	if (entry->s.state != PKTIO_STATE_STARTED)
+	if (entry->state != PKTIO_STATE_STARTED)
 		return -1;
 
-	if (entry->s.ops->stop)
-		res = entry->s.ops->stop(entry);
+	if (entry->ops->stop)
+		res = entry->ops->stop(entry);
 
 	if (res)
 		return -1;
 
 	if (mode == ODP_PKTIN_MODE_SCHED)
-		entry->s.state = PKTIO_STATE_STOP_PENDING;
+		entry->state = PKTIO_STATE_STOP_PENDING;
 	else
-		entry->s.state = PKTIO_STATE_STOPPED;
+		entry->state = PKTIO_STATE_STOPPED;
 
 	return res;
 }
 
 int odp_pktio_stop(odp_pktio_t hdl)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int res;
 
 	entry = get_pktio_entry(hdl);
@@ -505,7 +505,7 @@ int odp_pktio_stop(odp_pktio_t hdl)
 odp_pktio_t odp_pktio_lookup(const char *name)
 {
 	odp_pktio_t hdl = ODP_PKTIO_INVALID;
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int i;
 
 	odp_spinlock_lock(&pktio_tbl->lock);
@@ -517,8 +517,8 @@ odp_pktio_t odp_pktio_lookup(const char *name)
 
 		lock_entry(entry);
 
-		if (entry->s.state >= PKTIO_STATE_ACTIVE &&
-		    strncmp(entry->s.name, name, sizeof(entry->s.name)) == 0)
+		if (entry->state >= PKTIO_STATE_ACTIVE &&
+		    strncmp(entry->name, name, sizeof(entry->name)) == 0)
 			hdl = _odp_cast_scalar(odp_pktio_t, i + 1);
 
 		unlock_entry(entry);
@@ -652,24 +652,24 @@ int pktin_poll_one(int pktio_index,
 		   odp_event_t evt_tbl[QUEUE_MULTI_MAX])
 {
 	int num_rx, num_pkts, i;
-	pktio_entry_t *entry = pktio_entry_by_index(pktio_index);
+	odp_pktio_entry_t *entry = pktio_entry_by_index(pktio_index);
 	odp_packet_t pkt;
 	odp_packet_hdr_t *pkt_hdr;
 	odp_buffer_hdr_t *buf_hdr;
 	odp_packet_t packets[QUEUE_MULTI_MAX];
 	queue_t queue;
 
-	if (odp_unlikely(entry->s.state != PKTIO_STATE_STARTED)) {
-		if (entry->s.state < PKTIO_STATE_ACTIVE ||
-		    entry->s.state == PKTIO_STATE_STOP_PENDING)
+	if (odp_unlikely(entry->state != PKTIO_STATE_STARTED)) {
+		if (entry->state < PKTIO_STATE_ACTIVE ||
+		    entry->state == PKTIO_STATE_STOP_PENDING)
 			return -1;
 
 		ODP_DBG("interface not started\n");
 		return 0;
 	}
 
-	ODP_ASSERT((unsigned)rx_queue < entry->s.num_in_queue);
-	num_pkts = entry->s.ops->recv(entry, rx_queue,
+	ODP_ASSERT((unsigned)rx_queue < entry->num_in_queue);
+	num_pkts = entry->ops->recv(entry, rx_queue,
 				      packets, QUEUE_MULTI_MAX);
 
 	num_rx = 0;
@@ -682,7 +682,7 @@ int pktin_poll_one(int pktio_index,
 			if (queue_fn->enq_multi(queue, &buf_hdr, 1) < 0) {
 				/* Queue full? */
 				odp_packet_free(pkt);
-				__atomic_fetch_add(&entry->s.stats.in_discards,
+				__atomic_fetch_add(&entry->stats.in_discards,
 						   1,
 						   __ATOMIC_RELAXED);
 			}
@@ -697,9 +697,9 @@ int pktin_poll(int pktio_index, int num_queue, int index[])
 {
 	odp_buffer_hdr_t *hdr_tbl[QUEUE_MULTI_MAX];
 	int num, idx;
-	pktio_entry_t *entry;
-	entry = pktio_entry_by_index(pktio_index);
-	int state = entry->s.state;
+	odp_pktio_entry_t *entry =
+		pktio_entry_by_index(pktio_index);
+	int state = entry->state;
 
 	if (odp_unlikely(state != PKTIO_STATE_STARTED)) {
 		if (state < PKTIO_STATE_ACTIVE ||
@@ -712,7 +712,7 @@ int pktin_poll(int pktio_index, int num_queue, int index[])
 
 	for (idx = 0; idx < num_queue; idx++) {
 		queue_t q_int;
-		odp_pktin_queue_t pktin = entry->s.in_queue[index[idx]].pktin;
+		odp_pktin_queue_t pktin = entry->in_queue[index[idx]].pktin;
 
 		num = pktin_recv_buf(pktin, hdr_tbl, QUEUE_MULTI_MAX);
 
@@ -724,7 +724,7 @@ int pktin_poll(int pktio_index, int num_queue, int index[])
 			return -1;
 		}
 
-		q_int = entry->s.in_queue[index[idx]].queue_int;
+		q_int = entry->in_queue[index[idx]].queue_int;
 		queue_fn->enq_multi(q_int, hdr_tbl, num);
 	}
 
@@ -734,11 +734,12 @@ int pktin_poll(int pktio_index, int num_queue, int index[])
 void pktio_stop_finalize(int pktio_index)
 {
 	int state;
-	pktio_entry_t *entry = pktio_entry_by_index(pktio_index);
+	odp_pktio_entry_t *entry =
+		pktio_entry_by_index(pktio_index);
 
 	lock_entry(entry);
 
-	state = entry->s.state;
+	state = entry->state;
 
 	if (state != PKTIO_STATE_STOP_PENDING &&
 	    state != PKTIO_STATE_CLOSE_PENDING) {
@@ -748,16 +749,16 @@ void pktio_stop_finalize(int pktio_index)
 	}
 
 	if (state == PKTIO_STATE_STOP_PENDING)
-		entry->s.state = PKTIO_STATE_STOPPED;
+		entry->state = PKTIO_STATE_STOPPED;
 	else
-		entry->s.state = PKTIO_STATE_FREE;
+		entry->state = PKTIO_STATE_FREE;
 
 	unlock_entry(entry);
 }
 
 uint32_t odp_pktio_mtu(odp_pktio_t hdl)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	uint32_t ret = 0;
 
 	entry = get_pktio_entry(hdl);
@@ -774,8 +775,8 @@ uint32_t odp_pktio_mtu(odp_pktio_t hdl)
 		return 0;
 	}
 
-	if (entry->s.ops->mtu_get)
-		ret = entry->s.ops->mtu_get(entry);
+	if (entry->ops->mtu_get)
+		ret = entry->ops->mtu_get(entry);
 
 	unlock_entry(entry);
 	return ret;
@@ -783,7 +784,7 @@ uint32_t odp_pktio_mtu(odp_pktio_t hdl)
 
 int odp_pktio_promisc_mode_set(odp_pktio_t hdl, odp_bool_t enable)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int ret = -1;
 
 	entry = get_pktio_entry(hdl);
@@ -799,13 +800,13 @@ int odp_pktio_promisc_mode_set(odp_pktio_t hdl, odp_bool_t enable)
 		ODP_DBG("already freed pktio\n");
 		return -1;
 	}
-	if (entry->s.state == PKTIO_STATE_STARTED) {
+	if (entry->state == PKTIO_STATE_STARTED) {
 		unlock_entry(entry);
 		return -1;
 	}
 
-	if (entry->s.ops->promisc_mode_set)
-		ret = entry->s.ops->promisc_mode_set(entry, enable);
+	if (entry->ops->promisc_mode_set)
+		ret = entry->ops->promisc_mode_set(entry, enable);
 
 	unlock_entry(entry);
 	return ret;
@@ -813,7 +814,7 @@ int odp_pktio_promisc_mode_set(odp_pktio_t hdl, odp_bool_t enable)
 
 int odp_pktio_promisc_mode(odp_pktio_t hdl)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int ret = -1;
 
 	entry = get_pktio_entry(hdl);
@@ -830,8 +831,8 @@ int odp_pktio_promisc_mode(odp_pktio_t hdl)
 		return -1;
 	}
 
-	if (entry->s.ops->promisc_mode_get)
-		ret = entry->s.ops->promisc_mode_get(entry);
+	if (entry->ops->promisc_mode_get)
+		ret = entry->ops->promisc_mode_get(entry);
 	unlock_entry(entry);
 
 	return ret;
@@ -839,7 +840,7 @@ int odp_pktio_promisc_mode(odp_pktio_t hdl)
 
 int odp_pktio_mac_addr(odp_pktio_t hdl, void *mac_addr, int addr_size)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int ret = ETH_ALEN;
 
 	if (addr_size < ETH_ALEN) {
@@ -861,8 +862,8 @@ int odp_pktio_mac_addr(odp_pktio_t hdl, void *mac_addr, int addr_size)
 		return -1;
 	}
 
-	if (entry->s.ops->mac_get) {
-		ret = entry->s.ops->mac_get(entry, mac_addr);
+	if (entry->ops->mac_get) {
+		ret = entry->ops->mac_get(entry, mac_addr);
 	} else {
 		ODP_DBG("pktio does not support mac addr get\n");
 		ret = -1;
@@ -874,7 +875,7 @@ int odp_pktio_mac_addr(odp_pktio_t hdl, void *mac_addr, int addr_size)
 
 int odp_pktio_mac_addr_set(odp_pktio_t hdl, const void *mac_addr, int addr_size)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int ret = -1;
 
 	if (addr_size < ETH_ALEN) {
@@ -896,13 +897,13 @@ int odp_pktio_mac_addr_set(odp_pktio_t hdl, const void *mac_addr, int addr_size)
 		return -1;
 	}
 
-	if (entry->s.state == PKTIO_STATE_STARTED) {
+	if (entry->state == PKTIO_STATE_STARTED) {
 		unlock_entry(entry);
 		return -1;
 	}
 
-	if (entry->s.ops->mac_set)
-		ret = entry->s.ops->mac_set(entry, mac_addr);
+	if (entry->ops->mac_set)
+		ret = entry->ops->mac_set(entry, mac_addr);
 
 	unlock_entry(entry);
 	return ret;
@@ -910,7 +911,7 @@ int odp_pktio_mac_addr_set(odp_pktio_t hdl, const void *mac_addr, int addr_size)
 
 int odp_pktio_link_status(odp_pktio_t hdl)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int ret = -1;
 
 	entry = get_pktio_entry(hdl);
@@ -927,8 +928,8 @@ int odp_pktio_link_status(odp_pktio_t hdl)
 		return -1;
 	}
 
-	if (entry->s.ops->link_status)
-		ret = entry->s.ops->link_status(entry);
+	if (entry->ops->link_status)
+		ret = entry->ops->link_status(entry);
 	unlock_entry(entry);
 
 	return ret;
@@ -966,7 +967,7 @@ void odp_pktio_config_init(odp_pktio_config_t *config)
 
 int odp_pktio_info(odp_pktio_t hdl, odp_pktio_info_t *info)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 
 	entry = get_pktio_entry(hdl);
 
@@ -976,17 +977,19 @@ int odp_pktio_info(odp_pktio_t hdl, odp_pktio_info_t *info)
 	}
 
 	memset(info, 0, sizeof(odp_pktio_info_t));
-	info->name = entry->s.name;
-	info->drv_name = entry->s.ops->base.name;
-	info->pool = entry->s.pool;
-	memcpy(&info->param, &entry->s.param, sizeof(odp_pktio_param_t));
+	info->name = entry->name;
+	info->drv_name = entry->ops->base.name;
+	info->pool = entry->pool;
+	memcpy(&info->param, &entry->param, sizeof(odp_pktio_param_t));
 
 	return 0;
 }
 
 int odp_pktio_index(odp_pktio_t pktio)
 {
-	pktio_entry_t *entry = get_pktio_entry(pktio);
+	odp_pktio_entry_t *entry;
+
+	entry = get_pktio_entry(pktio);
 
 	if (!entry || is_free(entry))
 		return -1;
@@ -996,7 +999,7 @@ int odp_pktio_index(odp_pktio_t pktio)
 
 uint64_t odp_pktin_ts_res(odp_pktio_t hdl)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 
 	entry = get_pktio_entry(hdl);
 
@@ -1005,15 +1008,15 @@ uint64_t odp_pktin_ts_res(odp_pktio_t hdl)
 		return 0;
 	}
 
-	if (entry->s.ops->pktin_ts_res)
-		return entry->s.ops->pktin_ts_res(entry);
+	if (entry->ops->pktin_ts_res)
+		return entry->ops->pktin_ts_res(entry);
 
 	return odp_time_global_res();
 }
 
 odp_time_t odp_pktin_ts_from_ns(odp_pktio_t hdl, uint64_t ns)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 
 	entry = get_pktio_entry(hdl);
 
@@ -1022,15 +1025,15 @@ odp_time_t odp_pktin_ts_from_ns(odp_pktio_t hdl, uint64_t ns)
 		return ODP_TIME_NULL;
 	}
 
-	if (entry->s.ops->pktin_ts_from_ns)
-		return entry->s.ops->pktin_ts_from_ns(entry, ns);
+	if (entry->ops->pktin_ts_from_ns)
+		return entry->ops->pktin_ts_from_ns(entry, ns);
 
 	return odp_time_global_from_ns(ns);
 }
 
 void odp_pktio_print(odp_pktio_t hdl)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	odp_pktio_capability_t capa;
 	uint8_t addr[ETH_ALEN];
 	int max_len = 512;
@@ -1050,16 +1053,16 @@ void odp_pktio_print(odp_pktio_t hdl)
 			"  handle            %" PRIu64 "\n",
 			odp_pktio_to_u64(hdl));
 	len += snprintf(&str[len], n - len,
-			"  name              %s\n", entry->s.name);
+			"  name              %s\n", entry->name);
 	len += snprintf(&str[len], n - len,
-			"  type              %s\n", entry->s.ops->base.name);
+			"  type              %s\n", entry->ops->base.name);
 	len += snprintf(&str[len], n - len,
 			"  state             %s\n",
-			entry->s.state ==  PKTIO_STATE_STARTED ? "start" :
-		       (entry->s.state ==  PKTIO_STATE_STOPPED ? "stop" :
-		       (entry->s.state ==  PKTIO_STATE_STOP_PENDING ?
+			entry->state ==  PKTIO_STATE_STARTED ? "start" :
+		       (entry->state ==  PKTIO_STATE_STOPPED ? "stop" :
+		       (entry->state ==  PKTIO_STATE_STOP_PENDING ?
 			"stop pending" :
-		       (entry->s.state ==  PKTIO_STATE_OPENED ? "opened" :
+		       (entry->state ==  PKTIO_STATE_OPENED ? "opened" :
 								"unknown"))));
 	memset(addr, 0, sizeof(addr));
 	odp_pktio_mac_addr(hdl, addr, ETH_ALEN);
@@ -1084,8 +1087,8 @@ void odp_pktio_print(odp_pktio_t hdl)
 
 	ODP_PRINT("\n%s", str);
 
-	if (entry->s.ops->print)
-		entry->s.ops->print(entry);
+	if (entry->ops->print)
+		entry->ops->print(entry);
 
 	ODP_PRINT("\n");
 }
@@ -1096,26 +1099,26 @@ int odp_pktio_term_global(void)
 	int i;
 
 	for (i = 0; i < ODP_CONFIG_PKTIO_ENTRIES; ++i) {
-		pktio_entry_t *pktio_entry;
+		odp_pktio_entry_t *pktio_entry;
 
-		pktio_entry = &pktio_tbl->entries[i];
+		pktio_entry = ODP_PKTIO_ENTRY(&pktio_tbl->entries[i]);
 
 		if (is_free(pktio_entry))
 			continue;
 
 		lock_entry(pktio_entry);
-		if (pktio_entry->s.state == PKTIO_STATE_STARTED) {
+		if (pktio_entry->state == PKTIO_STATE_STARTED) {
 			ret = _pktio_stop(pktio_entry);
 			if (ret)
 				ODP_ABORT("unable to stop pktio %s\n",
-					  pktio_entry->s.name);
+					  pktio_entry->name);
 		}
 
-		if (pktio_entry->s.state != PKTIO_STATE_CLOSE_PENDING)
+		if (pktio_entry->state != PKTIO_STATE_CLOSE_PENDING)
 			ret = _pktio_close(pktio_entry);
 		if (ret)
 			ODP_ABORT("unable to close pktio %s\n",
-				  pktio_entry->s.name);
+				  pktio_entry->name);
 		unlock_entry(pktio_entry);
 	}
 
@@ -1141,7 +1144,7 @@ int single_capability(odp_pktio_capability_t *capa)
 
 int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int ret;
 
 	entry = get_pktio_entry(pktio);
@@ -1150,8 +1153,8 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 		return -1;
 	}
 
-	if (entry->s.ops->capability)
-		ret = entry->s.ops->capability(entry, capa);
+	if (entry->ops->capability)
+		ret = entry->ops->capability(entry, capa);
 	else
 		ret = single_capability(capa);
 
@@ -1170,7 +1173,7 @@ unsigned odp_pktio_max_index(void)
 int odp_pktio_stats(odp_pktio_t pktio,
 		    odp_pktio_stats_t *stats)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int ret = -1;
 
 	entry = get_pktio_entry(pktio);
@@ -1187,8 +1190,8 @@ int odp_pktio_stats(odp_pktio_t pktio,
 		return -1;
 	}
 
-	if (entry->s.ops->stats)
-		ret = entry->s.ops->stats(entry, stats);
+	if (entry->ops->stats)
+		ret = entry->ops->stats(entry, stats);
 	unlock_entry(entry);
 
 	return ret;
@@ -1196,7 +1199,7 @@ int odp_pktio_stats(odp_pktio_t pktio,
 
 int odp_pktio_stats_reset(odp_pktio_t pktio)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	int ret = -1;
 
 	entry = get_pktio_entry(pktio);
@@ -1213,8 +1216,8 @@ int odp_pktio_stats_reset(odp_pktio_t pktio)
 		return -1;
 	}
 
-	if (entry->s.ops->stats)
-		ret = entry->s.ops->stats_reset(entry);
+	if (entry->ops->stats)
+		ret = entry->ops->stats_reset(entry);
 	unlock_entry(entry);
 
 	return ret;
@@ -1252,7 +1255,7 @@ static int abort_pktout_deq_multi(queue_t q_int ODP_UNUSED,
 int odp_pktin_queue_config(odp_pktio_t pktio,
 			   const odp_pktin_queue_param_t *param)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	odp_pktin_mode_t mode;
 	odp_pktio_capability_t capa;
 	unsigned num_queues;
@@ -1273,12 +1276,12 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 		return -1;
 	}
 
-	if (entry->s.state == PKTIO_STATE_STARTED) {
-		ODP_DBG("pktio %s: not stopped\n", entry->s.name);
+	if (entry->state == PKTIO_STATE_STARTED) {
+		ODP_DBG("pktio %s: not stopped\n", entry->name);
 		return -1;
 	}
 
-	mode = entry->s.param.in_mode;
+	mode = entry->param.in_mode;
 
 	/* Ignore the call when packet input is disabled. */
 	if (mode == ODP_PKTIN_MODE_DISABLED)
@@ -1287,27 +1290,27 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 	num_queues = param->num_queues;
 
 	if (num_queues == 0) {
-		ODP_DBG("pktio %s: zero input queues\n", entry->s.name);
+		ODP_DBG("pktio %s: zero input queues\n", entry->name);
 		return -1;
 	}
 
 	rc = odp_pktio_capability(pktio, &capa);
 	if (rc) {
 		ODP_DBG("pktio %s: unable to read capabilities\n",
-			entry->s.name);
+			entry->name);
 		return -1;
 	}
 
 	pktio_cls_enabled_set(entry, param->classifier_enable);
 
 	if (num_queues > capa.max_input_queues) {
-		ODP_DBG("pktio %s: too many input queues\n", entry->s.name);
+		ODP_DBG("pktio %s: too many input queues\n", entry->name);
 		return -1;
 	}
 
 	/* If re-configuring, destroy old queues */
-	if (entry->s.num_in_queue)
-		destroy_in_queues(entry, entry->s.num_in_queue);
+	if (entry->num_in_queue)
+		destroy_in_queues(entry, entry->num_in_queue);
 
 	for (i = 0; i < num_queues; i++) {
 		if (mode == ODP_PKTIN_MODE_QUEUE ||
@@ -1331,7 +1334,7 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 
 			if (queue == ODP_QUEUE_INVALID) {
 				ODP_DBG("pktio %s: event queue create failed\n",
-					entry->s.name);
+					entry->name);
 				destroy_in_queues(entry, i + 1);
 				return -1;
 			}
@@ -1347,22 +1350,22 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 							 pktin_deq_multi);
 			}
 
-			entry->s.in_queue[i].queue = queue;
-			entry->s.in_queue[i].queue_int = q_int;
+			entry->in_queue[i].queue = queue;
+			entry->in_queue[i].queue_int = q_int;
 
 		} else {
-			entry->s.in_queue[i].queue = ODP_QUEUE_INVALID;
-			entry->s.in_queue[i].queue_int = QUEUE_NULL;
+			entry->in_queue[i].queue = ODP_QUEUE_INVALID;
+			entry->in_queue[i].queue_int = QUEUE_NULL;
 		}
 
-		entry->s.in_queue[i].pktin.index = i;
-		entry->s.in_queue[i].pktin.pktio = entry->s.handle;
+		entry->in_queue[i].pktin.index = i;
+		entry->in_queue[i].pktin.pktio = entry->handle;
 	}
 
-	entry->s.num_in_queue = num_queues;
+	entry->num_in_queue = num_queues;
 
-	if (entry->s.ops->input_queues_config)
-		return entry->s.ops->input_queues_config(entry, param);
+	if (entry->ops->input_queues_config)
+		return entry->ops->input_queues_config(entry, param);
 
 	return 0;
 }
@@ -1370,7 +1373,7 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 int odp_pktout_queue_config(odp_pktio_t pktio,
 			    const odp_pktout_queue_param_t *param)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	odp_pktout_mode_t mode;
 	odp_pktio_capability_t capa;
 	unsigned num_queues;
@@ -1389,12 +1392,12 @@ int odp_pktout_queue_config(odp_pktio_t pktio,
 		return -1;
 	}
 
-	if (entry->s.state == PKTIO_STATE_STARTED) {
-		ODP_DBG("pktio %s: not stopped\n", entry->s.name);
+	if (entry->state == PKTIO_STATE_STARTED) {
+		ODP_DBG("pktio %s: not stopped\n", entry->name);
 		return -1;
 	}
 
-	mode = entry->s.param.out_mode;
+	mode = entry->param.out_mode;
 
 	/* Ignore the call when packet output is disabled, or routed through
 	 * traffic manager. */
@@ -1402,43 +1405,43 @@ int odp_pktout_queue_config(odp_pktio_t pktio,
 		return 0;
 
 	if (mode != ODP_PKTOUT_MODE_DIRECT && mode != ODP_PKTOUT_MODE_QUEUE) {
-		ODP_DBG("pktio %s: bad packet output mode\n", entry->s.name);
+		ODP_DBG("pktio %s: bad packet output mode\n", entry->name);
 		return -1;
 	}
 
 	num_queues = param->num_queues;
 
 	if (num_queues == 0) {
-		ODP_DBG("pktio %s: zero output queues\n", entry->s.name);
+		ODP_DBG("pktio %s: zero output queues\n", entry->name);
 		return -1;
 	}
 
 	rc = odp_pktio_capability(pktio, &capa);
 	if (rc) {
 		ODP_DBG("pktio %s: unable to read capabilities\n",
-			entry->s.name);
+			entry->name);
 		return -1;
 	}
 
 	if (num_queues > capa.max_output_queues) {
-		ODP_DBG("pktio %s: too many output queues\n", entry->s.name);
+		ODP_DBG("pktio %s: too many output queues\n", entry->name);
 		return -1;
 	}
 
 	/* If re-configuring, destroy old queues */
-	if (entry->s.num_out_queue) {
-		destroy_out_queues(entry, entry->s.num_out_queue);
-		entry->s.num_out_queue = 0;
+	if (entry->num_out_queue) {
+		destroy_out_queues(entry, entry->num_out_queue);
+		entry->num_out_queue = 0;
 	}
 
 	init_out_queues(entry);
 
 	for (i = 0; i < num_queues; i++) {
-		entry->s.out_queue[i].pktout.index = i;
-		entry->s.out_queue[i].pktout.pktio = pktio;
+		entry->out_queue[i].pktout.index = i;
+		entry->out_queue[i].pktout.pktio = pktio;
 	}
 
-	entry->s.num_out_queue = num_queues;
+	entry->num_out_queue = num_queues;
 
 	if (mode == ODP_PKTOUT_MODE_QUEUE) {
 		for (i = 0; i < num_queues; i++) {
@@ -1459,7 +1462,7 @@ int odp_pktout_queue_config(odp_pktio_t pktio,
 
 			if (queue == ODP_QUEUE_INVALID) {
 				ODP_DBG("pktout %s: event queue create failed\n",
-					entry->s.name);
+					entry->name);
 				destroy_out_queues(entry, i + 1);
 				return -1;
 			}
@@ -1474,19 +1477,19 @@ int odp_pktout_queue_config(odp_pktio_t pktio,
 						 abort_pktout_dequeue,
 						 abort_pktout_deq_multi);
 
-			entry->s.out_queue[i].queue = queue;
+			entry->out_queue[i].queue = queue;
 		}
 	}
 
-	if (entry->s.ops->output_queues_config)
-		return entry->s.ops->output_queues_config(entry, param);
+	if (entry->ops->output_queues_config)
+		return entry->ops->output_queues_config(entry, param);
 
 	return 0;
 }
 
 int odp_pktin_event_queue(odp_pktio_t pktio, odp_queue_t queues[], int num)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	odp_pktin_mode_t mode;
 	int i;
 	int num_queues;
@@ -1497,7 +1500,7 @@ int odp_pktin_event_queue(odp_pktio_t pktio, odp_queue_t queues[], int num)
 		return -1;
 	}
 
-	mode = entry->s.param.in_mode;
+	mode = entry->param.in_mode;
 
 	if (mode == ODP_PKTIN_MODE_DISABLED)
 		return 0;
@@ -1506,11 +1509,11 @@ int odp_pktin_event_queue(odp_pktio_t pktio, odp_queue_t queues[], int num)
 	    mode != ODP_PKTIN_MODE_SCHED)
 		return -1;
 
-	num_queues = entry->s.num_in_queue;
+	num_queues = entry->num_in_queue;
 
 	if (queues && num > 0) {
 		for (i = 0; i < num && i < num_queues; i++)
-			queues[i] = entry->s.in_queue[i].queue;
+			queues[i] = entry->in_queue[i].queue;
 	}
 
 	return num_queues;
@@ -1518,7 +1521,7 @@ int odp_pktin_event_queue(odp_pktio_t pktio, odp_queue_t queues[], int num)
 
 int odp_pktin_queue(odp_pktio_t pktio, odp_pktin_queue_t queues[], int num)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	odp_pktin_mode_t mode;
 	int i;
 	int num_queues;
@@ -1529,7 +1532,7 @@ int odp_pktin_queue(odp_pktio_t pktio, odp_pktin_queue_t queues[], int num)
 		return -1;
 	}
 
-	mode = entry->s.param.in_mode;
+	mode = entry->param.in_mode;
 
 	if (mode == ODP_PKTIN_MODE_DISABLED)
 		return 0;
@@ -1537,11 +1540,11 @@ int odp_pktin_queue(odp_pktio_t pktio, odp_pktin_queue_t queues[], int num)
 	if (mode != ODP_PKTIN_MODE_DIRECT)
 		return -1;
 
-	num_queues = entry->s.num_in_queue;
+	num_queues = entry->num_in_queue;
 
 	if (queues && num > 0) {
 		for (i = 0; i < num && i < num_queues; i++)
-			queues[i] = entry->s.in_queue[i].pktin;
+			queues[i] = entry->in_queue[i].pktin;
 	}
 
 	return num_queues;
@@ -1549,7 +1552,7 @@ int odp_pktin_queue(odp_pktio_t pktio, odp_pktin_queue_t queues[], int num)
 
 int odp_pktout_event_queue(odp_pktio_t pktio, odp_queue_t queues[], int num)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	odp_pktout_mode_t mode;
 	int i;
 	int num_queues;
@@ -1560,7 +1563,7 @@ int odp_pktout_event_queue(odp_pktio_t pktio, odp_queue_t queues[], int num)
 		return -1;
 	}
 
-	mode = entry->s.param.out_mode;
+	mode = entry->param.out_mode;
 
 	if (mode == ODP_PKTOUT_MODE_DISABLED)
 		return 0;
@@ -1568,11 +1571,11 @@ int odp_pktout_event_queue(odp_pktio_t pktio, odp_queue_t queues[], int num)
 	if (mode != ODP_PKTOUT_MODE_QUEUE)
 		return -1;
 
-	num_queues = entry->s.num_out_queue;
+	num_queues = entry->num_out_queue;
 
 	if (queues && num > 0) {
 		for (i = 0; i < num && i < num_queues; i++)
-			queues[i] = entry->s.out_queue[i].queue;
+			queues[i] = entry->out_queue[i].queue;
 	}
 
 	return num_queues;
@@ -1580,7 +1583,7 @@ int odp_pktout_event_queue(odp_pktio_t pktio, odp_queue_t queues[], int num)
 
 int odp_pktout_queue(odp_pktio_t pktio, odp_pktout_queue_t queues[], int num)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	odp_pktout_mode_t mode;
 	int i;
 	int num_queues;
@@ -1591,7 +1594,7 @@ int odp_pktout_queue(odp_pktio_t pktio, odp_pktout_queue_t queues[], int num)
 		return -1;
 	}
 
-	mode = entry->s.param.out_mode;
+	mode = entry->param.out_mode;
 
 	if (mode == ODP_PKTOUT_MODE_DISABLED)
 		return 0;
@@ -1599,11 +1602,11 @@ int odp_pktout_queue(odp_pktio_t pktio, odp_pktout_queue_t queues[], int num)
 	if (mode != ODP_PKTOUT_MODE_DIRECT)
 		return -1;
 
-	num_queues = entry->s.num_out_queue;
+	num_queues = entry->num_out_queue;
 
 	if (queues && num > 0) {
 		for (i = 0; i < num && i < num_queues; i++)
-			queues[i] = entry->s.out_queue[i].pktout;
+			queues[i] = entry->out_queue[i].pktout;
 	}
 
 	return num_queues;
@@ -1611,7 +1614,7 @@ int odp_pktout_queue(odp_pktio_t pktio, odp_pktout_queue_t queues[], int num)
 
 int odp_pktin_recv(odp_pktin_queue_t queue, odp_packet_t packets[], int num)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	odp_pktio_t pktio = queue.pktio;
 
 	entry = get_pktio_entry(pktio);
@@ -1620,7 +1623,7 @@ int odp_pktin_recv(odp_pktin_queue_t queue, odp_packet_t packets[], int num)
 		return -1;
 	}
 
-	return entry->s.ops->recv(entry, queue.index, packets, num);
+	return entry->ops->recv(entry, queue.index, packets, num);
 }
 
 int odp_pktin_recv_tmo(odp_pktin_queue_t queue, odp_packet_t packets[], int num,
@@ -1733,7 +1736,7 @@ uint64_t odp_pktin_wait_time(uint64_t nsec)
 int odp_pktout_send(odp_pktout_queue_t queue, const odp_packet_t packets[],
 		    int num)
 {
-	pktio_entry_t *entry;
+	odp_pktio_entry_t *entry;
 	odp_pktio_t pktio = queue.pktio;
 
 	entry = get_pktio_entry(pktio);
@@ -1742,5 +1745,5 @@ int odp_pktout_send(odp_pktout_queue_t queue, const odp_packet_t packets[],
 		return -1;
 	}
 
-	return entry->s.ops->send(entry, queue.index, packets, num);
+	return entry->ops->send(entry, queue.index, packets, num);
 }

--- a/platform/linux-generic/pktio/common.c
+++ b/platform/linux-generic/pktio/common.c
@@ -27,31 +27,31 @@
  * ODP_PACKET_SOCKET_MMAP:
  * ODP_PACKET_NETMAP:
  */
-int sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd)
+int sock_stats_reset_fd(odp_pktio_entry_t *pktio_entry, int fd)
 {
 	int err = 0;
 	odp_pktio_stats_t cur_stats;
 
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
-		memset(&pktio_entry->s.stats, 0,
+	if (pktio_entry->stats_type == STATS_UNSUPPORTED) {
+		memset(&pktio_entry->stats, 0,
 		       sizeof(odp_pktio_stats_t));
 		return 0;
 	}
 
 	memset(&cur_stats, 0, sizeof(odp_pktio_stats_t));
 
-	if (pktio_entry->s.stats_type == STATS_ETHTOOL) {
+	if (pktio_entry->stats_type == STATS_ETHTOOL) {
 		(void)ethtool_stats_get_fd(fd,
-					   pktio_entry->s.name,
+					   pktio_entry->name,
 					   &cur_stats);
-	} else if (pktio_entry->s.stats_type == STATS_SYSFS) {
+	} else if (pktio_entry->stats_type == STATS_SYSFS) {
 		err = sysfs_stats(pktio_entry, &cur_stats);
 		if (err != 0)
 			ODP_ERR("stats error\n");
 	}
 
 	if (err == 0)
-		memcpy(&pktio_entry->s.stats, &cur_stats,
+		memcpy(&pktio_entry->stats, &cur_stats,
 		       sizeof(odp_pktio_stats_t));
 
 	return err;
@@ -62,44 +62,44 @@ int sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd)
  * ODP_PACKET_SOCKET_MMAP:
  * ODP_PACKET_NETMAP:
  */
-int sock_stats_fd(pktio_entry_t *pktio_entry,
+int sock_stats_fd(odp_pktio_entry_t *pktio_entry,
 		  odp_pktio_stats_t *stats,
 		  int fd)
 {
 	odp_pktio_stats_t cur_stats;
 	int ret = 0;
 
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED)
+	if (pktio_entry->stats_type == STATS_UNSUPPORTED)
 		return 0;
 
 	memset(&cur_stats, 0, sizeof(odp_pktio_stats_t));
-	if (pktio_entry->s.stats_type == STATS_ETHTOOL) {
+	if (pktio_entry->stats_type == STATS_ETHTOOL) {
 		(void)ethtool_stats_get_fd(fd,
-					   pktio_entry->s.name,
+					   pktio_entry->name,
 					   &cur_stats);
-	} else if (pktio_entry->s.stats_type == STATS_SYSFS) {
+	} else if (pktio_entry->stats_type == STATS_SYSFS) {
 		sysfs_stats(pktio_entry, &cur_stats);
 	}
 
 	stats->in_octets = cur_stats.in_octets -
-				pktio_entry->s.stats.in_octets;
+				pktio_entry->stats.in_octets;
 	stats->in_ucast_pkts = cur_stats.in_ucast_pkts -
-				pktio_entry->s.stats.in_ucast_pkts;
+				pktio_entry->stats.in_ucast_pkts;
 	stats->in_discards = cur_stats.in_discards -
-				pktio_entry->s.stats.in_discards;
+				pktio_entry->stats.in_discards;
 	stats->in_errors = cur_stats.in_errors -
-				pktio_entry->s.stats.in_errors;
+				pktio_entry->stats.in_errors;
 	stats->in_unknown_protos = cur_stats.in_unknown_protos -
-				pktio_entry->s.stats.in_unknown_protos;
+				pktio_entry->stats.in_unknown_protos;
 
 	stats->out_octets = cur_stats.out_octets -
-				pktio_entry->s.stats.out_octets;
+				pktio_entry->stats.out_octets;
 	stats->out_ucast_pkts = cur_stats.out_ucast_pkts -
-				pktio_entry->s.stats.out_ucast_pkts;
+				pktio_entry->stats.out_ucast_pkts;
 	stats->out_discards = cur_stats.out_discards -
-				pktio_entry->s.stats.out_discards;
+				pktio_entry->stats.out_discards;
 	stats->out_errors = cur_stats.out_errors -
-				pktio_entry->s.stats.out_errors;
+				pktio_entry->stats.out_errors;
 
 	return ret;
 }

--- a/platform/linux-generic/pktio/common.h
+++ b/platform/linux-generic/pktio/common.h
@@ -96,7 +96,7 @@ void rss_conf_print(const odp_pktin_hash_proto_t *hash_proto);
  * @retval 0 on success
  * @retval != 0 on failure
  */
-int sock_stats_fd(pktio_entry_t *pktio_entry,
+int sock_stats_fd(odp_pktio_entry_t *pktio_entry,
 		  odp_pktio_stats_t *stats,
 		  int fd);
 
@@ -109,6 +109,6 @@ int sock_stats_fd(pktio_entry_t *pktio_entry,
  * @retval  0 on success
  * @retval != 0 on failure
  */
-int sock_stats_reset_fd(pktio_entry_t *pktio_entry, int fd);
+int sock_stats_reset_fd(odp_pktio_entry_t *pktio_entry, int fd);
 
 #endif /*ODP_PKTIO_COMMON_H_*/

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -347,7 +347,7 @@ static inline int pkt_set_ol_rx(odp_pktin_config_opt_t *pktin_cfg,
 	return 0;
 }
 
-static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
+static inline int mbuf_to_pkt(odp_pktio_entry_t *pktio_entry,
 			      odp_packet_t pkt_table[],
 			      struct rte_mbuf *mbuf_table[],
 			      uint16_t mbuf_num, odp_time_t *ts)
@@ -361,7 +361,7 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 	int i, j;
 	int nb_pkts = 0;
 	int alloc_len, num;
-	odp_pktin_config_opt_t *pktin_cfg = &pktio_entry->s.config.pktin;
+	odp_pktin_config_opt_t *pktin_cfg = &pktio_entry->config.pktin;
 	odp_pool_t pool = pkt_dpdk->pool;
 
 	/* Allocate maximum sized packets */
@@ -404,13 +404,13 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 		if (odp_packet_copy_from_mem(pkt, 0, pkt_len, data) != 0)
 			goto fail;
 
-		pkt_hdr->input = pktio_entry->s.handle;
+		pkt_hdr->input = pktio_entry->handle;
 
 		if (pktio_cls_enabled(pktio_entry))
 			copy_packet_cls_metadata(&parsed_hdr, pkt_hdr);
 		else
 			packet_parse_layer(pkt_hdr,
-					   pktio_entry->s.config.parser.layer);
+					   pktio_entry->config.parser.layer);
 
 		if (mbuf->ol_flags & PKT_RX_RSS_HASH)
 			odp_packet_flow_hash_set(pkt, mbuf->hash.rss);
@@ -530,7 +530,7 @@ static inline void pkt_set_ol_tx(odp_pktout_config_opt_t *pktout_cfg,
 	}
 }
 
-static inline int pkt_to_mbuf(pktio_entry_t *pktio_entry,
+static inline int pkt_to_mbuf(odp_pktio_entry_t *pktio_entry,
 			      struct rte_mbuf *mbuf_table[],
 			      const odp_packet_t pkt_table[], uint16_t num)
 {
@@ -539,7 +539,7 @@ static inline int pkt_to_mbuf(pktio_entry_t *pktio_entry,
 	int i, j;
 	char *data;
 	uint16_t pkt_len;
-	odp_pktout_config_opt_t *pktout_cfg = &pktio_entry->s.config.pktout;
+	odp_pktout_config_opt_t *pktout_cfg = &pktio_entry->config.pktout;
 
 	if (odp_unlikely((rte_pktmbuf_alloc_bulk(pkt_dpdk->pkt_pool,
 						 mbuf_table, num)))) {
@@ -574,7 +574,7 @@ fail:
 	return i;
 }
 
-static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
+static inline int mbuf_to_pkt_zero(odp_pktio_entry_t *pktio_entry,
 				   odp_packet_t pkt_table[],
 				   struct rte_mbuf *mbuf_table[],
 				   uint16_t mbuf_num, odp_time_t *ts)
@@ -588,7 +588,7 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 	void *data;
 	int i;
 	int nb_pkts = 0;
-	odp_pktin_config_opt_t *pktin_cfg = &pktio_entry->s.config.pktin;
+	odp_pktin_config_opt_t *pktin_cfg = &pktio_entry->config.pktin;
 	odp_pool_t pool = pkt_dpdk->pool;
 
 	for (i = 0; i < mbuf_num; i++) {
@@ -622,13 +622,13 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 		pkt_hdr->buf_hdr.seg[0].data = data;
 
 		packet_init(pkt_hdr, pkt_len);
-		pkt_hdr->input = pktio_entry->s.handle;
+		pkt_hdr->input = pktio_entry->handle;
 
 		if (pktio_cls_enabled(pktio_entry))
 			copy_packet_cls_metadata(&parsed_hdr, pkt_hdr);
 		else
 			packet_parse_layer(pkt_hdr,
-					   pktio_entry->s.config.parser.layer);
+					   pktio_entry->config.parser.layer);
 
 		if (mbuf->ol_flags & PKT_RX_RSS_HASH)
 			odp_packet_flow_hash_set(pkt, mbuf->hash.rss);
@@ -648,14 +648,14 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 	return nb_pkts;
 }
 
-static inline int pkt_to_mbuf_zero(pktio_entry_t *pktio_entry,
+static inline int pkt_to_mbuf_zero(odp_pktio_entry_t *pktio_entry,
 				   struct rte_mbuf *mbuf_table[],
 				   const odp_packet_t pkt_table[], uint16_t num,
 				   uint16_t *copy_count)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);
-	odp_pktout_config_opt_t *pktout_cfg = &pktio_entry->s.config.pktout;
+	odp_pktout_config_opt_t *pktout_cfg = &pktio_entry->config.pktout;
 	int i;
 	*copy_count = 0;
 
@@ -741,7 +741,7 @@ static uint32_t dpdk_vdev_mtu_get(uint8_t port_id)
 	return mtu;
 }
 
-static uint32_t dpdk_mtu_get(pktio_entry_t *pktio_entry)
+static uint32_t dpdk_mtu_get(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);
@@ -834,7 +834,7 @@ static void rss_conf_to_hash_proto(struct rte_eth_rss_conf *rss_conf,
 	rss_conf->rss_key = NULL;
 }
 
-static int dpdk_setup_port(pktio_entry_t *pktio_entry)
+static int dpdk_setup_port(odp_pktio_entry_t *pktio_entry)
 {
 	int ret;
 	pktio_ops_dpdk_data_t *pkt_dpdk =
@@ -850,9 +850,9 @@ static int dpdk_setup_port(pktio_entry_t *pktio_entry)
 		rss_conf_to_hash_proto(&rss_conf, &pkt_dpdk->hash);
 	}
 
-	if (pktio_entry->s.config.pktin.bit.ipv4_chksum ||
-	    pktio_entry->s.config.pktin.bit.udp_chksum ||
-	    pktio_entry->s.config.pktin.bit.tcp_chksum)
+	if (pktio_entry->config.pktin.bit.ipv4_chksum ||
+	    pktio_entry->config.pktin.bit.udp_chksum ||
+	    pktio_entry->config.pktin.bit.tcp_chksum)
 		hw_ip_checksum = 1;
 
 	struct rte_eth_conf port_conf = {
@@ -874,8 +874,8 @@ static int dpdk_setup_port(pktio_entry_t *pktio_entry)
 	};
 
 	ret = rte_eth_dev_configure(pkt_dpdk->port_id,
-				    pktio_entry->s.num_in_queue,
-				    pktio_entry->s.num_out_queue, &port_conf);
+				    pktio_entry->num_in_queue,
+				    pktio_entry->num_out_queue, &port_conf);
 	if (ret < 0) {
 		ODP_ERR("Failed to setup device: err=%d, port=%" PRIu8 "\n",
 			ret, pkt_dpdk->port_id);
@@ -884,7 +884,7 @@ static int dpdk_setup_port(pktio_entry_t *pktio_entry)
 	return 0;
 }
 
-static int dpdk_close(pktio_entry_t *pktio_entry)
+static int dpdk_close(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);
@@ -899,7 +899,7 @@ static int dpdk_close(pktio_entry_t *pktio_entry)
 			rte_pktmbuf_free(pkt_dpdk->rx_cache[i].s.pkt[idx++]);
 	}
 
-	if (pktio_entry->s.state != PKTIO_STATE_OPENED)
+	if (pktio_entry->state != PKTIO_STATE_OPENED)
 		rte_eth_dev_close(pkt_dpdk->port_id);
 
 	if (!ODP_DPDK_ZERO_COPY)
@@ -1034,12 +1034,12 @@ static int dpdk_pktio_init_local(void)
 	return 0;
 }
 
-static int dpdk_input_queues_config(pktio_entry_t *pktio_entry,
+static int dpdk_input_queues_config(odp_pktio_entry_t *pktio_entry,
 				    const odp_pktin_queue_param_t *p)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);
-	odp_pktin_mode_t mode = pktio_entry->s.param.in_mode;
+	odp_pktin_mode_t mode = pktio_entry->param.in_mode;
 	odp_bool_t lockless;
 
 	/**
@@ -1059,7 +1059,7 @@ static int dpdk_input_queues_config(pktio_entry_t *pktio_entry,
 	return 0;
 }
 
-static int dpdk_output_queues_config(pktio_entry_t *pktio_entry,
+static int dpdk_output_queues_config(odp_pktio_entry_t *pktio_entry,
 				     const odp_pktout_queue_param_t *p)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
@@ -1076,7 +1076,7 @@ static int dpdk_output_queues_config(pktio_entry_t *pktio_entry,
 	return 0;
 }
 
-static void dpdk_init_capability(pktio_entry_t *pktio_entry,
+static void dpdk_init_capability(odp_pktio_entry_t *pktio_entry,
 				 struct rte_eth_dev_info *dev_info)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
@@ -1153,7 +1153,7 @@ static void dpdk_init_capability(pktio_entry_t *pktio_entry,
 }
 
 static int dpdk_open(odp_pktio_t id ODP_UNUSED,
-		     pktio_entry_t *pktio_entry,
+		     odp_pktio_entry_t *pktio_entry,
 		     const char *netdev,
 		     odp_pool_t pool)
 {
@@ -1265,7 +1265,7 @@ static int dpdk_open(odp_pktio_t id ODP_UNUSED,
 	return 0;
 }
 
-static int dpdk_start(pktio_entry_t *pktio_entry)
+static int dpdk_start(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);
@@ -1274,10 +1274,10 @@ static int dpdk_start(pktio_entry_t *pktio_entry)
 	unsigned i;
 
 	/* DPDK doesn't support nb_rx_q/nb_tx_q being 0 */
-	if (!pktio_entry->s.num_in_queue)
-		pktio_entry->s.num_in_queue = 1;
-	if (!pktio_entry->s.num_out_queue)
-		pktio_entry->s.num_out_queue = 1;
+	if (!pktio_entry->num_in_queue)
+		pktio_entry->num_in_queue = 1;
+	if (!pktio_entry->num_out_queue)
+		pktio_entry->num_out_queue = 1;
 
 	/* init port */
 	if (dpdk_setup_port(pktio_entry)) {
@@ -1285,7 +1285,7 @@ static int dpdk_start(pktio_entry_t *pktio_entry)
 		return -1;
 	}
 	/* Init TX queues */
-	for (i = 0; i < pktio_entry->s.num_out_queue; i++) {
+	for (i = 0; i < pktio_entry->num_out_queue; i++) {
 		ret = rte_eth_tx_queue_setup(port_id, i, DPDK_NM_TX_DESC,
 					     rte_eth_dev_socket_id(port_id),
 					     NULL);
@@ -1296,7 +1296,7 @@ static int dpdk_start(pktio_entry_t *pktio_entry)
 		}
 	}
 	/* Init RX queues */
-	for (i = 0; i < pktio_entry->s.num_in_queue; i++) {
+	for (i = 0; i < pktio_entry->num_in_queue; i++) {
 		ret = rte_eth_rx_queue_setup(port_id, i, DPDK_NM_RX_DESC,
 					     rte_eth_dev_socket_id(port_id),
 					     NULL, pkt_dpdk->pkt_pool);
@@ -1317,7 +1317,7 @@ static int dpdk_start(pktio_entry_t *pktio_entry)
 	return 0;
 }
 
-static int dpdk_stop(pktio_entry_t *pktio_entry)
+static int dpdk_stop(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);
@@ -1327,7 +1327,7 @@ static int dpdk_stop(pktio_entry_t *pktio_entry)
 	return 0;
 }
 
-static int dpdk_recv(pktio_entry_t *pktio_entry, int index,
+static int dpdk_recv(odp_pktio_entry_t *pktio_entry, int index,
 		     odp_packet_t pkt_table[], int num)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
@@ -1340,7 +1340,7 @@ static int dpdk_recv(pktio_entry_t *pktio_entry, int index,
 	int i;
 	unsigned cache_idx;
 
-	if (odp_unlikely(pktio_entry->s.state != PKTIO_STATE_STARTED))
+	if (odp_unlikely(pktio_entry->state != PKTIO_STATE_STARTED))
 		return 0;
 
 	if (!pkt_dpdk->lockless_rx)
@@ -1386,8 +1386,8 @@ static int dpdk_recv(pktio_entry_t *pktio_entry, int index,
 		odp_ticketlock_unlock(&pkt_dpdk->rx_lock[index]);
 
 	if (nb_rx > 0) {
-		if (pktio_entry->s.config.pktin.bit.ts_all ||
-		    pktio_entry->s.config.pktin.bit.ts_ptp) {
+		if (pktio_entry->config.pktin.bit.ts_all ||
+		    pktio_entry->config.pktin.bit.ts_ptp) {
 			ts_val = odp_time_global();
 			ts = &ts_val;
 		}
@@ -1402,7 +1402,7 @@ static int dpdk_recv(pktio_entry_t *pktio_entry, int index,
 	return nb_rx;
 }
 
-static int dpdk_send(pktio_entry_t *pktio_entry, int index,
+static int dpdk_send(odp_pktio_entry_t *pktio_entry, int index,
 		     const odp_packet_t pkt_table[], int num)
 {
 	struct rte_mbuf *tx_mbufs[num];
@@ -1413,7 +1413,7 @@ static int dpdk_send(pktio_entry_t *pktio_entry, int index,
 	int i;
 	int mbufs;
 
-	if (odp_unlikely(pktio_entry->s.state != PKTIO_STATE_STARTED))
+	if (odp_unlikely(pktio_entry->state != PKTIO_STATE_STARTED))
 		return 0;
 
 	if (ODP_DPDK_ZERO_COPY)
@@ -1468,7 +1468,7 @@ static int dpdk_send(pktio_entry_t *pktio_entry, int index,
 	return tx_pkts;
 }
 
-static int dpdk_mac_addr_get(pktio_entry_t *pktio_entry, void *mac_addr)
+static int dpdk_mac_addr_get(odp_pktio_entry_t *pktio_entry, void *mac_addr)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);
@@ -1478,7 +1478,8 @@ static int dpdk_mac_addr_get(pktio_entry_t *pktio_entry, void *mac_addr)
 	return ETH_ALEN;
 }
 
-static int dpdk_promisc_mode_set(pktio_entry_t *pktio_entry, odp_bool_t enable)
+static int dpdk_promisc_mode_set(odp_pktio_entry_t *pktio_entry,
+				 odp_bool_t enable)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);
@@ -1495,7 +1496,7 @@ static int dpdk_promisc_mode_set(pktio_entry_t *pktio_entry, odp_bool_t enable)
 	return 0;
 }
 
-static int dpdk_promisc_mode_get(pktio_entry_t *pktio_entry)
+static int dpdk_promisc_mode_get(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);
@@ -1507,7 +1508,7 @@ static int dpdk_promisc_mode_get(pktio_entry_t *pktio_entry)
 		return rte_eth_promiscuous_get(port_id);
 }
 
-static int dpdk_capability(pktio_entry_t *pktio_entry,
+static int dpdk_capability(odp_pktio_entry_t *pktio_entry,
 			   odp_pktio_capability_t *capa)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
@@ -1517,7 +1518,7 @@ static int dpdk_capability(pktio_entry_t *pktio_entry,
 	return 0;
 }
 
-static int dpdk_link_status(pktio_entry_t *pktio_entry)
+static int dpdk_link_status(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);
@@ -1542,7 +1543,7 @@ static void stats_convert(const struct rte_eth_stats *rte_stats,
 	stats->out_errors = rte_stats->oerrors;
 }
 
-static int dpdk_stats(pktio_entry_t *pktio_entry, odp_pktio_stats_t *stats)
+static int dpdk_stats(odp_pktio_entry_t *pktio_entry, odp_pktio_stats_t *stats)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);
@@ -1558,7 +1559,7 @@ static int dpdk_stats(pktio_entry_t *pktio_entry, odp_pktio_stats_t *stats)
 	return -1;
 }
 
-static int dpdk_stats_reset(pktio_entry_t *pktio_entry)
+static int dpdk_stats_reset(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_dpdk_data_t *pkt_dpdk =
 		odp_ops_data(pktio_entry, dpdk);

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -44,9 +44,9 @@
 #define NM_INJECT_RETRIES 10
 
 static int disable_pktio; /** !0 this pktio disabled, 0 enabled */
-static int netmap_stats_reset(pktio_entry_t *pktio_entry);
+static int netmap_stats_reset(odp_pktio_entry_t *pktio_entry);
 
-static int netmap_do_ioctl(pktio_entry_t *pktio_entry, unsigned long cmd,
+static int netmap_do_ioctl(odp_pktio_entry_t *pktio_entry, unsigned long cmd,
 			   int subcmd)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
@@ -134,12 +134,12 @@ static inline void map_netmap_rings(netmap_ring_t *rings,
 	}
 }
 
-static int netmap_input_queues_config(pktio_entry_t *pktio_entry,
+static int netmap_input_queues_config(odp_pktio_entry_t *pktio_entry,
 				      const odp_pktin_queue_param_t *p)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
 		odp_ops_data(pktio_entry, netmap);
-	odp_pktin_mode_t mode = pktio_entry->s.param.in_mode;
+	odp_pktin_mode_t mode = pktio_entry->param.in_mode;
 	unsigned num_queues = p->num_queues;
 	odp_bool_t lockless;
 
@@ -163,7 +163,7 @@ static int netmap_input_queues_config(pktio_entry_t *pktio_entry,
 	return 0;
 }
 
-static int netmap_output_queues_config(pktio_entry_t *pktio_entry,
+static int netmap_output_queues_config(odp_pktio_entry_t *pktio_entry,
 				       const odp_pktout_queue_param_t *p)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
@@ -181,7 +181,7 @@ static int netmap_output_queues_config(pktio_entry_t *pktio_entry,
  *
  * @param pktio_entry    Packet IO entry
  */
-static inline void netmap_close_descriptors(pktio_entry_t *pktio_entry)
+static inline void netmap_close_descriptors(odp_pktio_entry_t *pktio_entry)
 {
 	int i, j;
 	pktio_ops_netmap_data_t *pkt_nm =
@@ -206,7 +206,7 @@ static inline void netmap_close_descriptors(pktio_entry_t *pktio_entry)
 	pkt_nm->num_tx_desc_rings = 0;
 }
 
-static int netmap_close(pktio_entry_t *pktio_entry)
+static int netmap_close(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
 		odp_ops_data(pktio_entry, netmap);
@@ -221,7 +221,7 @@ static int netmap_close(pktio_entry_t *pktio_entry)
 	return 0;
 }
 
-static int netmap_link_status(pktio_entry_t *pktio_entry)
+static int netmap_link_status(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
 		odp_ops_data(pktio_entry, netmap);
@@ -241,7 +241,7 @@ static int netmap_link_status(pktio_entry_t *pktio_entry)
  * @retval  0 link is down
  * @retval <0 on failure
  */
-static inline int netmap_wait_for_link(pktio_entry_t *pktio_entry)
+static inline int netmap_wait_for_link(odp_pktio_entry_t *pktio_entry)
 {
 	int i;
 	int ret;
@@ -272,7 +272,7 @@ static inline int netmap_wait_for_link(pktio_entry_t *pktio_entry)
  *
  * @param pktio_entry    Packet IO entry
  */
-static void netmap_init_capability(pktio_entry_t *pktio_entry)
+static void netmap_init_capability(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
 		odp_ops_data(pktio_entry, netmap);
@@ -333,7 +333,8 @@ static void netmap_init_capability(pktio_entry_t *pktio_entry)
  * @retval 0 on success
  * @retval <0 on failure
  */
-static int netmap_open(odp_pktio_t id ODP_UNUSED, pktio_entry_t *pktio_entry,
+static int netmap_open(odp_pktio_t id ODP_UNUSED,
+		       odp_pktio_entry_t *pktio_entry,
 		       const char *netdev, odp_pool_t pool)
 {
 	int i;
@@ -403,7 +404,7 @@ static int netmap_open(odp_pktio_t id ODP_UNUSED, pktio_entry_t *pktio_entry,
 		pkt_nm->capa.max_input_queues = 1;
 		pkt_nm->capa.set_op.op.promisc_mode = 0;
 		pkt_nm->mtu = buf_size;
-		pktio_entry->s.stats_type = STATS_UNSUPPORTED;
+		pktio_entry->stats_type = STATS_UNSUPPORTED;
 		/* Set MAC address for virtual interface */
 		pkt_nm->if_mac[0] = 0x2;
 		pkt_nm->if_mac[5] = ++mac;
@@ -450,9 +451,9 @@ static int netmap_open(odp_pktio_t id ODP_UNUSED, pktio_entry_t *pktio_entry,
 	if (err) {
 		ODP_ERR("netmap pktio %s does not support statistics counters\n",
 			pkt_nm->if_name);
-		pktio_entry->s.stats_type = STATS_UNSUPPORTED;
+		pktio_entry->stats_type = STATS_UNSUPPORTED;
 	} else {
-		pktio_entry->s.stats_type = STATS_ETHTOOL;
+		pktio_entry->stats_type = STATS_ETHTOOL;
 	}
 
 	(void)netmap_stats_reset(pktio_entry);
@@ -464,7 +465,7 @@ error:
 	return -1;
 }
 
-static int netmap_start(pktio_entry_t *pktio_entry)
+static int netmap_start(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
 		odp_ops_data(pktio_entry, netmap);
@@ -474,51 +475,51 @@ static int netmap_start(pktio_entry_t *pktio_entry)
 	unsigned j;
 	unsigned num_rx_desc = 0;
 	uint64_t flags;
-	odp_pktin_mode_t in_mode = pktio_entry->s.param.in_mode;
-	odp_pktout_mode_t out_mode = pktio_entry->s.param.out_mode;
+	odp_pktin_mode_t in_mode = pktio_entry->param.in_mode;
+	odp_pktout_mode_t out_mode = pktio_entry->param.out_mode;
 
 	/* If no pktin/pktout queues have been configured. Configure one
 	 * for each direction. */
-	if (!pktio_entry->s.num_in_queue &&
+	if (!pktio_entry->num_in_queue &&
 	    in_mode != ODP_PKTIN_MODE_DISABLED) {
 		odp_pktin_queue_param_t param;
 
 		odp_pktin_queue_param_init(&param);
 		param.num_queues = 1;
-		if (odp_pktin_queue_config(pktio_entry->s.handle, &param))
+		if (odp_pktin_queue_config(pktio_entry->handle, &param))
 			return -1;
 	}
-	if (!pktio_entry->s.num_out_queue &&
+	if (!pktio_entry->num_out_queue &&
 	    out_mode == ODP_PKTOUT_MODE_DIRECT) {
 		odp_pktout_queue_param_t param;
 
 		odp_pktout_queue_param_init(&param);
 		param.num_queues = 1;
-		if (odp_pktout_queue_config(pktio_entry->s.handle, &param))
+		if (odp_pktout_queue_config(pktio_entry->handle, &param))
 			return -1;
 	}
 
-	if (pkt_nm->num_rx_desc_rings == pktio_entry->s.num_in_queue &&
-	    pkt_nm->num_tx_desc_rings == pktio_entry->s.num_out_queue)
+	if (pkt_nm->num_rx_desc_rings == pktio_entry->num_in_queue &&
+	    pkt_nm->num_tx_desc_rings == pktio_entry->num_out_queue)
 		return (netmap_wait_for_link(pktio_entry) == 1) ? 0 : -1;
 
 	netmap_close_descriptors(pktio_entry);
 
 	/* Map pktin/pktout queues to netmap rings */
-	if (pktio_entry->s.num_in_queue) {
+	if (pktio_entry->num_in_queue) {
 		/* In single queue case only one netmap descriptor is
 		 * required. */
-		num_rx_desc = (pktio_entry->s.num_in_queue == 1) ? 1 :
+		num_rx_desc = (pktio_entry->num_in_queue == 1) ? 1 :
 				pkt_nm->num_rx_rings;
 
 		map_netmap_rings(pkt_nm->rx_desc_ring,
-				 pktio_entry->s.num_in_queue, num_rx_desc);
+				 pktio_entry->num_in_queue, num_rx_desc);
 	}
-	if (pktio_entry->s.num_out_queue)
+	if (pktio_entry->num_out_queue)
 		/* Enough to map only one netmap tx ring per pktout queue */
 		map_netmap_rings(pkt_nm->tx_desc_ring,
-				 pktio_entry->s.num_out_queue,
-				 pktio_entry->s.num_out_queue);
+				 pktio_entry->num_out_queue,
+				 pktio_entry->num_out_queue);
 
 	/* Use nm_open() to parse netmap flags from interface name */
 	desc_ptr = nm_open(pkt_nm->nm_name, NULL, 0, NULL);
@@ -553,7 +554,7 @@ static int netmap_start(pktio_entry_t *pktio_entry)
 	}
 	/* Open rest of the rx descriptors (one per netmap ring) */
 	flags = NM_OPEN_IFNAME | NETMAP_NO_TX_POLL | NM_OPEN_NO_MMAP;
-	for (i = 0; i < pktio_entry->s.num_in_queue; i++) {
+	for (i = 0; i < pktio_entry->num_in_queue; i++) {
 		for (j = desc_ring[i].s.first; j <= desc_ring[i].s.last; j++) {
 			if (i == 0 && j == 0) { /* First already opened */
 				if (num_rx_desc > 1)
@@ -580,7 +581,7 @@ static int netmap_start(pktio_entry_t *pktio_entry)
 		base_desc.req.nr_flags |= NR_REG_ONE_NIC;
 	}
 
-	for (i = 0; i < pktio_entry->s.num_out_queue; i++) {
+	for (i = 0; i < pktio_entry->num_out_queue; i++) {
 		for (j = desc_ring[i].s.first; j <= desc_ring[i].s.last; j++) {
 			base_desc.req.nr_ringid = j;
 			desc_ring[i].s.desc[j] = nm_open(pkt_nm->nm_name, NULL,
@@ -592,8 +593,8 @@ static int netmap_start(pktio_entry_t *pktio_entry)
 			}
 		}
 	}
-	pkt_nm->num_rx_desc_rings = pktio_entry->s.num_in_queue;
-	pkt_nm->num_tx_desc_rings = pktio_entry->s.num_out_queue;
+	pkt_nm->num_rx_desc_rings = pktio_entry->num_in_queue;
+	pkt_nm->num_tx_desc_rings = pktio_entry->num_out_queue;
 	/* Wait for the link to come up */
 	return (netmap_wait_for_link(pktio_entry) == 1) ? 0 : -1;
 
@@ -602,7 +603,7 @@ error:
 	return -1;
 }
 
-static int netmap_stop(pktio_entry_t *pktio_entry ODP_UNUSED)
+static int netmap_stop(odp_pktio_entry_t *pktio_entry ODP_UNUSED)
 {
 	return 0;
 }
@@ -618,7 +619,7 @@ static int netmap_stop(pktio_entry_t *pktio_entry ODP_UNUSED)
  *
  * @retval Number of created packets
  */
-static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
+static inline int netmap_pkt_to_odp(odp_pktio_entry_t *pktio_entry,
 				    odp_packet_t pkt_tbl[],
 				    netmap_slot_t slot_tbl[], int16_t slot_num,
 				    odp_time_t *ts)
@@ -674,13 +675,13 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 		if (odp_packet_copy_from_mem(pkt, 0, len, slot.buf) != 0)
 			goto fail;
 
-		pkt_hdr->input = pktio_entry->s.handle;
+		pkt_hdr->input = pktio_entry->handle;
 
 		if (pktio_cls_enabled(pktio_entry))
 			copy_packet_cls_metadata(&parsed_hdr, pkt_hdr);
 		else
 			packet_parse_layer(pkt_hdr,
-					   pktio_entry->s.config.parser.layer);
+					   pktio_entry->config.parser.layer);
 
 		packet_set_ts(pkt_hdr, ts);
 	}
@@ -692,7 +693,7 @@ fail:
 	return i;
 }
 
-static inline int netmap_recv_desc(pktio_entry_t *pktio_entry,
+static inline int netmap_recv_desc(odp_pktio_entry_t *pktio_entry,
 				   struct nm_desc *desc,
 				   odp_packet_t pkt_table[], int num)
 {
@@ -707,8 +708,8 @@ static inline int netmap_recv_desc(pktio_entry_t *pktio_entry,
 	int num_rx = 0;
 	int num_rings = desc->last_rx_ring - desc->first_rx_ring + 1;
 
-	if (pktio_entry->s.config.pktin.bit.ts_all ||
-	    pktio_entry->s.config.pktin.bit.ts_ptp)
+	if (pktio_entry->config.pktin.bit.ts_all ||
+	    pktio_entry->config.pktin.bit.ts_ptp)
 		ts = &ts_val;
 
 	for (i = 0; i < num_rings && num_rx != num; i++) {
@@ -741,7 +742,7 @@ static inline int netmap_recv_desc(pktio_entry_t *pktio_entry,
 	return 0;
 }
 
-static int netmap_recv(pktio_entry_t *pktio_entry, int index,
+static int netmap_recv(odp_pktio_entry_t *pktio_entry, int index,
 		       odp_packet_t pkt_table[], int num)
 {
 	struct nm_desc *desc;
@@ -756,7 +757,7 @@ static int netmap_recv(pktio_entry_t *pktio_entry, int index,
 	int max_fd = 0;
 	fd_set empty_rings;
 
-	if (odp_unlikely(pktio_entry->s.state != PKTIO_STATE_STARTED))
+	if (odp_unlikely(pktio_entry->state != PKTIO_STATE_STARTED))
 		return 0;
 
 	FD_ZERO(&empty_rings);
@@ -796,7 +797,7 @@ static int netmap_recv(pktio_entry_t *pktio_entry, int index,
 	return num_rx;
 }
 
-static int netmap_send(pktio_entry_t *pktio_entry, int index,
+static int netmap_send(odp_pktio_entry_t *pktio_entry, int index,
 		       const odp_packet_t pkt_table[], int num)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
@@ -812,7 +813,7 @@ static int netmap_send(pktio_entry_t *pktio_entry, int index,
 	unsigned slot_id;
 	char *buf;
 
-	if (odp_unlikely(pktio_entry->s.state != PKTIO_STATE_STARTED))
+	if (odp_unlikely(pktio_entry->state != PKTIO_STATE_STARTED))
 		return 0;
 
 	/* Only one netmap tx ring per pktout queue */
@@ -873,7 +874,7 @@ static int netmap_send(pktio_entry_t *pktio_entry, int index,
 	return nb_tx;
 }
 
-static int netmap_mac_addr_get(pktio_entry_t *pktio_entry, void *mac_addr)
+static int netmap_mac_addr_get(odp_pktio_entry_t *pktio_entry, void *mac_addr)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
 		odp_ops_data(pktio_entry, netmap);
@@ -882,7 +883,7 @@ static int netmap_mac_addr_get(pktio_entry_t *pktio_entry, void *mac_addr)
 	return ETH_ALEN;
 }
 
-static uint32_t netmap_mtu_get(pktio_entry_t *pktio_entry)
+static uint32_t netmap_mtu_get(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
 		odp_ops_data(pktio_entry, netmap);
@@ -890,7 +891,7 @@ static uint32_t netmap_mtu_get(pktio_entry_t *pktio_entry)
 	return pkt_nm->mtu;
 }
 
-static int netmap_promisc_mode_set(pktio_entry_t *pktio_entry,
+static int netmap_promisc_mode_set(odp_pktio_entry_t *pktio_entry,
 				   odp_bool_t enable)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
@@ -904,7 +905,7 @@ static int netmap_promisc_mode_set(pktio_entry_t *pktio_entry,
 	return promisc_mode_set_fd(pkt_nm->sockfd, pkt_nm->if_name, enable);
 }
 
-static int netmap_promisc_mode_get(pktio_entry_t *pktio_entry)
+static int netmap_promisc_mode_get(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
 		odp_ops_data(pktio_entry, netmap);
@@ -915,7 +916,7 @@ static int netmap_promisc_mode_get(pktio_entry_t *pktio_entry)
 	return promisc_mode_get_fd(pkt_nm->sockfd, pkt_nm->if_name);
 }
 
-static int netmap_capability(pktio_entry_t *pktio_entry,
+static int netmap_capability(odp_pktio_entry_t *pktio_entry,
 			     odp_pktio_capability_t *capa)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
@@ -925,13 +926,13 @@ static int netmap_capability(pktio_entry_t *pktio_entry,
 	return 0;
 }
 
-static int netmap_stats(pktio_entry_t *pktio_entry,
+static int netmap_stats(odp_pktio_entry_t *pktio_entry,
 			odp_pktio_stats_t *stats)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
 		odp_ops_data(pktio_entry, netmap);
 
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
+	if (pktio_entry->stats_type == STATS_UNSUPPORTED) {
 		memset(stats, 0, sizeof(*stats));
 		return 0;
 	}
@@ -940,13 +941,13 @@ static int netmap_stats(pktio_entry_t *pktio_entry,
 			     stats, pkt_nm->sockfd);
 }
 
-static int netmap_stats_reset(pktio_entry_t *pktio_entry)
+static int netmap_stats_reset(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_netmap_data_t *pkt_nm =
 		odp_ops_data(pktio_entry, netmap);
 
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
-		memset(&pktio_entry->s.stats, 0,
+	if (pktio_entry->stats_type == STATS_UNSUPPORTED) {
+		memset(&pktio_entry->stats, 0,
 		       sizeof(odp_pktio_stats_t));
 		return 0;
 	}
@@ -954,7 +955,7 @@ static int netmap_stats_reset(pktio_entry_t *pktio_entry)
 	return sock_stats_reset_fd(pktio_entry, pkt_nm->sockfd);
 }
 
-static void netmap_print(pktio_entry_t *pktio_entry)
+static void netmap_print(odp_pktio_entry_t *pktio_entry)
 {
 	odp_pktin_hash_proto_t hash_proto;
 	pktio_ops_netmap_data_t *pkt_nm =

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -150,7 +150,7 @@ static uint8_t *pkt_mmap_vlan_insert(uint8_t *l2_hdr_ptr,
 	return l2_hdr_ptr;
 }
 
-static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
+static inline unsigned pkt_mmap_v2_rx(odp_pktio_entry_t *pktio_entry,
 				      pktio_ops_socket_mmap_data_t *pkt_sock,
 				      odp_packet_t pkt_table[], unsigned len,
 				      unsigned char if_mac[])
@@ -167,8 +167,8 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 	struct ring *ring;
 	int ret;
 
-	if (pktio_entry->s.config.pktin.bit.ts_all ||
-	    pktio_entry->s.config.pktin.bit.ts_ptp)
+	if (pktio_entry->config.pktin.bit.ts_all ||
+	    pktio_entry->config.pktin.bit.ts_ptp)
 		ts = &ts_val;
 
 	ring  = &pkt_sock->rx_ring;
@@ -233,13 +233,13 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 			frame_num = next_frame_num;
 			continue;
 		}
-		hdr->input = pktio_entry->s.handle;
+		hdr->input = pktio_entry->handle;
 
 		if (pktio_cls_enabled(pktio_entry))
 			copy_packet_cls_metadata(&parsed_hdr, hdr);
 		else
 			packet_parse_layer(hdr,
-					   pktio_entry->s.config.parser.layer);
+					   pktio_entry->config.parser.layer);
 
 		packet_set_ts(hdr, ts);
 
@@ -492,7 +492,7 @@ static int mmap_bind_sock(pktio_ops_socket_mmap_data_t *pkt_sock,
 	return 0;
 }
 
-static int sock_mmap_close(pktio_entry_t *entry)
+static int sock_mmap_close(odp_pktio_entry_t *entry)
 {
 	pktio_ops_socket_mmap_data_t
 		*const pkt_sock = odp_ops_data(entry, socket_mmap);
@@ -514,7 +514,7 @@ static int sock_mmap_close(pktio_entry_t *entry)
 }
 
 static int sock_mmap_open(odp_pktio_t id ODP_UNUSED,
-			  pktio_entry_t *pktio_entry,
+			  odp_pktio_entry_t *pktio_entry,
 			  const char *netdev, odp_pool_t pool)
 {
 	int if_idx;
@@ -581,19 +581,19 @@ static int sock_mmap_open(odp_pktio_t id ODP_UNUSED,
 	}
 
 	ret = ethtool_stats_get_fd(pkt_sock->sockfd,
-				   pktio_entry->s.name,
+				   pktio_entry->name,
 				   &cur_stats);
 	if (ret != 0) {
 		ret = sysfs_stats(pktio_entry, &cur_stats);
 		if (ret != 0) {
-			pktio_entry->s.stats_type = STATS_UNSUPPORTED;
+			pktio_entry->stats_type = STATS_UNSUPPORTED;
 			ODP_DBG("pktio: %s unsupported stats\n",
-				pktio_entry->s.name);
+				pktio_entry->name);
 		} else {
-			pktio_entry->s.stats_type = STATS_SYSFS;
+			pktio_entry->stats_type = STATS_SYSFS;
 		}
 	} else {
-		pktio_entry->s.stats_type = STATS_ETHTOOL;
+		pktio_entry->stats_type = STATS_ETHTOOL;
 	}
 
 	ret = sock_stats_reset_fd(pktio_entry, pkt_sock->sockfd);
@@ -607,45 +607,46 @@ error:
 	return -1;
 }
 
-static int sock_mmap_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
+static int sock_mmap_recv(odp_pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			  odp_packet_t pkt_table[], int len)
 {
 	pktio_ops_socket_mmap_data_t
 		*const pkt_sock = odp_ops_data(pktio_entry, socket_mmap);
 	int ret;
 
-	odp_ticketlock_lock(&pktio_entry->s.rxl);
+	odp_ticketlock_lock(&pktio_entry->rxl);
 	ret = pkt_mmap_v2_rx(pktio_entry, pkt_sock, pkt_table, len,
 			     pkt_sock->if_mac);
-	odp_ticketlock_unlock(&pktio_entry->s.rxl);
+	odp_ticketlock_unlock(&pktio_entry->rxl);
 
 	return ret;
 }
 
-static int sock_mmap_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
+static int sock_mmap_send(odp_pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			  const odp_packet_t pkt_table[], int len)
 {
 	int ret;
-	pktio_ops_socket_mmap_data_t
-		*const pkt_sock = odp_ops_data(pktio_entry, socket_mmap);
+	pktio_ops_socket_mmap_data_t *const pkt_sock =
+		odp_ops_data(pktio_entry, socket_mmap);
 
-	odp_ticketlock_lock(&pktio_entry->s.txl);
+	odp_ticketlock_lock(&pktio_entry->txl);
 	ret = pkt_mmap_v2_tx(pkt_sock->tx_ring.sock, &pkt_sock->tx_ring,
 			     pkt_table, len);
-	odp_ticketlock_unlock(&pktio_entry->s.txl);
+	odp_ticketlock_unlock(&pktio_entry->txl);
 
 	return ret;
 }
 
-static uint32_t sock_mmap_mtu_get(pktio_entry_t *pktio_entry)
+static uint32_t sock_mmap_mtu_get(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_socket_mmap_data_t
 		*const pkt_sock = odp_ops_data(pktio_entry, socket_mmap);
 
-	return mtu_get_fd(pkt_sock->sockfd, pktio_entry->s.name);
+	return mtu_get_fd(pkt_sock->sockfd, pktio_entry->name);
 }
 
-static int sock_mmap_mac_addr_get(pktio_entry_t *pktio_entry, void *mac_addr)
+static int sock_mmap_mac_addr_get(odp_pktio_entry_t *pktio_entry,
+				  void *mac_addr)
 {
 	pktio_ops_socket_mmap_data_t
 		*const pkt_sock = odp_ops_data(pktio_entry, socket_mmap);
@@ -654,34 +655,34 @@ static int sock_mmap_mac_addr_get(pktio_entry_t *pktio_entry, void *mac_addr)
 	return ETH_ALEN;
 }
 
-static int sock_mmap_promisc_mode_set(pktio_entry_t *pktio_entry,
+static int sock_mmap_promisc_mode_set(odp_pktio_entry_t *pktio_entry,
 				      odp_bool_t enable)
 {
 	pktio_ops_socket_mmap_data_t
 		*const pkt_sock = odp_ops_data(pktio_entry, socket_mmap);
 
 	return promisc_mode_set_fd(pkt_sock->sockfd,
-				   pktio_entry->s.name, enable);
+				   pktio_entry->name, enable);
 }
 
-static int sock_mmap_promisc_mode_get(pktio_entry_t *pktio_entry)
+static int sock_mmap_promisc_mode_get(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_socket_mmap_data_t
 		*const pkt_sock = odp_ops_data(pktio_entry, socket_mmap);
 
 	return promisc_mode_get_fd(pkt_sock->sockfd,
-				   pktio_entry->s.name);
+				   pktio_entry->name);
 }
 
-static int sock_mmap_link_status(pktio_entry_t *pktio_entry)
+static int sock_mmap_link_status(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_socket_mmap_data_t
 		*const pkt_sock = odp_ops_data(pktio_entry, socket_mmap);
 
-	return link_status_fd(pkt_sock->sockfd, pktio_entry->s.name);
+	return link_status_fd(pkt_sock->sockfd, pktio_entry->name);
 }
 
-static int sock_mmap_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
+static int sock_mmap_capability(odp_pktio_entry_t *pktio_entry ODP_UNUSED,
 				odp_pktio_capability_t *capa)
 {
 	memset(capa, 0, sizeof(odp_pktio_capability_t));
@@ -696,13 +697,13 @@ static int sock_mmap_capability(pktio_entry_t *pktio_entry ODP_UNUSED,
 	return 0;
 }
 
-static int sock_mmap_stats(pktio_entry_t *pktio_entry,
+static int sock_mmap_stats(odp_pktio_entry_t *pktio_entry,
 			   odp_pktio_stats_t *stats)
 {
 	pktio_ops_socket_mmap_data_t
 		*const pkt_sock = odp_ops_data(pktio_entry, socket_mmap);
 
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
+	if (pktio_entry->stats_type == STATS_UNSUPPORTED) {
 		memset(stats, 0, sizeof(*stats));
 		return 0;
 	}
@@ -711,13 +712,13 @@ static int sock_mmap_stats(pktio_entry_t *pktio_entry,
 			     stats, pkt_sock->sockfd);
 }
 
-static int sock_mmap_stats_reset(pktio_entry_t *pktio_entry)
+static int sock_mmap_stats_reset(odp_pktio_entry_t *pktio_entry)
 {
 	pktio_ops_socket_mmap_data_t
 		*const pkt_sock = odp_ops_data(pktio_entry, socket_mmap);
 
-	if (pktio_entry->s.stats_type == STATS_UNSUPPORTED) {
-		memset(&pktio_entry->s.stats, 0,
+	if (pktio_entry->stats_type == STATS_UNSUPPORTED) {
+		memset(&pktio_entry->stats, 0,
 		       sizeof(odp_pktio_stats_t));
 		return 0;
 	}

--- a/platform/linux-generic/pktio/sysfs.c
+++ b/platform/linux-generic/pktio/sysfs.c
@@ -43,11 +43,11 @@ static int sysfs_get_val(const char *fname, uint64_t *val)
 	return 0;
 }
 
-int sysfs_stats(pktio_entry_t *pktio_entry,
+int sysfs_stats(odp_pktio_entry_t *pktio_entry,
 		odp_pktio_stats_t *stats)
 {
 	char fname[256];
-	const char *dev = pktio_entry->s.name;
+	const char *dev = pktio_entry->name;
 	int ret = 0;
 
 	sprintf(fname, "/sys/class/net/%s/statistics/rx_bytes", dev);

--- a/platform/linux-generic/pktio/sysfs.h
+++ b/platform/linux-generic/pktio/sysfs.h
@@ -17,7 +17,7 @@
  * @retval != 0 on failure
  */
 
-int sysfs_stats(pktio_entry_t *pktio_entry,
+int sysfs_stats(odp_pktio_entry_t *pktio_entry,
 		odp_pktio_stats_t *stats);
 
 #endif /* ODP_PKTIO_SYSFS_H_ */


### PR DESCRIPTION
Remove extra indirection for accessing pktio_entry fields by modifying interface to use inner structure.
Inner pktio_entry structure was renamed as a public odp symbol since is used by pktio_ops subsystem.
