### PR TITLE
[PATCH 2.0 v1] linux-dpdk: buffer: remove default queue meta data

### DIFF
--- a/platform/linux-dpdk/Makefile.am
+++ b/platform/linux-dpdk/Makefile.am
@@ -265,8 +265,6 @@ __LIB__libodp_dpdk_la_SOURCES = \
 			   pool/dpdk.c \
 			   ../linux-generic/odp_queue_if.c \
 			   ../linux-generic/queue/subsystem.c \
-			   ../linux-generic/queue/generic.c \
-			   ../linux-generic/queue/scalable.c \
 			   ../linux-generic/odp_rwlock.c \
 			   ../linux-generic/odp_rwlock_recursive.c \
 			   ../linux-generic/pool/subsystem.c \
@@ -348,8 +346,10 @@ endif
 endif
 endif
 if ODP_SCHEDULE_SCALABLE
+__LIB__libodp_dpdk_la_SOURCES += ../linux-generic/queue/scalable.c
 ../linux-generic/queue/scalable.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
 else
+__LIB__libodp_dpdk_la_SOURCES += ../linux-generic/queue/generic.c
 ../linux-generic/queue/generic.lo: AM_CFLAGS += -DIM_ACTIVE_MODULE
 endif
 

--- a/platform/linux-dpdk/buffer/dpdk.c
+++ b/platform/linux-dpdk/buffer/dpdk.c
@@ -36,7 +36,6 @@ static odp_buffer_t buffer_alloc(odp_pool_t pool_hdl)
 		return ODP_BUFFER_INVALID;
 	}
 
-	buf_hdl_to_hdr(buffer)->next = NULL;
 	return buffer;
 }
 

--- a/platform/linux-dpdk/include/odp_buffer_internal.h
+++ b/platform/linux-dpdk/include/odp_buffer_internal.h
@@ -57,12 +57,17 @@ struct odp_buffer_hdr_t {
 	 /* ODP buffer type, not DPDK buf type */
 	int type;
 
+#ifndef ODP_SCHEDULE_SCALABLE
 	/* Burst counts */
 	int burst_num;
 	int burst_first;
 
 	/* Next buf in a list */
 	struct odp_buffer_hdr_t *next;
+
+	/* Burst table */
+	struct odp_buffer_hdr_t *burst[BUFFER_BURST_SIZE];
+#endif
 
 	/* User context pointer or u64 */
 	union {
@@ -76,9 +81,6 @@ struct odp_buffer_hdr_t {
 
 	/* Event subtype. Should be ODP_EVENT_NO_SUBTYPE except packets. */
 	odp_event_type_t         event_subtype;
-
-	/* Burst table */
-	struct odp_buffer_hdr_t *burst[BUFFER_BURST_SIZE];
 
 	/* Pool handle */
 	odp_pool_t pool_hdl;

--- a/platform/linux-dpdk/odp_packet.c
+++ b/platform/linux-dpdk/odp_packet.c
@@ -189,8 +189,6 @@ int odp_packet_reset(odp_packet_t pkt, uint32_t len)
 	pkt_hdr->p.l3_offset = ODP_PACKET_OFFSET_INVALID;
 	pkt_hdr->p.l4_offset = ODP_PACKET_OFFSET_INVALID;
 
-	pkt_hdr->buf_hdr.next = NULL;
-
 	pkt_hdr->input = ODP_PKTIO_INVALID;
 	pkt_hdr->buf_hdr.event_subtype = ODP_EVENT_PACKET_BASIC;
 


### PR DESCRIPTION
Remove the default queue meta data for scalable scheduler in linux-dpdk. This was missed in the earlier PR.