### PR TITLE
[PATCH 2.0 v2] driver.h: add parameter when registering enumerators

### DIFF
--- a/example/ddf_ifs/ddf_ifs_enumr_dpdk.c
+++ b/example/ddf_ifs/ddf_ifs_enumr_dpdk.c
@@ -17,7 +17,7 @@ static odpdrv_enumr_t dpdk_enumr;
 
 static odpdrv_device_t dpdk_dev[DDF_DPDK_DEV_MAX];
 static int dpdk_dev_cnt;
-static int dpdk_enumr_probe(void)
+static int dpdk_enumr_probe(void *data __attribute__((__unused__)))
 {
 	int dpdk_dev_cnt_detected = TEST_DPDK_DEV_CNT; /* detected with
 							  dpdk APIs*/
@@ -46,7 +46,7 @@ static int dpdk_enumr_probe(void)
 	return 0;
 }
 
-static int dpdk_enumr_remove(void)
+static int dpdk_enumr_remove(void *data __attribute__((__unused__)))
 {
 	printf("%s()\n", __func__);
 	return 0;

--- a/example/ddf_ifs/ddf_ifs_enumr_generic.c
+++ b/example/ddf_ifs/ddf_ifs_enumr_generic.c
@@ -11,13 +11,13 @@
 
 static odpdrv_enumr_t gen_enumr;
 
-static int gen_enumr_probe(void)
+static int gen_enumr_probe(void *data __attribute__((__unused__)))
 {
 	printf("%s() - no devices found\n", __func__);
 	return 0;
 }
 
-static int gen_enumr_remove(void)
+static int gen_enumr_remove(void *data __attribute__((__unused__)))
 {
 	printf("%s()\n", __func__);
 	return 0;

--- a/include/odp/drv/spec/driver.h
+++ b/include/odp/drv/spec/driver.h
@@ -205,12 +205,12 @@ struct odpdrv_enumr_param_t {
 	 * Called by ODP when it is ready for device creation/deletion
 	 * returns an negative value on error or 0 on success.
 	 */
-	int (*probe)(void);
+	int (*probe)(void *enumr_data);
 
 	/** Remove function:
 	 * destroy all enumerated devices and release all resources
 	 */
-	int (*remove)(void);
+	int (*remove)(void *enumr_data);
 
 	/** Register event notifier function for hotplug events:
 	 * register_notifier(fcnt,event_mask) registers fcnt as a callback when
@@ -218,6 +218,12 @@ struct odpdrv_enumr_param_t {
 	 */
 	int (*register_notifier)(void (*event_handler) (uint64_t event),
 				 int64_t event_mask);
+
+	/** Class dependent part
+	 * This part is allocated by the enumerator class for use by the
+	 * enumerator, it is passed as a parameter to the probe function.
+	 */
+	void *enumr_data;
 };
 
 /* The following events are supported by enumerators */

--- a/platform/linux-generic/drv_driver.c
+++ b/platform/linux-generic/drv_driver.c
@@ -851,7 +851,7 @@ void _odpdrv_driver_probe_drv_items(void)
 	enumr = enumr_lst.head;
 	while (enumr) {
 		if (!enumr->probed) {
-			enumr->param.probe();
+			enumr->param.probe(enumr->param.enumr_data);
 			enumr->probed = 1;
 		}
 		enumr = enumr->next;
@@ -1055,7 +1055,7 @@ int _odpdrv_driver_term_global(void)
 	while (enumr_lst.head) {
 		enumr = enumr_lst.head;
 		if (enumr->param.remove) { /* run remove callback, if any */
-			if (enumr->param.remove())
+			if (enumr->param.remove(enumr->param.enumr_data))
 				ODP_ERR("Enumerator (API %s) removal failed.\n",
 					enumr->param.api_name);
 		}

--- a/test/validation/drv/drvdriver/drvdriver_device.c
+++ b/test/validation/drv/drvdriver/drvdriver_device.c
@@ -22,8 +22,8 @@ typedef struct dev_enumr_data_t { /* enumerator data for registered devices */
 #define NB_DEVICES 5
 
 /* forward declaration */
-static int enumr1_probe(void);
-static int enumr1_remove(void);
+static int enumr1_probe(void *);
+static int enumr1_remove(void *);
 static int enumr_class1_probe(void);
 static int enumr_class1_remove(void);
 
@@ -68,7 +68,8 @@ static odpdrv_enumr_t enumr1_register(void)
 		.api_version = 1,
 		.probe = enumr1_probe,
 		.remove = enumr1_remove,
-		.register_notifier = NULL
+		.register_notifier = NULL,
+		.enumr_data = NULL
 	};
 
 	enumr1 = odpdrv_enumr_register(&param);
@@ -76,7 +77,7 @@ static odpdrv_enumr_t enumr1_register(void)
 }
 
 /*enumerator probe functions, just making sure they have been run: */
-static int enumr1_probe(void)
+static int enumr1_probe(void *enumr_data __attribute__((__unused__)))
 {
 	int dev;
 	odpdrv_shm_t shm;
@@ -128,7 +129,7 @@ static void  enumr5_device_destroy_terminate(void *priv_data)
 }
 
 /*enumerator remove functions, to remove the enumerated devices: */
-static int enumr1_remove(void)
+static int enumr1_remove(void *data __attribute__((__unused__)))
 {
 	odpdrv_device_t *my_devices;
 	odpdrv_device_t *dev;

--- a/test/validation/drv/drvdriver/drvdriver_driver.c
+++ b/test/validation/drv/drvdriver/drvdriver_driver.c
@@ -56,10 +56,10 @@ static int driver1_probed_index;
 static int driver2_probed_index;
 
 /* forward declaration */
-static int enumr1_probe(void);
-static int enumr2_probe(void);
-static int enumr1_remove(void);
-static int enumr2_remove(void);
+static int enumr1_probe(void *);
+static int enumr2_probe(void *);
+static int enumr1_remove(void *);
+static int enumr2_remove(void *);
 static int enumr_class1_probe(void);
 static int enumr_class2_probe(void);
 static int driver1_probe(odpdrv_device_t dev, odpdrv_devio_t devio, int idx);
@@ -167,8 +167,10 @@ static int enumr_class2_probe(void)
 	return 0;
 }
 
+#define UNUSED __attribute__((__unused__))
+
 /*enumerator probe functions, creating four devices each: */
-static int enumr1_probe(void)
+static int enumr1_probe(void *enumr_data UNUSED)
 {
 	int dev;
 
@@ -189,7 +191,7 @@ static int enumr1_probe(void)
 	return 0;
 }
 
-static int enumr2_probe(void)
+static int enumr2_probe(void *enumr_data UNUSED)
 {
 	int dev;
 
@@ -211,7 +213,7 @@ static int enumr2_probe(void)
 }
 
 /*enumerator remove functions, to remove the enumerated devices: */
-static int enumr1_remove(void)
+static int enumr1_remove(void *data UNUSED)
 {
 	odpdrv_device_t *my_devices;
 	odpdrv_device_t *dev;
@@ -231,7 +233,7 @@ static int enumr1_remove(void)
 	return 0;
 }
 
-static int enumr2_remove(void)
+static int enumr2_remove(void *data UNUSED)
 {
 	odpdrv_device_t *my_devices;
 	odpdrv_device_t *dev;

--- a/test/validation/drv/drvdriver/drvdriver_enumr.c
+++ b/test/validation/drv/drvdriver/drvdriver_enumr.c
@@ -20,15 +20,15 @@ static int enumr3_probed;
 static int enumr4_probed;
 
 /* forward declaration */
-static int enumr1_probe(void);
-static int enumr2_probe(void);
-static int enumr3_probe(void);
-static int enumr4_probe(void);
+static int enumr1_probe(void *);
+static int enumr2_probe(void *);
+static int enumr3_probe(void *);
+static int enumr4_probe(void *);
 
-static int enumr1_remove(void);
-static int enumr2_remove(void);
-static int enumr3_remove(void);
-static int enumr4_remove(void);
+static int enumr1_remove(void *);
+static int enumr2_remove(void *);
+static int enumr3_remove(void *);
+static int enumr4_remove(void *);
 
 static int enumr_class1_probe(void);
 static int enumr_class2_probe(void);
@@ -68,6 +68,8 @@ static int tests_global_term(void)
 	return 0;
 }
 
+#define ENUMR1_PROBE_DATA ((void *)0x1000)
+
 /*enumerator register functions */
 static odpdrv_enumr_t enumr1_register(void)
 {
@@ -77,7 +79,8 @@ static odpdrv_enumr_t enumr1_register(void)
 		.api_version = 1,
 		.probe = enumr1_probe,
 		.remove = enumr1_remove,
-		.register_notifier = NULL
+		.register_notifier = NULL,
+		.enumr_data = ENUMR1_PROBE_DATA
 	};
 
 	return odpdrv_enumr_register(&param);
@@ -91,7 +94,8 @@ static odpdrv_enumr_t enumr2_register(void)
 		.api_version = 1,
 		.probe = enumr2_probe,
 		.remove = enumr2_remove,
-		.register_notifier = NULL
+		.register_notifier = NULL,
+		.enumr_data = NULL
 	};
 
 	return odpdrv_enumr_register(&param);
@@ -105,7 +109,8 @@ static odpdrv_enumr_t enumr3_register(void)
 		.api_version = 1,
 		.probe = enumr3_probe,
 		.remove = enumr3_remove,
-		.register_notifier = NULL
+		.register_notifier = NULL,
+		.enumr_data = NULL
 	};
 
 	return odpdrv_enumr_register(&param);
@@ -119,7 +124,8 @@ static odpdrv_enumr_t enumr4_register(void)
 		.api_version = 1,
 		.probe = enumr4_probe,
 		.remove = enumr4_remove,
-		.register_notifier = NULL
+		.register_notifier = NULL,
+		.enumr_data = NULL
 	};
 
 	return odpdrv_enumr_register(&param);
