### PR TITLE
[PATCH API-NEXT v1] api: pktio: max frame length

### DIFF
--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -970,6 +970,36 @@ int odp_pktio_promisc_mode_set(odp_pktio_t pktio, odp_bool_t enable);
 int odp_pktio_promisc_mode(odp_pktio_t pktio);
 
 /**
+ * Maximum frame length at packet input
+ *
+ * Maximum frame length in bytes that the packet IO interface can receive.
+ * For Ethernet, the frame length bytes start with MAC addresses and continue
+ * to the end of the payload. So, Ethernet checksum, interpacket gap
+ * and preamble bytes are excluded from the length.
+ *
+ * @param pktio  Packet IO handle.
+ *
+ * @return Maximum frame length at packet input
+ * @retval 0 on failure
+ */
+uint32_t odp_pktin_maxlen(odp_pktio_t pktio);
+
+/**
+ * Maximum frame length at packet output
+ *
+ * Maximum frame length in bytes that the packet IO interface can transmit.
+ * For Ethernet, the frame length bytes start with MAC addresses and continue
+ * to the end of the payload. So, Ethernet checksum, interpacket gap
+ * and preamble bytes are excluded from the length.
+ *
+ * @param pktio  Packet IO handle.
+ *
+ * @return Maximum frame length at packet output
+ * @retval 0 on failure
+ */
+uint32_t odp_pktout_maxlen(odp_pktio_t pktio);
+
+/**
  * Get the default MAC address of a packet IO interface.
  *
  * @param	pktio     Packet IO handle

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -954,8 +954,8 @@ uint32_t ODP_DEPRECATE(odp_pktio_mtu)(odp_pktio_t pktio);
 /**
  * Enable/Disable promiscuous mode on a packet IO interface.
  *
- * @param[in] pktio	Packet IO handle.
- * @param[in] enable	1 to enable, 0 to disable.
+ * @param pktio   Packet IO handle.
+ * @param enable  1 to enable, 0 to disable.
  *
  * @retval 0 on success
  * @retval <0 on failure
@@ -965,7 +965,7 @@ int odp_pktio_promisc_mode_set(odp_pktio_t pktio, odp_bool_t enable);
 /**
  * Determine if promiscuous mode is enabled for a packet IO interface.
  *
- * @param[in] pktio Packet IO handle.
+ * @param pktio  Packet IO handle.
  *
  * @retval  1 if promiscuous mode is enabled.
  * @retval  0 if promiscuous mode is disabled.
@@ -1034,14 +1034,13 @@ int odp_pktio_mac_addr_set(odp_pktio_t pktio, const void *mac_addr,
 /**
  * Setup per-port default class-of-service.
  *
- * @param[in]	pktio		Ingress port pktio handle.
- * @param[in]	default_cos	Class-of-service set to all packets arriving
- *				at this ingress port,
- *				unless overridden by subsequent
- *				header-based filters.
+ * @param pktio        Ingress port pktio handle.
+ * @param default_cos  Class-of-service set to all packets arriving at this
+ *                     ingress port, unless overridden by subsequent
+ *                     header-based filters.
  *
- * @retval			0 on success
- * @retval			<0 on failure
+ * @retval  0 on success
+ * @retval <0 on failure
  *
  * @note The default_cos has to be unique per odp_pktio_t instance.
  */
@@ -1050,12 +1049,12 @@ int odp_pktio_default_cos_set(odp_pktio_t pktio, odp_cos_t default_cos);
 /**
  * Setup per-port error class-of-service
  *
- * @param[in]	pktio		Ingress port pktio handle.
- * @param[in]	error_cos	class-of-service set to all packets arriving
- *				at this ingress port that contain an error.
+ * @param pktio      Ingress port pktio handle.
+ * @param error_cos  class-of-service set to all packets arriving at this
+ *                   ingress port that contain an error.
  *
- * @retval			0 on success
- * @retval			<0 on failure
+ * @retval  0 on success
+ * @retval <0 on failure
  *
  * @note Optional.
  */
