### PR TITLE
[PATCH API-NEXT v2] api: pktio: add checksum insert enable bits

### DIFF
--- a/example/generator/odp_generator.c
+++ b/example/generator/odp_generator.c
@@ -523,6 +523,10 @@ static int create_pktio(const char *dev, odp_pool_t pool,
 		capa.config.pktin.bit.drop_ipv4_err;
 	itf->config.pktin.bit.drop_udp_err = capa.config.pktin.bit.drop_udp_err;
 
+	itf->config.pktout.bit.ipv4_chksum_ena =
+		capa.config.pktout.bit.ipv4_chksum_ena;
+	itf->config.pktout.bit.udp_chksum_ena =
+		capa.config.pktout.bit.udp_chksum_ena;
 	itf->config.pktout.bit.ipv4_chksum = capa.config.pktout.bit.ipv4_chksum;
 	itf->config.pktout.bit.udp_chksum = capa.config.pktout.bit.udp_chksum;
 

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1531,7 +1531,7 @@ odp_packet_chksum_status_t odp_packet_l4_chksum_status(odp_packet_t pkt);
  *
  * Calling this function is always allowed but the checksum will not be
  * inserted if the packet is output through a pktio that does not have
- * the relevant pktout chksum bit set in the pktio capability.
+ * the relevant checksum insertion enabled.
  *
  * @param pkt     Packet handle
  * @param insert  0: do not insert L3 checksum
@@ -1548,7 +1548,7 @@ void odp_packet_l3_chksum_insert(odp_packet_t pkt, int insert);
  *
  * Calling this function is always allowed but the checksum will not be
  * inserted if the packet is output through a pktio that does not have
- * the relevant pktout chksum bit set in the pktio capability.
+ * the relevant checksum insertion enabled.
  *
  * @param pkt     Packet handle
  * @param insert  0: do not insert L4 checksum

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -329,15 +329,29 @@ typedef union odp_pktin_config_opt_t {
  * Packet output configuration options bit field
  *
  * Packet output configuration options listed in a bit field structure. Packet
- * output checksum insertion may be enabled or disabled. When it is enabled,
- * implementation will calculate and insert checksum into every outgoing packet
- * by default. Application may disable checksum insertion (e.g.
- * odp_packet_l4_chksum_insert()) on per packet basis. For correct operation,
- * packet metadata must provide valid offsets for the appropriate protocols.
- * For example, UDP checksum calculation needs both L3 and L4 offsets (to access
- * IP and UDP headers). When application (e.g. a switch) does not modify L3/L4
- * data and thus checksum does not need to be updated, output checksum insertion
- * should be disabled for optimal performance.
+ * output checksum insertion may be enabled or disabled (e.g. ipv4_chksum_ena):
+ *
+ *  0: Disable checksum insertion. Application will not request checksum
+ *     insertion for any packet. This is the default value for xxx_chksum_ena
+ *     bits.
+ *  1: Enable checksum insertion. Application will request checksum insertion
+ *     for some packets.
+ *
+ * When checksum insertion is enabled, application may use configuration options
+ * to set the default behaviour on packet output (e.g. ipv4_chksum):
+ *
+ *  0: Do not insert checksum by default. This is the default value for
+ *     xxx_chksum bits.
+ *  1: Calculate and insert checksum by default.
+ *
+ * These defaults may be overridden on per packet basis using e.g.
+ * odp_packet_l4_chksum_insert().
+ *
+ * For correct operation, packet metadata must provide valid offsets for the
+ * appropriate protocols. For example, UDP checksum calculation needs both L3
+ * and L4 offsets (to access IP and UDP headers). When application
+ * (e.g. a switch) does not modify L3/L4 data and thus checksum does not need
+ * to be updated, checksum insertion should be disabled for optimal performance.
  *
  * Packet flags (odp_packet_has_*()) are ignored for the purpose of checksum
  * insertion in packet output.
@@ -354,19 +368,31 @@ typedef union odp_pktin_config_opt_t {
  * insertion.
  */
 typedef union odp_pktout_config_opt_t {
-	/** Option flags */
+	/** Option flags for packet output */
 	struct {
-		/** Insert IPv4 header checksum on packet output */
-		uint64_t ipv4_chksum  : 1;
+		/** Enable IPv4 header checksum insertion. */
+		uint64_t ipv4_chksum_ena : 1;
 
-		/** Insert UDP checksum on packet output */
-		uint64_t udp_chksum   : 1;
+		/** Enable UDP checksum insertion */
+		uint64_t udp_chksum_ena  : 1;
 
-		/** Insert TCP checksum on packet output */
-		uint64_t tcp_chksum   : 1;
+		/** Enable TCP checksum insertion */
+		uint64_t tcp_chksum_ena  : 1;
 
-		/** Insert SCTP checksum on packet output */
-		uint64_t sctp_chksum  : 1;
+		/** Enable SCTP checksum insertion */
+		uint64_t sctp_chksum_ena : 1;
+
+		/** Insert IPv4 header checksum by default */
+		uint64_t ipv4_chksum     : 1;
+
+		/** Insert UDP checksum on packet by default */
+		uint64_t udp_chksum      : 1;
+
+		/** Insert TCP checksum on packet by default */
+		uint64_t tcp_chksum      : 1;
+
+		/** Insert SCTP checksum on packet by default */
+		uint64_t sctp_chksum     : 1;
 
 	} bit;
 

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -113,7 +113,8 @@ struct pktio_entry {
 	/* These two locks together lock the whole pktio device */
 	odp_ticketlock_t rxl;		/**< RX ticketlock */
 	odp_ticketlock_t txl;		/**< TX ticketlock */
-	int cls_enabled;		/**< is classifier enabled */
+	uint8_t cls_enabled;            /**< classifier enabled */
+	uint8_t chksum_insert_ena;      /**< pktout checksum offload enabled */
 	odp_pktio_t handle;		/**< pktio handle */
 	union {
 		pkt_loop_t pkt_loop;            /**< Using loopback for IO */

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -546,6 +546,9 @@ static inline void pkt_set_ol_tx(odp_pktout_config_opt_t *pktout_cfg,
 	odp_bool_t ipv4_chksum_pkt, udp_chksum_pkt, tcp_chksum_pkt;
 	packet_parser_t *pkt_p = &pkt_hdr->p;
 
+	if (pkt_p->l3_offset == ODP_PACKET_OFFSET_INVALID)
+		return;
+
 	l3_hdr = (void *)(mbuf_data + pkt_p->l3_offset);
 
 	if (check_proto(l3_hdr, &l3_proto_v4, &l4_proto))
@@ -633,7 +636,7 @@ static inline int pkt_to_mbuf(pktio_entry_t *pktio_entry,
 
 		odp_packet_copy_to_mem(pkt_table[i], 0, pkt_len, data);
 
-		if (pkt_hdr->p.l3_offset != ODP_PACKET_OFFSET_INVALID) {
+		if (odp_unlikely(pktio_entry->s.chksum_insert_ena)) {
 			odp_pktout_config_opt_t *pktout_capa =
 			&pktio_entry->s.capa.config.pktout;
 
@@ -748,7 +751,7 @@ static inline int pkt_to_mbuf_zero(pktio_entry_t *pktio_entry,
 			       pkt_hdr->extra_type == PKT_EXTRA_TYPE_DPDK)) {
 			mbuf_update(mbuf, pkt_hdr, pkt_len);
 
-			if (pkt_hdr->p.l3_offset != ODP_PACKET_OFFSET_INVALID)
+			if (odp_unlikely(pktio_entry->s.chksum_insert_ena))
 				pkt_set_ol_tx(pktout_cfg, pktout_capa, pkt_hdr,
 					      mbuf, _odp_packet_data(pkt));
 		} else {
@@ -771,8 +774,7 @@ static inline int pkt_to_mbuf_zero(pktio_entry_t *pktio_entry,
 				mbuf_init((struct rte_mempool *)
 					  pool_entry->ext_desc, mbuf, pkt_hdr);
 				mbuf_update(mbuf, pkt_hdr, pkt_len);
-				if (pkt_hdr->p.l3_offset !=
-				    ODP_PACKET_OFFSET_INVALID)
+				if (pktio_entry->s.chksum_insert_ena)
 					pkt_set_ol_tx(pktout_cfg, pktout_capa,
 						      pkt_hdr, mbuf,
 						      _odp_packet_data(pkt));
@@ -1432,6 +1434,7 @@ static int dpdk_start(pktio_entry_t *pktio_entry)
 			rte_eth_dev_info_get(port_id, &dev_info);
 			dev_info.default_txconf.txq_flags = txq_flags;
 			txconf = &dev_info.default_txconf;
+			pktio_entry->s.chksum_insert_ena = 1;
 		}
 
 		ret = rte_eth_tx_queue_setup(port_id, i, DPDK_NM_TX_DESC,

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -123,6 +123,7 @@ static inline void mbuf_update(struct rte_mbuf *mbuf, odp_packet_hdr_t *pkt_hdr,
 	mbuf->data_len = pkt_len;
 	mbuf->pkt_len = pkt_len;
 	mbuf->refcnt = 1;
+	mbuf->ol_flags = 0;
 
 	if (odp_unlikely(pkt_hdr->buf_hdr.base_data !=
 			 pkt_hdr->buf_hdr.seg[0].data))
@@ -1253,6 +1254,13 @@ static void dpdk_init_capability(pktio_entry_t *pktio_entry,
 		(dev_info->tx_offload_capa & DEV_TX_OFFLOAD_UDP_CKSUM) ? 1 : 0;
 	capa->config.pktout.bit.tcp_chksum =
 		(dev_info->tx_offload_capa & DEV_TX_OFFLOAD_TCP_CKSUM) ? 1 : 0;
+
+	capa->config.pktout.bit.ipv4_chksum_ena =
+		capa->config.pktout.bit.ipv4_chksum;
+	capa->config.pktout.bit.udp_chksum_ena =
+		capa->config.pktout.bit.udp_chksum;
+	capa->config.pktout.bit.tcp_chksum_ena =
+		capa->config.pktout.bit.tcp_chksum;
 }
 
 static int dpdk_open(odp_pktio_t id ODP_UNUSED,
@@ -1388,9 +1396,47 @@ static int dpdk_start(pktio_entry_t *pktio_entry)
 	}
 	/* Init TX queues */
 	for (i = 0; i < pktio_entry->s.num_out_queue; i++) {
+		struct rte_eth_dev_info dev_info;
+		const struct rte_eth_txconf *txconf = NULL;
+		int ip_ena  = pktio_entry->s.config.pktout.bit.ipv4_chksum_ena;
+		int udp_ena = pktio_entry->s.config.pktout.bit.udp_chksum_ena;
+		int tcp_ena = pktio_entry->s.config.pktout.bit.tcp_chksum_ena;
+		int sctp_ena = pktio_entry->s.config.pktout.bit.sctp_chksum_ena;
+		int chksum_ena = ip_ena | udp_ena | tcp_ena | sctp_ena;
+
+		if (chksum_ena) {
+			/* Enable UDP, TCP, STCP checksum offload */
+			uint32_t txq_flags = 0;
+
+			if (udp_ena == 0)
+				txq_flags |= ETH_TXQ_FLAGS_NOXSUMUDP;
+
+			if (tcp_ena == 0)
+				txq_flags |= ETH_TXQ_FLAGS_NOXSUMTCP;
+
+			if (sctp_ena == 0)
+				txq_flags |= ETH_TXQ_FLAGS_NOXSUMSCTP;
+
+			/* When IP checksum is requested alone, enable UDP
+			 * offload. DPDK IP checksum offload is enabled only
+			 * when one of the L4 checksum offloads is requested.*/
+			if ((udp_ena == 0) && (tcp_ena == 0) && (sctp_ena == 0))
+				txq_flags = ETH_TXQ_FLAGS_NOXSUMTCP |
+					    ETH_TXQ_FLAGS_NOXSUMSCTP;
+
+			txq_flags |= ETH_TXQ_FLAGS_NOMULTSEGS |
+				     ETH_TXQ_FLAGS_NOREFCOUNT |
+				     ETH_TXQ_FLAGS_NOMULTMEMP |
+				     ETH_TXQ_FLAGS_NOVLANOFFL;
+
+			rte_eth_dev_info_get(port_id, &dev_info);
+			dev_info.default_txconf.txq_flags = txq_flags;
+			txconf = &dev_info.default_txconf;
+		}
+
 		ret = rte_eth_tx_queue_setup(port_id, i, DPDK_NM_TX_DESC,
 					     rte_eth_dev_socket_id(port_id),
-					     NULL);
+					     txconf);
 		if (ret < 0) {
 			ODP_ERR("Queue setup failed: err=%d, port=%" PRIu8 "\n",
 				ret, port_id);

--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -92,6 +92,7 @@ static inline int sched_mode(pktin_mode_t in_mode)
  * Parsed command line application arguments
  */
 typedef struct {
+	int extra_check;        /**< Some extra checks have been enabled */
 	int cpu_count;
 	int if_count;		/**< Number of interfaces to be used */
 	int addr_count;		/**< Number of dst addresses to be used */
@@ -106,6 +107,7 @@ typedef struct {
 	int dst_change;		/**< Change destination eth addresses */
 	int src_change;		/**< Change source eth addresses */
 	int error_check;        /**< Check packet errors */
+	int chksum;             /**< Checksum offload */
 	int sched_mode;         /**< Scheduler mode */
 	int num_groups;         /**< Number of scheduling groups */
 	int verbose;		/**< Verbose output */
@@ -293,6 +295,18 @@ static inline int event_queue_send(odp_queue_t queue, odp_packet_t *pkt_tbl,
 	return sent;
 }
 
+static inline void chksum_insert(odp_packet_t *pkt_tbl, int pkts)
+{
+	odp_packet_t pkt;
+	int i;
+
+	for (i = 0; i < pkts; i++) {
+		pkt = pkt_tbl[i];
+		odp_packet_l3_chksum_insert(pkt, 1);
+		odp_packet_l4_chksum_insert(pkt, 1);
+	}
+}
+
 /**
  * Packet IO worker thread using scheduled queues
  *
@@ -366,18 +380,23 @@ static int run_worker_sched_mode(void *arg)
 		for (i = 0; i < pkts; i++)
 			pkt_tbl[i] = odp_packet_from_event(ev_tbl[i]);
 
-		if (gbl_args->appl.error_check) {
-			int rx_drops;
+		if (odp_unlikely(gbl_args->appl.extra_check)) {
+			if (gbl_args->appl.chksum)
+				chksum_insert(pkt_tbl, pkts);
 
-			/* Drop packets with errors */
-			rx_drops = drop_err_pkts(pkt_tbl, pkts);
+			if (gbl_args->appl.error_check) {
+				int rx_drops;
 
-			if (odp_unlikely(rx_drops)) {
-				stats->s.rx_drops += rx_drops;
-				if (pkts == rx_drops)
-					continue;
+				/* Drop packets with errors */
+				rx_drops = drop_err_pkts(pkt_tbl, pkts);
 
-				pkts -= rx_drops;
+				if (odp_unlikely(rx_drops)) {
+					stats->s.rx_drops += rx_drops;
+					if (pkts == rx_drops)
+						continue;
+
+					pkts -= rx_drops;
+				}
 			}
 		}
 
@@ -487,18 +506,23 @@ static int run_worker_plain_queue_mode(void *arg)
 		for (i = 0; i < pkts; i++)
 			pkt_tbl[i] = odp_packet_from_event(event[i]);
 
-		if (gbl_args->appl.error_check) {
-			int rx_drops;
+		if (odp_unlikely(gbl_args->appl.extra_check)) {
+			if (gbl_args->appl.chksum)
+				chksum_insert(pkt_tbl, pkts);
 
-			/* Drop packets with errors */
-			rx_drops = drop_err_pkts(pkt_tbl, pkts);
+			if (gbl_args->appl.error_check) {
+				int rx_drops;
 
-			if (odp_unlikely(rx_drops)) {
-				stats->s.rx_drops += rx_drops;
-				if (pkts == rx_drops)
-					continue;
+				/* Drop packets with errors */
+				rx_drops = drop_err_pkts(pkt_tbl, pkts);
 
-				pkts -= rx_drops;
+				if (odp_unlikely(rx_drops)) {
+					stats->s.rx_drops += rx_drops;
+					if (pkts == rx_drops)
+						continue;
+
+					pkts -= rx_drops;
+				}
 			}
 		}
 
@@ -605,18 +629,23 @@ static int run_worker_direct_mode(void *arg)
 		if (odp_unlikely(pkts <= 0))
 			continue;
 
-		if (gbl_args->appl.error_check) {
-			int rx_drops;
+		if (odp_unlikely(gbl_args->appl.extra_check)) {
+			if (gbl_args->appl.chksum)
+				chksum_insert(pkt_tbl, pkts);
 
-			/* Drop packets with errors */
-			rx_drops = drop_err_pkts(pkt_tbl, pkts);
+			if (gbl_args->appl.error_check) {
+				int rx_drops;
 
-			if (odp_unlikely(rx_drops)) {
-				stats->s.rx_drops += rx_drops;
-				if (pkts == rx_drops)
-					continue;
+				/* Drop packets with errors */
+				rx_drops = drop_err_pkts(pkt_tbl, pkts);
 
-				pkts -= rx_drops;
+				if (odp_unlikely(rx_drops)) {
+					stats->s.rx_drops += rx_drops;
+					if (pkts == rx_drops)
+						continue;
+
+					pkts -= rx_drops;
+				}
 			}
 		}
 
@@ -707,9 +736,17 @@ static int create_pktio(const char *dev, int idx, int num_rx, int num_tx,
 	}
 
 	odp_pktio_config_init(&config);
-	config.parser.layer = gbl_args->appl.error_check ?
+	config.parser.layer = gbl_args->appl.extra_check ?
 			ODP_PKTIO_PARSER_LAYER_ALL :
 			ODP_PKTIO_PARSER_LAYER_NONE;
+
+	if (gbl_args->appl.chksum) {
+		printf("Checksum offload enabled\n");
+		config.pktout.bit.ipv4_chksum_ena = 1;
+		config.pktout.bit.udp_chksum_ena  = 1;
+		config.pktout.bit.tcp_chksum_ena  = 1;
+	}
+
 	odp_pktio_config(pktio, &config);
 
 	odp_pktin_queue_param_init(&pktin_param);
@@ -1132,9 +1169,12 @@ static void usage(char *progname)
 	       "                          Requires also the -d flag to be set\n"
 	       "  -e, --error_check <arg> 0: Don't check packet errors (default)\n"
 	       "                          1: Check packet errors\n"
+	       "  -k, --chksum <arg>      0: Don't use checksum offload (default)\n"
+	       "                          1: Use checksum offload\n"
 	       "  -g, --groups <num>      Number of groups to use: 0 ... num\n"
 	       "                          0: SCHED_GROUP_ALL (default)\n"
 	       "                          num: must not exceed number of interfaces or workers\n"
+	       "  -v, --verbose           Verbose output.\n"
 	       "  -h, --help              Display help and exit.\n\n"
 	       "\n", NO_PATH(progname), NO_PATH(progname), MAX_PKTIOS
 	    );
@@ -1166,13 +1206,14 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 		{"dst_change", required_argument, NULL, 'd'},
 		{"src_change", required_argument, NULL, 's'},
 		{"error_check", required_argument, NULL, 'e'},
+		{"chksum", required_argument, NULL, 'k'},
 		{"groups", required_argument, NULL, 'g'},
 		{"verbose", no_argument, NULL, 'v'},
 		{"help", no_argument, NULL, 'h'},
 		{NULL, 0, NULL, 0}
 	};
 
-	static const char *shortopts =  "+c:+t:+a:i:m:o:r:d:s:e:g:vh";
+	static const char *shortopts =  "+c:+t:+a:i:m:o:r:d:s:e:k:g:vh";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
 	odph_parse_options(argc, argv, shortopts, longopts);
@@ -1184,6 +1225,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->num_groups = 0; /* use default group */
 	appl_args->error_check = 0; /* don't check packet errors by default */
 	appl_args->verbose = 0;
+	appl_args->chksum = 0; /* don't use checksum offload by default */
 
 	opterr = 0; /* do not issue errors on helper options */
 
@@ -1308,6 +1350,9 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 		case 'e':
 			appl_args->error_check = atoi(optarg);
 			break;
+		case 'k':
+			appl_args->chksum = atoi(optarg);
+			break;
 		case 'g':
 			appl_args->num_groups = atoi(optarg);
 			break;
@@ -1334,6 +1379,8 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 		usage(argv[0]);
 		exit(EXIT_FAILURE);
 	}
+
+	appl_args->extra_check = appl_args->error_check || appl_args->chksum;
 
 	optind = 1;		/* reset 'extern optind' from the getopt lib */
 }


### PR DESCRIPTION
Added bits to control if checksum insertion is enabled /
disabled at packet output. Current configuration options
control if checksum is inserted / not inserted by default,
but leaves it open for application to request checksum
always with override functions. Explicit disable allows
implementation to optimize performance. E.g. DPDK does 
uses more optimized driver code on Intel NICs when checksum 
offload is disabled.