@@ -133,57 +139,61 @@ static odpdrv_enumr_t enumr_invalid_register(void)
 		.api_version = 1,
 		.probe = enumr4_probe,
 		.remove = enumr4_remove,
-		.register_notifier = NULL
+		.register_notifier = NULL,
+		.enumr_data = NULL
 	};
 
 	return odpdrv_enumr_register(&param);
 }
 
 /*enumerator probe functions, just making sure they have been run: */
-static int enumr1_probe(void)
+static int enumr1_probe(void *data)
 {
+	CU_ASSERT(data == ENUMR1_PROBE_DATA);
 	enumr1_probed = 1;
 	return 0;
 }
 
-static int enumr2_probe(void)
+#define UNUSED __attribute__((__unused__))
+
+static int enumr2_probe(void *data UNUSED)
 {
 	enumr2_probed = 1;
 	return 0;
 }
 
-static int enumr3_probe(void)
+static int enumr3_probe(void *data UNUSED)
 {
 	enumr3_probed = 1;
 	return 0;
 }
 
-static int enumr4_probe(void)
+static int enumr4_probe(void *data UNUSED)
 {
 	enumr4_probed = 1;
 	return 0;
 }
 
 /*enumerator remove functions, just making sure they have been run: */
-static int enumr1_remove(void)
+static int enumr1_remove(void *data UNUSED)
 {
 	enumr1_probed = -1;
 	return 0;
 }
 
-static int enumr2_remove(void)
+static int enumr2_remove(void *data UNUSED)
 {
 	enumr2_probed = -1;
 	return 0;
 }
 
-static int enumr3_remove(void)
+static int enumr3_remove(void *data UNUSED)
 {
 	enumr3_probed = -1;
 	return 0;
 }
 
-static int enumr4_remove(void)
+static int enumr4_remove(void *data UNUSED)
 {
 	enumr4_probed = -1;
 	return 0;


### PR DESCRIPTION
If a class registers more than once the same enumerator, as it could
happen for different PCI platforms, we need to provide information for
the enumerator probe function to know where to act.

This information shall be provided in the odpdrv_enumr_param_t structure
as a void pointer, which will be passed to the probe() function of the
enumerator.

Signed-off-by: Josep Puigdemont <josep.puigdemont@linaro.org>