### PR TITLE
[PATCH API-NEXT v1] optimize pktio performance

### DIFF
--- a/platform/linux-generic/include/odp_buffer_inlines.h
+++ b/platform/linux-generic/include/odp_buffer_inlines.h
@@ -21,8 +21,6 @@ extern "C" {
 
 odp_event_type_t _odp_buffer_event_type(odp_buffer_t buf);
 void _odp_buffer_event_type_set(odp_buffer_t buf, int ev);
-odp_event_subtype_t _odp_buffer_event_subtype(odp_buffer_t buf);
-void _odp_buffer_event_subtype_set(odp_buffer_t buf, int ev);
 int odp_buffer_snprint(char *str, uint32_t n, odp_buffer_t buf);
 
 static inline odp_buffer_t buf_from_buf_hdr(odp_buffer_hdr_t *hdr)

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -104,12 +104,6 @@ struct odp_buffer_hdr_t {
 	/* User area pointer */
 	void    *uarea_addr;
 
-	/* User area size */
-	uint32_t uarea_size;
-
-	/* Max data size */
-	uint32_t size;
-
 	/* Event subtype. Should be ODP_EVENT_NO_SUBTYPE except packets. */
 	int8_t    event_subtype;
 

--- a/platform/linux-generic/include/odp_buffer_internal.h
+++ b/platform/linux-generic/include/odp_buffer_internal.h
@@ -104,9 +104,6 @@ struct odp_buffer_hdr_t {
 	/* User area pointer */
 	void    *uarea_addr;
 
-	/* Event subtype. Should be ODP_EVENT_NO_SUBTYPE except packets. */
-	int8_t    event_subtype;
-
 	/* ipc mapped process can not walk over pointers,
 	 * offset has to be used */
 	uint64_t ipc_data_offset;

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -132,6 +132,9 @@ typedef struct {
 	uint16_t headroom;
 	uint16_t tailroom;
 
+	/* Event subtype */
+	int8_t subtype;
+
 	/*
 	 * Members below are not initialized by packet_init()
 	 */
@@ -195,6 +198,16 @@ static inline seg_entry_t *seg_entry_last(odp_packet_hdr_t *hdr)
 	return &last->buf_hdr.seg[last_seg];
 }
 
+static inline odp_event_subtype_t packet_subtype(odp_packet_t pkt)
+{
+	return odp_packet_hdr(pkt)->subtype;
+}
+
+static inline void packet_subtype_set(odp_packet_t pkt, int ev)
+{
+	odp_packet_hdr(pkt)->subtype = ev;
+}
+
 /**
  * Initialize packet
  */
@@ -234,9 +247,10 @@ static inline void packet_init(odp_packet_hdr_t *pkt_hdr, uint32_t len)
 	pkt_hdr->headroom  = CONFIG_PACKET_HEADROOM;
 	pkt_hdr->tailroom  = pool->seg_len - seg_len + CONFIG_PACKET_TAILROOM;
 
-	pkt_hdr->input = ODP_PKTIO_INVALID;
-	pkt_hdr->buf_hdr.event_subtype = ODP_EVENT_PACKET_BASIC;
+	if (odp_unlikely(pkt_hdr->subtype != ODP_EVENT_PACKET_BASIC))
+		pkt_hdr->subtype = ODP_EVENT_PACKET_BASIC;
 
+	pkt_hdr->input = ODP_PKTIO_INVALID;
 }
 
 static inline void copy_packet_parser_metadata(odp_packet_hdr_t *src_hdr,

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -1072,8 +1072,7 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 	/* Indicate to caller operation was sync */
 	*posted = 0;
 
-	_odp_buffer_event_subtype_set(packet_to_buffer(out_pkt),
-				      ODP_EVENT_PACKET_BASIC);
+	packet_subtype_set(out_pkt, ODP_EVENT_PACKET_BASIC);
 
 	/* Fill in result */
 	local_result.ctx = param->ctx;
@@ -1351,8 +1350,7 @@ int odp_crypto_int(odp_packet_t pkt_in,
 	}
 
 	/* Fill in result */
-	_odp_buffer_event_subtype_set(packet_to_buffer(out_pkt),
-				      ODP_EVENT_PACKET_CRYPTO);
+	packet_subtype_set(out_pkt, ODP_EVENT_PACKET_CRYPTO);
 	op_result = get_op_result_from_packet(out_pkt);
 	op_result->cipher_status.alg_err = rc_cipher;
 	op_result->cipher_status.hw_err = ODP_CRYPTO_HW_ERR_NONE;

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -16,6 +16,7 @@
 #include <odp_ipsec_internal.h>
 #include <odp_buffer_inlines.h>
 #include <odp_debug_internal.h>
+#include <odp_packet_internal.h>
 
 odp_event_type_t odp_event_type(odp_event_t event)
 {
@@ -24,17 +25,24 @@ odp_event_type_t odp_event_type(odp_event_t event)
 
 odp_event_subtype_t odp_event_subtype(odp_event_t event)
 {
-	return _odp_buffer_event_subtype(odp_buffer_from_event(event));
+	if (_odp_buffer_event_type(odp_buffer_from_event(event)) !=
+			ODP_EVENT_PACKET)
+		return ODP_EVENT_NO_SUBTYPE;
+
+	return packet_subtype(odp_packet_from_event(event));
 }
 
 odp_event_type_t odp_event_types(odp_event_t event,
 				 odp_event_subtype_t *subtype)
 {
 	odp_buffer_t buf = odp_buffer_from_event(event);
+	odp_event_type_t event_type = _odp_buffer_event_type(buf);
 
-	*subtype = _odp_buffer_event_subtype(buf);
+	*subtype = event_type == ODP_EVENT_PACKET ?
+			packet_subtype(odp_packet_from_event(event)) :
+			ODP_EVENT_NO_SUBTYPE;
 
-	return _odp_buffer_event_type(buf);
+	return event_type;
 }
 
 void odp_event_free(odp_event_t event)

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -973,8 +973,7 @@ int odp_ipsec_in(const odp_packet_t pkt_in[], int num_in,
 
 		ipsec_sa = ipsec_in_single(pkt, sa, &pkt, &status);
 
-		_odp_buffer_event_subtype_set(packet_to_buffer(pkt),
-					      ODP_EVENT_PACKET_IPSEC);
+		packet_subtype_set(pkt, ODP_EVENT_PACKET_IPSEC);
 		result = ipsec_pkt_result(pkt);
 		memset(result, 0, sizeof(*result));
 		result->status = status;
@@ -1037,8 +1036,7 @@ int odp_ipsec_out(const odp_packet_t pkt_in[], int num_in,
 		ipsec_sa = ipsec_out_single(pkt, sa, &pkt, opt, &status);
 		ODP_ASSERT(NULL != ipsec_sa);
 
-		_odp_buffer_event_subtype_set(packet_to_buffer(pkt),
-					      ODP_EVENT_PACKET_IPSEC);
+		packet_subtype_set(pkt, ODP_EVENT_PACKET_IPSEC);
 		result = ipsec_pkt_result(pkt);
 		memset(result, 0, sizeof(*result));
 		result->status = status;
@@ -1085,8 +1083,7 @@ int odp_ipsec_in_enq(const odp_packet_t pkt_in[], int num_in,
 
 		ipsec_sa = ipsec_in_single(pkt, sa, &pkt, &status);
 
-		_odp_buffer_event_subtype_set(packet_to_buffer(pkt),
-					      ODP_EVENT_PACKET_IPSEC);
+		packet_subtype_set(pkt, ODP_EVENT_PACKET_IPSEC);
 		result = ipsec_pkt_result(pkt);
 		memset(result, 0, sizeof(*result));
 		result->status = status;
@@ -1146,8 +1143,7 @@ int odp_ipsec_out_enq(const odp_packet_t pkt_in[], int num_in,
 		ipsec_sa = ipsec_out_single(pkt, sa, &pkt, opt, &status);
 		ODP_ASSERT(NULL != ipsec_sa);
 
-		_odp_buffer_event_subtype_set(packet_to_buffer(pkt),
-					      ODP_EVENT_PACKET_IPSEC);
+		packet_subtype_set(pkt, ODP_EVENT_PACKET_IPSEC);
 		result = ipsec_pkt_result(pkt);
 		memset(result, 0, sizeof(*result));
 		result->status = status;
@@ -1186,8 +1182,7 @@ int _odp_ipsec_try_inline(odp_packet_t pkt)
 	if (NULL == ipsec_sa)
 		return -1;
 
-	_odp_buffer_event_subtype_set(packet_to_buffer(pkt),
-				      ODP_EVENT_PACKET_IPSEC);
+	packet_subtype_set(pkt, ODP_EVENT_PACKET_IPSEC);
 	result = ipsec_pkt_result(pkt);
 	memset(result, 0, sizeof(*result));
 	result->status = status;
@@ -1264,8 +1259,7 @@ int odp_ipsec_out_inline(const odp_packet_t pkt_in[], int num_in,
 		ipsec_sa = ipsec_out_single(pkt, sa, &pkt, opt, &status);
 		ODP_ASSERT(NULL != ipsec_sa);
 
-		_odp_buffer_event_subtype_set(packet_to_buffer(pkt),
-					      ODP_EVENT_PACKET_IPSEC);
+		packet_subtype_set(pkt, ODP_EVENT_PACKET_IPSEC);
 		result = ipsec_pkt_result(pkt);
 		memset(result, 0, sizeof(*result));
 		result->sa = ipsec_sa->ipsec_sa_hdl;
@@ -1286,11 +1280,8 @@ int odp_ipsec_out_inline(const odp_packet_t pkt_in[], int num_in,
 			}
 		} else {
 			odp_queue_t queue;
-			odp_buffer_t buf;
 err:
-			buf = packet_to_buffer(pkt);
-			_odp_buffer_event_subtype_set(buf,
-						      ODP_EVENT_PACKET_IPSEC);
+			packet_subtype_set(pkt, ODP_EVENT_PACKET_IPSEC);
 			result = ipsec_pkt_result(pkt);
 			memset(result, 0, sizeof(*result));
 			result->sa = ipsec_sa->ipsec_sa_hdl;

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -298,7 +298,6 @@ static void init_buffers(pool_t *pool)
 		buf_hdr->index = i;
 		buf_hdr->type = type;
 		buf_hdr->event_type = type;
-		buf_hdr->event_subtype = ODP_EVENT_NO_SUBTYPE;
 		buf_hdr->pool_ptr = pool;
 		buf_hdr->uarea_addr = uarea;
 		buf_hdr->segcount = 1;
@@ -663,16 +662,6 @@ odp_event_type_t _odp_buffer_event_type(odp_buffer_t buf)
 void _odp_buffer_event_type_set(odp_buffer_t buf, int ev)
 {
 	buf_hdl_to_hdr(buf)->event_type = ev;
-}
-
-odp_event_subtype_t _odp_buffer_event_subtype(odp_buffer_t buf)
-{
-	return buf_hdl_to_hdr(buf)->event_subtype;
-}
-
-void _odp_buffer_event_subtype_set(odp_buffer_t buf, int ev)
-{
-	buf_hdl_to_hdr(buf)->event_subtype = ev;
 }
 
 odp_pool_t odp_pool_lookup(const char *name)

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -172,18 +172,16 @@ static int loopback_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 	if (pktio_entry->s.config.outbound_ipsec)
 		for (i = 0; i < len; ++i) {
-			odp_buffer_t buf = buf_from_buf_hdr(hdr_tbl[i]);
 			odp_ipsec_packet_result_t result;
 
-			if (_odp_buffer_event_subtype(buf) !=
+			if (packet_subtype(pkt_tbl[i]) !=
 			    ODP_EVENT_PACKET_IPSEC)
 				continue;
 
 			/* Possibly postprocessing packet */
 			odp_ipsec_result(&result, pkt_tbl[i]);
 
-			_odp_buffer_event_subtype_set(buf,
-						      ODP_EVENT_PACKET_BASIC);
+			packet_subtype_set(pkt_tbl[i], ODP_EVENT_PACKET_BASIC);
 		}
 
 	odp_ticketlock_lock(&pktio_entry->s.txl);


### PR DESCRIPTION
Optimize pktio performance by rearranging odp_buffer_hdr_t and odp_packet_hdr_t struct members.

Event subtype is only used by packets, so move subtype to packet header to optimize cache usage. This change fixes the ~30% performance penalty in l2fwd (zero-copy dpdk pktio) caused by the initialization of event subtype.
