### PR TITLE
[PATCH 2.0 v1] pktio: include padding bytes in pktio's ops_data

### DIFF
--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -43,8 +43,6 @@ typedef union pktio_entry_u pktio_entry_t;
 
 struct pktio_entry {
 	const pktio_ops_module_t *ops;	/**< Implementation specific methods */
-	uint8_t ops_data[ODP_PKTIO_ODPS_DATA_MAX_SIZE]; /**< IO operation
-							specific data */
 	/* These two locks together lock the whole pktio device */
 	odp_ticketlock_t rxl;		/**< RX ticketlock */
 	odp_ticketlock_t txl;		/**< TX ticketlock */
@@ -97,12 +95,17 @@ struct pktio_entry {
 		odp_queue_t        queue;
 		odp_pktout_queue_t pktout;
 	} out_queue[PKTIO_MAX_QUEUES];
+
+	uint8_t ops_data[ODP_PKTIO_ODPS_DATA_MIN_SIZE]; /**< IO operation
+							specific data */
 };
 
 union pktio_entry_u {
 	struct pktio_entry s;
 	uint8_t pad[ROUNDUP_CACHE_LINE(sizeof(struct pktio_entry))];
 };
+
+#define ODP_PKTIO_ODPS_DATA_MAX_SIZE (sizeof(pktio_entry_t) - offsetof(struct pktio_entry, ops_data))
 
 typedef struct {
 	odp_spinlock_t lock;

--- a/platform/linux-generic/include/odp_pktio_ops_subsystem.h
+++ b/platform/linux-generic/include/odp_pktio_ops_subsystem.h
@@ -85,8 +85,8 @@ typedef ODP_MODULE_CLASS(pktio_ops) {
 	odp_api_proto(pktio_ops, print) print;
 } pktio_ops_module_t;
 
-/* Maximum size of pktio specific ops data.*/
-#define ODP_PKTIO_ODPS_DATA_MAX_SIZE 80000
+/* Minimum size of pktio specific ops data.*/
+#define ODP_PKTIO_ODPS_DATA_MIN_SIZE 80000
 
 /* Extract pktio ops data from pktio entry structure */
 #define odp_ops_data(_p, _mod) \


### PR DESCRIPTION
By placing the odp_data array at the end of the pktio_entry struct,
we can now let pktios make use of any padding bytes that may have
been added for alignment in pktio_entry_u.

Signed-off-by: Josep Puigdemont <josep.puigdemont@linaro.org>