### PR TITLE
[PATCH v1] example: fix pointers to odp_l2fwd.c source

### DIFF
--- a/example/l2fwd/README
+++ b/example/l2fwd/README
@@ -1,7 +1,6 @@
     ODP L2FWD application
 
-Source code and Makefiles placed under test/common_plat/performance/
-directory.
+Source code and Makefiles placed under test/performance/ directory.
 
 This L2 forwarding application can be used as example reference as well
 as performance test for different odp modes (direct, queue or scheduler

--- a/example/l2fwd/odp_l2fwd.c
+++ b/example/l2fwd/odp_l2fwd.c
@@ -1,1 +1,1 @@
-../../test/common_plat/performance/odp_l2fwd.c
+../../test/performance/odp_l2fwd.c


### PR DESCRIPTION
During mass-move of tests I forgot to update odp_l2fwd example to point
to new locattion. Fix that now.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>