@@ -1064,24 +1063,23 @@ int odp_pktio_error_cos_set(odp_pktio_t pktio, odp_cos_t error_cos);
 /**
  * Setup per-port header offset
  *
- * @param[in]	pktio		Ingress port pktio handle.
- * @param[in]	offset		Number of bytes the classifier must skip.
+ * @param pktio      Ingress port pktio handle.
+ * @param offset     Number of bytes the classifier must skip.
  *
- * @retval			0 on success
- * @retval			<0 on failure
- * @note  Optional.
+ * @retval  0 on success
+ * @retval <0 on failure
  *
+ * @note Optional.
  */
 int odp_pktio_skip_set(odp_pktio_t pktio, uint32_t offset);
 
 /**
  * Specify per-port buffer headroom
  *
- * @param[in]	pktio		Ingress port pktio handle.
- * @param[in]	headroom	Number of bytes of space preceding
- *				packet data to reserve for use as headroom.
- *				Must not exceed the implementation
- *				defined ODP_PACKET_MAX_HEADROOM.
+ * @param pktio     Ingress port pktio handle.
+ * @param headroom  Number of bytes of space preceding packet data to reserve
+ *                  for use as headroom. Must not exceed the implementation
+ *                  defined ODP_PACKET_MAX_HEADROOM.
  *
  * @retval			0 on success
  * @retval			<0 on failure

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -30,7 +30,7 @@ extern "C" {
  *
  * Packet IO is the Ingress and Egress interface to ODP processing. It
  * allows manipulation of the interface for setting such attributes as
- * the mtu, mac etc.
+ * number of queues, MAC address etc.
  * Pktio is usually followed by the classifier and a default class COS
  * can be set so that the scheduler may distribute flows. The interface
  * may be used directly in polled mode with odp_pktin_recv() and
@@ -938,14 +938,18 @@ int odp_pktout_send(odp_pktout_queue_t queue, const odp_packet_t packets[],
 		    int num);
 
 /**
- * Return the currently configured MTU value of a packet IO interface.
+ * MTU value of a packet IO interface
  *
- * @param[in] pktio  Packet IO handle.
+ * @deprecated  Use odp_pktin_maxlen() and odp_pktout_maxlen() instead. MTU was
+ * not well defined. There may be difference between MTU and maximum frame
+ * length values.
+ *
+ * @param pktio  Packet IO handle.
  *
  * @return MTU value on success
  * @retval 0 on failure
  */
