### PR TITLE
[PATCH v1] travis: add enable-deprecated test configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ cache:
 env:
         - CONF=""
         - CONF="--disable-abi-compat"
+        - CONF="--enable-deprecated"
         - CONF="--enable-schedule-sp"
         - CONF="--enable-schedule-iquery"
         - CONF="--enable-dpdk-zero-copy"


### PR DESCRIPTION
Test ODP build with 'enable-deprecated' flag set.

Signed-off-by: Matias Elo <matias.elo@nokia.com>