### PR TITLE
[PATCH API-NEXT v1] api: time: time difference in nsec

### DIFF
--- a/include/odp/api/spec/time.h
+++ b/include/odp/api/spec/time.h
@@ -77,6 +77,16 @@ odp_time_t odp_time_global(void);
 odp_time_t odp_time_diff(odp_time_t t2, odp_time_t t1);
 
 /**
+ * Time difference in nanoseconds
+ *
+ * @param t2    Second time stamp
+ * @param t1    First time stamp
+ *
+ * @return Difference of time stamps (t2 - t1) in nanoseconds
+ */
+uint64_t odp_time_diff_ns(odp_time_t t2, odp_time_t t1);
+
+/**
  * Time sum
  *
  * @param t1    Time stamp

--- a/platform/linux-generic/odp_time.c
+++ b/platform/linux-generic/odp_time.c
@@ -228,6 +228,15 @@ odp_time_t odp_time_diff(odp_time_t t2, odp_time_t t1)
 	return time;
 }
 
+uint64_t odp_time_diff_ns(odp_time_t t2, odp_time_t t1)
+{
+	odp_time_t time;
+
+	time.u64 = t2.u64 - t1.u64;
+
+	return time_to_ns(time);
+}
+
 uint64_t odp_time_to_ns(odp_time_t time)
 {
 	return time_to_ns(time);

--- a/test/validation/api/time/time.c
+++ b/test/validation/api/time/time.c
@@ -201,7 +201,8 @@ static void time_test_diff(time_cb time_cur,
 	/* volatile to stop optimization of busy loop */
 	volatile int count = 0;
 	odp_time_t diff, t1, t2;
-	uint64_t nsdiff, ns1, ns2, ns;
+	uint64_t ns1, ns2, ns;
+	uint64_t nsdiff, diff_ns;
 	uint64_t upper_limit, lower_limit;
 
 	/* test timestamp diff */
@@ -217,6 +218,9 @@ static void time_test_diff(time_cb time_cur,
 	diff = odp_time_diff(t2, t1);
 	CU_ASSERT(odp_time_cmp(diff, ODP_TIME_NULL) > 0);
 
+	diff_ns = odp_time_diff_ns(t2, t1);
+	CU_ASSERT(diff_ns > 0);
+
 	ns1 = odp_time_to_ns(t1);
 	ns2 = odp_time_to_ns(t2);
 	ns = ns2 - ns1;
@@ -225,6 +229,7 @@ static void time_test_diff(time_cb time_cur,
 	upper_limit = ns + 2 * res;
 	lower_limit = ns - 2 * res;
 	CU_ASSERT((nsdiff <= upper_limit) && (nsdiff >= lower_limit));
+	CU_ASSERT((diff_ns <= upper_limit) && (diff_ns >= lower_limit));
 
 	/* test timestamp and interval diff */
 	ns1 = 54;
@@ -233,11 +238,16 @@ static void time_test_diff(time_cb time_cur,
 
 	diff = odp_time_diff(t2, t1);
 	CU_ASSERT(odp_time_cmp(diff, ODP_TIME_NULL) > 0);
+
+	diff_ns = odp_time_diff_ns(t2, t1);
+	CU_ASSERT(diff_ns > 0);
+
 	nsdiff = odp_time_to_ns(diff);
 
 	upper_limit = ns + 2 * res;
 	lower_limit = ns - 2 * res;
 	CU_ASSERT((nsdiff <= upper_limit) && (nsdiff >= lower_limit));
+	CU_ASSERT((diff_ns <= upper_limit) && (diff_ns >= lower_limit));
 
 	/* test interval diff */
 	ns2 = 60 * 10 * ODP_TIME_SEC_IN_NS;
@@ -246,11 +256,16 @@ static void time_test_diff(time_cb time_cur,
 	t2 = time_from_ns(ns2);
 	diff = odp_time_diff(t2, t1);
 	CU_ASSERT(odp_time_cmp(diff, ODP_TIME_NULL) > 0);
+
+	diff_ns = odp_time_diff_ns(t2, t1);
+	CU_ASSERT(diff_ns > 0);
+
 	nsdiff = odp_time_to_ns(diff);
 
 	upper_limit = ns + 2 * res;
 	lower_limit = ns - 2 * res;
 	CU_ASSERT((nsdiff <= upper_limit) && (nsdiff >= lower_limit));
+	CU_ASSERT((diff_ns <= upper_limit) && (diff_ns >= lower_limit));
 
 	/* same time has to diff to 0 */
 	diff = odp_time_diff(t2, t2);
@@ -258,6 +273,9 @@ static void time_test_diff(time_cb time_cur,
 
 	diff = odp_time_diff(t2, ODP_TIME_NULL);
 	CU_ASSERT(odp_time_cmp(t2, diff) == 0);
+
+	diff_ns = odp_time_diff_ns(t2, t2);
+	CU_ASSERT(diff_ns == 0);
 }
 
 void time_test_local_diff(void)


### PR DESCRIPTION
Added function which returns time difference in nanoseconds.
This short cuts a common pattern...

t1 = odp_time_global();
foo();
t2 = odp_time_global();
printf("foo() takes %u nsec\n", odp_time_diff_ns(t2, t1);

... by combining convert and diff functions.