-uint32_t odp_pktio_mtu(odp_pktio_t pktio);
+uint32_t ODP_DEPRECATE(odp_pktio_mtu)(odp_pktio_t pktio);
 
 /**
  * Enable/Disable promiscuous mode on a packet IO interface.

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -777,7 +777,7 @@ void sched_cb_pktio_stop_finalize(int pktio_index)
 	unlock_entry(entry);
 }
 
-uint32_t odp_pktio_mtu(odp_pktio_t hdl)
+static inline uint32_t pktio_mtu(odp_pktio_t hdl)
 {
 	pktio_entry_t *entry;
 	uint32_t ret = 0;
@@ -801,6 +801,21 @@ uint32_t odp_pktio_mtu(odp_pktio_t hdl)
 
 	unlock_entry(entry);
 	return ret;
+}
+
+uint32_t odp_pktio_mtu(odp_pktio_t pktio)
+{
+	return pktio_mtu(pktio);
+}
+
+uint32_t odp_pktin_maxlen(odp_pktio_t pktio)
+{
+	return pktio_mtu(pktio);
+}
+
+uint32_t odp_pktout_maxlen(odp_pktio_t pktio)
+{
+	return pktio_mtu(pktio);
 }
 
 int odp_pktio_promisc_mode_set(odp_pktio_t hdl, odp_bool_t enable)
@@ -1089,8 +1104,11 @@ void odp_pktio_print(odp_pktio_t hdl)
 			"  mac               %02x:%02x:%02x:%02x:%02x:%02x\n",
 			addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 	len += snprintf(&str[len], n - len,
-			"  mtu               %" PRIu32 "\n",
-			odp_pktio_mtu(hdl));
+			"  pktin maxlen      %" PRIu32 "\n",
+			odp_pktin_maxlen(hdl));
+	len += snprintf(&str[len], n - len,
+			"  pktout maxlen     %" PRIu32 "\n",
+			odp_pktout_maxlen(hdl));
 	len += snprintf(&str[len], n - len,
 			"  promisc           %s\n",
 			odp_pktio_promisc_mode(hdl) ? "yes" : "no");

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -803,7 +803,7 @@ static inline uint32_t pktio_mtu(odp_pktio_t hdl)
 	return ret;
 }
 
-uint32_t odp_pktio_mtu(odp_pktio_t pktio)
+uint32_t ODP_DEPRECATE(odp_pktio_mtu)(odp_pktio_t pktio)
 {
 	return pktio_mtu(pktio);
 }

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -832,6 +832,13 @@ static uint32_t dpdk_mtu_get(pktio_entry_t *pktio_entry)
 	return mtu;
 }
 
+static uint32_t dpdk_frame_maxlen(pktio_entry_t *pktio_entry)
+{
+	pkt_dpdk_t *pkt_dpdk = &pktio_entry->s.pkt_dpdk;
+
+	return pkt_dpdk->mtu;
+}
+
 static int dpdk_vdev_promisc_mode_get(uint8_t port_id)
 {
 	struct rte_eth_dev_info dev_info;
@@ -1631,7 +1638,7 @@ const pktio_if_ops_t dpdk_pktio_ops = {
 	.recv = dpdk_recv,
 	.send = dpdk_send,
 	.link_status = dpdk_link_status,
-	.mtu_get = dpdk_mtu_get,
+	.mtu_get = dpdk_frame_maxlen,
 	.promisc_mode_set = dpdk_promisc_mode_set,
 	.promisc_mode_get = dpdk_promisc_mode_get,
 	.mac_get = dpdk_mac_addr_get,

--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -108,6 +108,7 @@ typedef struct {
 	int error_check;        /**< Check packet errors */
 	int sched_mode;         /**< Scheduler mode */
 	int num_groups;         /**< Number of scheduling groups */
+	int verbose;		/**< Verbose output */
 } appl_args_t;
 
 static int exit_threads;	/**< Break workers loop if set to 1 */
@@ -697,6 +698,9 @@ static int create_pktio(const char *dev, int idx, int num_rx, int num_tx,
 	printf("created pktio %" PRIu64 ", dev: %s, drv: %s\n",
 	       odp_pktio_to_u64(pktio), dev, info.drv_name);
 
+	if (gbl_args->appl.verbose)
+		odp_pktio_print(pktio);
+
 	if (odp_pktio_capability(pktio, &capa)) {
 		LOG_ERR("Error: capability query failed %s\n", dev);
 		return -1;
@@ -1163,11 +1167,12 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 		{"src_change", required_argument, NULL, 's'},
 		{"error_check", required_argument, NULL, 'e'},
 		{"groups", required_argument, NULL, 'g'},
+		{"verbose", no_argument, NULL, 'v'},
 		{"help", no_argument, NULL, 'h'},
 		{NULL, 0, NULL, 0}
 	};
 
-	static const char *shortopts =  "+c:+t:+a:i:m:o:r:d:s:e:g:h";
+	static const char *shortopts =  "+c:+t:+a:i:m:o:r:d:s:e:g:vh";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
 	odph_parse_options(argc, argv, shortopts, longopts);
@@ -1178,6 +1183,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->src_change = 1; /* change eth src address by default */
 	appl_args->num_groups = 0; /* use default group */
 	appl_args->error_check = 0; /* don't check packet errors by default */
+	appl_args->verbose = 0;
 
 	opterr = 0; /* do not issue errors on helper options */
 
@@ -1304,6 +1310,9 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 			break;
 		case 'g':
 			appl_args->num_groups = atoi(optarg);
+			break;
+		case 'v':
+			appl_args->verbose = 1;
 			break;
 		case 'h':
 			usage(argv[0]);


### PR DESCRIPTION
MTU is not a well defined term for link layer maximum receive and transmit frame sizes. Added functions to request maximum packet input and output frame lengths. Deprecated odp_pktio_mtu() function.