### PR TITLE
[PATCH API-NEXT v2] api: queue: lockfree queue

### DIFF
--- a/platform/linux-generic/odp_queue.c
+++ b/platform/linux-generic/odp_queue.c
@@ -150,7 +150,9 @@ static int queue_capability(odp_queue_capability_t *capa)
 	capa->max_sched_groups  = sched_fn->num_grps();
 	capa->sched_prios       = odp_schedule_num_prio();
 	capa->plain.max_num     = capa->max_queues;
+	capa->plain.nonblocking = ODP_BLOCKING;
 	capa->sched.max_num     = capa->max_queues;
+	capa->sched.nonblocking = ODP_BLOCKING;
 
 	return 0;
 }
@@ -601,6 +603,7 @@ static void queue_param_init(odp_queue_param_t *params)
 	params->type = ODP_QUEUE_TYPE_PLAIN;
 	params->enq_mode = ODP_QUEUE_OP_MT;
 	params->deq_mode = ODP_QUEUE_OP_MT;
+	params->nonblocking = ODP_BLOCKING;
 	params->sched.prio  = ODP_SCHED_PRIO_DEFAULT;
 	params->sched.sync  = ODP_SCHED_SYNC_PARALLEL;
 	params->sched.group = ODP_SCHED_GROUP_ALL;

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -315,8 +315,10 @@ static int queue_capability(odp_queue_capability_t *capa)
 	capa->sched_prios       = odp_schedule_num_prio();
 	capa->plain.max_num     = ODP_CONFIG_QUEUES - NUM_INTERNAL_QUEUES;
 	capa->plain.max_size    = 0;
+	capa->plain.nonblocking = ODP_BLOCKING;
 	capa->sched.max_num     = ODP_CONFIG_QUEUES - NUM_INTERNAL_QUEUES;
 	capa->sched.max_size    = 0;
+	capa->sched.nonblocking = ODP_BLOCKING;
 
 	return 0;
 }
@@ -861,6 +863,7 @@ static void queue_param_init(odp_queue_param_t *params)
 	params->type = ODP_QUEUE_TYPE_PLAIN;
 	params->enq_mode = ODP_QUEUE_OP_MT;
 	params->deq_mode = ODP_QUEUE_OP_MT;
+	params->nonblocking = ODP_BLOCKING;
 	params->sched.prio = ODP_SCHED_PRIO_DEFAULT;
 	params->sched.sync = ODP_SCHED_SYNC_PARALLEL;
 	params->sched.group = ODP_SCHED_GROUP_ALL;

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -69,6 +69,8 @@ void queue_test_capa(void)
 	CU_ASSERT(capa.sched_prios != 0);
 	CU_ASSERT(capa.plain.max_num != 0);
 	CU_ASSERT(capa.sched.max_num != 0);
+	CU_ASSERT(capa.plain.nonblocking >= ODP_BLOCKING);
+	CU_ASSERT(capa.sched.nonblocking >= ODP_BLOCKING);
 
 	min = capa.plain.max_num;
 	if (min > capa.sched.max_num)
@@ -82,6 +84,7 @@ void queue_test_capa(void)
 	name[ODP_QUEUE_NAME_LEN - 1] = 0;
 
 	odp_queue_param_init(&qparams);
+	CU_ASSERT(qparams.nonblocking == ODP_BLOCKING);
 
 	for (j = 0; j < 2; j++) {
 		if (j == 0) {


### PR DESCRIPTION
Add queue parameter for indicating need for non-blocked operation. Non-blocking guarantee is important for real-time applications. E.g. when RT and non-RT threads uses queues for communication, RT threads must not block if an non-RT thread blocks (e.g. kernel interrupts it). Many HW implementations are inherently non-blocking, SW implementations need special care for non-block support.
 