### PR TITLE
[PATCH API-NEXT v1] api: multi event functions

### DIFF
--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -126,6 +126,22 @@ odp_event_type_t odp_event_types(odp_event_t event,
 				 odp_event_subtype_t *subtype);
 
 /**
+ * Event type of multiple events
+ *
+ * Returns the number of first events in the array which have the same event
+ * type. Outputs the event type of those events.
+ *
+ * @param      event    Array of event handles
+ * @param      num      Number of events (> 0)
+ * @param[out] type     Event type pointer for output
+ *
+ * @return Number of first events (1 ... num) with the same event type
+ *         (includes event[0])
+ */
+int odp_event_type_multi(const odp_event_t event[], int num,
+			 odp_event_type_t *type);
+
+/**
  * Get printable value for an odp_event_t
  *
  * @param hdl  odp_event_t handle to be printed

--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -150,6 +150,28 @@ uint64_t odp_event_to_u64(odp_event_t hdl);
 void odp_event_free(odp_event_t event);
 
 /**
+ * Free multiple events
+ *
+ * Otherwise like odp_event_free(), but frees multiple events to their
+ * originating pools.
+ *
+ * @param event    Array of event handles
+ * @param num      Number of events to free
+ */
+void odp_event_free_multi(const odp_event_t event[], int num);
+
+/**
+ * Free multiple events to the same pool
+ *
+ * Otherwise like odp_event_free_multi(), but all events must be from the
+ * same originating pool.
+ *
+ * @param event    Array of event handles
+ * @param num      Number of events to free
+ */
+void odp_event_free_sp(const odp_event_t event[], int num);
+
+/**
  * @}
  */
 

--- a/include/odp/api/spec/event.h
+++ b/include/odp/api/spec/event.h
@@ -19,11 +19,12 @@
 extern "C" {
 #endif
 
+#include <odp/api/packet.h>
+
 /** @defgroup odp_event ODP EVENT
  *  Operations on an event.
  *  @{
  */
-
 
 /**
  * @typedef odp_event_t
@@ -140,6 +141,27 @@ odp_event_type_t odp_event_types(odp_event_t event,
  */
 int odp_event_type_multi(const odp_event_t event[], int num,
 			 odp_event_type_t *type);
+
+/**
+ * Filter and convert packet events
+ *
+ * Checks event type of all input events, converts all packet events and outputs
+ * packet handles. Returns the number packet handles outputted. Outputs the
+ * remaining, non-packet event handles to 'remain' array. Handles are outputted
+ * to both arrays in the same order those are stored in 'event' array. Both
+ * output arrays must fit 'num' elements.
+ *
+ * @param      event    Array of event handles
+ * @param[out] packet   Packet handle array for output
+ * @param[out] remain   Event handle array for output of remaining, non-packet
+ *                      events
+ * @param      num      Number of events (> 0)
+ *
+ * @return Number of packets outputted (0 ... num)
+ */
+int odp_event_filter_packet(const odp_event_t event[],
+			    odp_packet_t packet[],
+			    odp_event_t remain[], int num);
 
 /**
  * Get printable value for an odp_event_t

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -205,6 +205,17 @@ void odp_packet_free(odp_packet_t pkt);
 void odp_packet_free_multi(const odp_packet_t pkt[], int num);
 
 /**
+ * Free multiple packets to the same pool
+ *
+ * Otherwise like odp_packet_free_multi(), but all packets must be from the
+ * same originating pool.
+ *
+ * @param pkt           Array of packet handles
+ * @param num           Number of packets to free
+ */
+void odp_packet_free_sp(const odp_packet_t pkt[], int num);
+
+/**
  * Reset packet
  *
  * Resets all packet metadata to their default values. Packet length is used
@@ -236,6 +247,18 @@ int odp_packet_reset(odp_packet_t pkt, uint32_t len);
 odp_packet_t odp_packet_from_event(odp_event_t ev);
 
 /**
+ * Convert multiple packet events to packet handles
+ *
+ * All events must be of type ODP_EVENT_PACKET.
+ *
+ * @param[out] pkt  Packet handle array for output
+ * @param      ev   Array of event handles to convert
+ * @param      num  Number of packets and events
+ */
+void odp_packet_from_event_multi(odp_packet_t pkt[], const odp_event_t ev[],
+				 int num);
+
+/**
  * Convert packet handle to event
  *
  * @param pkt  Packet handle
@@ -243,6 +266,16 @@ odp_packet_t odp_packet_from_event(odp_event_t ev);
  * @return Event handle
  */
 odp_event_t odp_packet_to_event(odp_packet_t pkt);
+
+/**
+ * Convert multiple packet handles to events
+ *
+ * @param      pkt  Array of packet handles to convert
+ * @param[out] ev   Event handle array for output
+ * @param      num  Number of packets and events
+ */
+void odp_packet_to_event_multi(const odp_packet_t pkt[], odp_event_t ev[],
+			       int num);
 
 /*
  *

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -60,6 +60,19 @@ void odp_event_free(odp_event_t event)
 	}
 }
 
+void odp_event_free_multi(const odp_event_t event[], int num)
+{
+	int i;
+
+	for (i = 0; i < num; i++)
+		odp_event_free(event[i]);
+}
+
+void odp_event_free_sp(const odp_event_t event[], int num)
+{
+	odp_event_free_multi(event, num);
+}
+
 uint64_t odp_event_to_u64(odp_event_t hdl)
 {
 	return _odp_pri(hdl);

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -37,6 +37,22 @@ odp_event_type_t odp_event_types(odp_event_t event,
 	return _odp_buffer_event_type(buf);
 }
 
+int odp_event_type_multi(const odp_event_t event[], int num,
+			 odp_event_type_t *type_out)
+{
+	int i;
+	odp_event_type_t type = odp_event_type(event[0]);
+
+	for (i = 1; i < num; i++) {
+		if (odp_event_type(event[i]) != type)
+			break;
+	}
+
+	*type_out = type;
+
+	return i;
+}
+
 void odp_event_free(odp_event_t event)
 {
 	switch (odp_event_type(event)) {

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -912,6 +912,11 @@ void odp_packet_free_multi(const odp_packet_t pkt[], int num)
 		packet_free_multi(buf_hdr, num - num_freed);
 }
 
+void odp_packet_free_sp(const odp_packet_t pkt[], int num)
+{
+	odp_packet_free_multi(pkt, num);
+}
+
 int odp_packet_reset(odp_packet_t pkt, uint32_t len)
 {
 	odp_packet_hdr_t *const pkt_hdr = packet_hdr(pkt);
@@ -942,6 +947,24 @@ odp_event_t odp_packet_to_event(odp_packet_t pkt)
 		return ODP_EVENT_INVALID;
 
 	return (odp_event_t)buffer_handle(packet_hdr(pkt));
+}
+
+void odp_packet_from_event_multi(odp_packet_t pkt[], const odp_event_t ev[],
+				 int num)
+{
+	int i;
+
+	for (i = 0; i < num; i++)
+		pkt[i] = odp_packet_from_event(ev[i]);
+}
+
+void odp_packet_to_event_multi(const odp_packet_t pkt[], odp_event_t ev[],
+			       int num)
+{
+	int i;
+
+	for (i = 0; i < num; i++)
+		ev[i] = odp_packet_to_event(pkt[i]);
 }
 
 /*

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -967,6 +967,27 @@ void odp_packet_to_event_multi(const odp_packet_t pkt[], odp_event_t ev[],
 		ev[i] = odp_packet_to_event(pkt[i]);
 }
 
+int odp_event_filter_packet(const odp_event_t event[],
+			    odp_packet_t packet[],
+			    odp_event_t remain[], int num)
+{
+	int i;
+	int num_pkt = 0;
+	int num_rem = 0;
+
+	for (i = 0; i < num; i++) {
+		if (odp_event_type(event[i]) == ODP_EVENT_PACKET) {
+			packet[num_pkt] = odp_packet_from_event(event[i]);
+			num_pkt++;
+		} else {
+			remain[num_rem] = event[i];
+			num_rem++;
+		}
+	}
+
+	return num_pkt;
+}
+
 /*
  *
  * Pointers and lengths

--- a/test/m4/configure.m4
+++ b/test/m4/configure.m4
@@ -15,6 +15,7 @@ AC_CONFIG_FILES([test/Makefile
 		 test/validation/api/cpumask/Makefile
 		 test/validation/api/crypto/Makefile
 		 test/validation/api/errno/Makefile
+		 test/validation/api/event/Makefile
 		 test/validation/api/hash/Makefile
 		 test/validation/api/init/Makefile
 		 test/validation/api/ipsec/Makefile

--- a/test/validation/api/Makefile.am
+++ b/test/validation/api/Makefile.am
@@ -6,6 +6,7 @@ ODP_MODULES = atomic \
 	      cpumask \
 	      crypto \
 	      errno \
+	      event \
 	      hash \
 	      init \
 	      ipsec \
@@ -38,6 +39,7 @@ TESTS = \
 	cpumask/cpumask_main$(EXEEXT) \
 	crypto/crypto_main$(EXEEXT) \
 	errno/errno_main$(EXEEXT) \
+	event/event_main$(EXEEXT) \
 	hash/hash_main$(EXEEXT) \
 	init/init_main_ok$(EXEEXT) \
 	init/init_main_abort$(EXEEXT) \

--- a/test/validation/api/event/.gitignore
+++ b/test/validation/api/event/.gitignore
@@ -1,0 +1,1 @@
+event_main

--- a/test/validation/api/event/Makefile.am
+++ b/test/validation/api/event/Makefile.am
@@ -1,0 +1,5 @@
+include ../Makefile.inc
+
+test_PROGRAMS = event_main
+event_main_SOURCES = event_main.c event.c event.h
+event_main_LDADD = $(LIBCUNIT_COMMON) $(LIBODP)

--- a/test/validation/api/event/event.c
+++ b/test/validation/api/event/event.c
@@ -348,11 +348,50 @@ static void event_test_type_multi(void)
 	CU_ASSERT(odp_pool_destroy(pkt_pool) == 0);
 }
 
+static void event_test_filter_packet(void)
+{
+	odp_pool_t buf_pool, pkt_pool;
+	int i, num_pkt, num_rem;
+	int num = 2 * NUM_TYPE_TEST;
+	odp_event_t buf_event[NUM_TYPE_TEST];
+	odp_event_t pkt_event[NUM_TYPE_TEST];
+	odp_event_t event[num];
+	odp_packet_t packet[num];
+	odp_event_t remain[num];
+
+	type_test_init(&buf_pool, &pkt_pool, buf_event, pkt_event, event);
+
+	for (i = 0; i < num; i++) {
+		packet[i] = ODP_PACKET_INVALID;
+		remain[i] = ODP_EVENT_INVALID;
+	}
+
+	num_pkt = odp_event_filter_packet(event, packet, remain, num);
+	CU_ASSERT(num_pkt == NUM_TYPE_TEST);
+
+	for (i = 0; i < num_pkt; i++)
+		CU_ASSERT(packet[i] != ODP_PACKET_INVALID);
+
+	num_rem = num - num_pkt;
+	CU_ASSERT(num_rem == NUM_TYPE_TEST);
+
+	for (i = 0; i < num_rem; i++) {
+		CU_ASSERT(remain[i] != ODP_EVENT_INVALID);
+		CU_ASSERT(odp_event_type(remain[i]) == ODP_EVENT_BUFFER);
+	}
+
+	odp_event_free_multi(event, num);
+
+	CU_ASSERT(odp_pool_destroy(buf_pool) == 0);
+	CU_ASSERT(odp_pool_destroy(pkt_pool) == 0);
+}
+
 odp_testinfo_t event_suite[] = {
 	ODP_TEST_INFO(event_test_free),
 	ODP_TEST_INFO(event_test_free_multi),
 	ODP_TEST_INFO(event_test_free_multi_mixed),
 	ODP_TEST_INFO(event_test_type_multi),
+	ODP_TEST_INFO(event_test_filter_packet),
 	ODP_TEST_INFO_NULL,
 };
 

--- a/test/validation/api/event/event.c
+++ b/test/validation/api/event/event.c
@@ -1,0 +1,274 @@
+/* Copyright (c) 2017, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include "config.h"
+#include <odp_api.h>
+#include <odp_cunit_common.h>
+#include "event.h"
+
+#define NUM_EVENTS  100
+#define EVENT_SIZE  100
+#define EVENT_BURST 10
+
+static void event_test_free(void)
+{
+	odp_pool_t pool;
+	odp_pool_param_t pool_param;
+	int i;
+	odp_buffer_t buf;
+	odp_packet_t pkt;
+	odp_timeout_t tmo;
+	odp_event_subtype_t subtype;
+	odp_event_t event[EVENT_BURST];
+
+	/* Buffer events */
+	odp_pool_param_init(&pool_param);
+	pool_param.buf.num  = NUM_EVENTS;
+	pool_param.buf.size = EVENT_SIZE;
+	pool_param.type     = ODP_POOL_BUFFER;
+
+	pool = odp_pool_create("event_free", &pool_param);
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	for (i = 0; i < EVENT_BURST; i++) {
+		buf = odp_buffer_alloc(pool);
+		CU_ASSERT_FATAL(buf != ODP_BUFFER_INVALID);
+		event[i] = odp_buffer_to_event(buf);
+		CU_ASSERT(odp_event_type(event[i]) == ODP_EVENT_BUFFER);
+		CU_ASSERT(odp_event_subtype(event[i]) == ODP_EVENT_NO_SUBTYPE);
+		CU_ASSERT(odp_event_types(event[i], &subtype) ==
+			  ODP_EVENT_BUFFER);
+		CU_ASSERT(subtype == ODP_EVENT_NO_SUBTYPE);
+	}
+
+	for (i = 0; i < EVENT_BURST; i++)
+		odp_event_free(event[i]);
+
+	CU_ASSERT(odp_pool_destroy(pool) == 0);
+
+	/* Packet events */
+	odp_pool_param_init(&pool_param);
+	pool_param.pkt.num = NUM_EVENTS;
+	pool_param.pkt.len = EVENT_SIZE;
+	pool_param.type    = ODP_POOL_PACKET;
+
+	pool = odp_pool_create("event_free", &pool_param);
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	for (i = 0; i < EVENT_BURST; i++) {
+		pkt = odp_packet_alloc(pool, EVENT_SIZE);
+		CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+		event[i] = odp_packet_to_event(pkt);
+		CU_ASSERT(odp_event_type(event[i]) == ODP_EVENT_PACKET);
+		CU_ASSERT(odp_event_subtype(event[i]) ==
+			  ODP_EVENT_PACKET_BASIC);
+		CU_ASSERT(odp_event_types(event[i], &subtype) ==
+			  ODP_EVENT_PACKET);
+		CU_ASSERT(subtype == ODP_EVENT_PACKET_BASIC);
+	}
+
+	for (i = 0; i < EVENT_BURST; i++)
+		odp_event_free(event[i]);
+
+	CU_ASSERT(odp_pool_destroy(pool) == 0);
+
+	/* Timeout events */
+	odp_pool_param_init(&pool_param);
+	pool_param.tmo.num = NUM_EVENTS;
+	pool_param.type    = ODP_POOL_TIMEOUT;
+
+	pool = odp_pool_create("event_free", &pool_param);
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	for (i = 0; i < EVENT_BURST; i++) {
+		tmo = odp_timeout_alloc(pool);
+		CU_ASSERT_FATAL(tmo != ODP_TIMEOUT_INVALID);
+		event[i] = odp_timeout_to_event(tmo);
+		CU_ASSERT(odp_event_type(event[i]) == ODP_EVENT_TIMEOUT);
+		CU_ASSERT(odp_event_subtype(event[i]) == ODP_EVENT_NO_SUBTYPE);
+		CU_ASSERT(odp_event_types(event[i], &subtype) ==
+			  ODP_EVENT_TIMEOUT);
+		CU_ASSERT(subtype == ODP_EVENT_NO_SUBTYPE);
+	}
+
+	for (i = 0; i < EVENT_BURST; i++)
+		odp_event_free(event[i]);
+
+	CU_ASSERT(odp_pool_destroy(pool) == 0);
+}
+
+static void event_test_free_multi(void)
+{
+	odp_pool_t pool;
+	odp_pool_param_t pool_param;
+	int i, j;
+	odp_buffer_t buf;
+	odp_packet_t pkt;
+	odp_timeout_t tmo;
+	odp_event_t event[EVENT_BURST];
+
+	/* Buffer events */
+	odp_pool_param_init(&pool_param);
+	pool_param.buf.num  = NUM_EVENTS;
+	pool_param.buf.size = EVENT_SIZE;
+	pool_param.type     = ODP_POOL_BUFFER;
+
+	pool = odp_pool_create("event_free", &pool_param);
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	for (j = 0; j < 2; j++) {
+		for (i = 0; i < EVENT_BURST; i++) {
+			buf = odp_buffer_alloc(pool);
+			CU_ASSERT_FATAL(buf != ODP_BUFFER_INVALID);
+			event[i] = odp_buffer_to_event(buf);
+		}
+
+		if (j == 0)
+			odp_event_free_multi(event, EVENT_BURST);
+		else
+			odp_event_free_sp(event, EVENT_BURST);
+	}
+
+	CU_ASSERT(odp_pool_destroy(pool) == 0);
+
+	/* Packet events */
+	odp_pool_param_init(&pool_param);
+	pool_param.pkt.num = NUM_EVENTS;
+	pool_param.pkt.len = EVENT_SIZE;
+	pool_param.type    = ODP_POOL_PACKET;
+
+	pool = odp_pool_create("event_free", &pool_param);
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	for (j = 0; j < 2; j++) {
+		for (i = 0; i < EVENT_BURST; i++) {
+			pkt = odp_packet_alloc(pool, EVENT_SIZE);
+			CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+			event[i] = odp_packet_to_event(pkt);
+		}
+
+		if (j == 0)
+			odp_event_free_multi(event, EVENT_BURST);
+		else
+			odp_event_free_sp(event, EVENT_BURST);
+	}
+
+	CU_ASSERT(odp_pool_destroy(pool) == 0);
+
+	/* Timeout events */
+	odp_pool_param_init(&pool_param);
+	pool_param.tmo.num = NUM_EVENTS;
+	pool_param.type    = ODP_POOL_TIMEOUT;
+
+	pool = odp_pool_create("event_free", &pool_param);
+	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
+
+	for (j = 0; j < 2; j++) {
+		for (i = 0; i < EVENT_BURST; i++) {
+			tmo = odp_timeout_alloc(pool);
+			CU_ASSERT_FATAL(tmo != ODP_TIMEOUT_INVALID);
+			event[i] = odp_timeout_to_event(tmo);
+		}
+
+		if (j == 0)
+			odp_event_free_multi(event, EVENT_BURST);
+		else
+			odp_event_free_sp(event, EVENT_BURST);
+	}
+
+	CU_ASSERT(odp_pool_destroy(pool) == 0);
+}
+
+static void event_test_free_multi_mixed(void)
+{
+	odp_pool_t pool1, pool2, pool3;
+	odp_pool_param_t pool_param;
+	int i, j;
+	odp_buffer_t buf;
+	odp_packet_t pkt;
+	odp_timeout_t tmo;
+	odp_event_t event[3 * EVENT_BURST];
+
+	/* Buffer events */
+	odp_pool_param_init(&pool_param);
+	pool_param.buf.num  = NUM_EVENTS;
+	pool_param.buf.size = EVENT_SIZE;
+	pool_param.type     = ODP_POOL_BUFFER;
+
+	pool1 = odp_pool_create("event_free1", &pool_param);
+	CU_ASSERT_FATAL(pool1 != ODP_POOL_INVALID);
+
+	/* Packet events */
+	odp_pool_param_init(&pool_param);
+	pool_param.pkt.num = NUM_EVENTS;
+	pool_param.pkt.len = EVENT_SIZE;
+	pool_param.type    = ODP_POOL_PACKET;
+
+	pool2 = odp_pool_create("event_free2", &pool_param);
+	CU_ASSERT_FATAL(pool2 != ODP_POOL_INVALID);
+
+	/* Timeout events */
+	odp_pool_param_init(&pool_param);
+	pool_param.tmo.num = NUM_EVENTS;
+	pool_param.type    = ODP_POOL_TIMEOUT;
+
+	pool3 = odp_pool_create("event_free3", &pool_param);
+	CU_ASSERT_FATAL(pool3 != ODP_POOL_INVALID);
+
+	for (j = 0; j < 2; j++) {
+		for (i = 0; i < 3 * EVENT_BURST;) {
+			buf = odp_buffer_alloc(pool1);
+			CU_ASSERT_FATAL(buf != ODP_BUFFER_INVALID);
+			event[i] = odp_buffer_to_event(buf);
+			i++;
+			pkt = odp_packet_alloc(pool2, EVENT_SIZE);
+			CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
+			event[i] = odp_packet_to_event(pkt);
+			i++;
+			tmo = odp_timeout_alloc(pool3);
+			CU_ASSERT_FATAL(tmo != ODP_TIMEOUT_INVALID);
+			event[i] = odp_timeout_to_event(tmo);
+			i++;
+		}
+
+		if (j == 0)
+			odp_event_free_multi(event, 3 * EVENT_BURST);
+		else
+			odp_event_free_sp(event, 3 * EVENT_BURST);
+	}
+
+	CU_ASSERT(odp_pool_destroy(pool1) == 0);
+	CU_ASSERT(odp_pool_destroy(pool2) == 0);
+	CU_ASSERT(odp_pool_destroy(pool3) == 0);
+}
+
+odp_testinfo_t event_suite[] = {
+	ODP_TEST_INFO(event_test_free),
+	ODP_TEST_INFO(event_test_free_multi),
+	ODP_TEST_INFO(event_test_free_multi_mixed),
+	ODP_TEST_INFO_NULL,
+};
+
+odp_suiteinfo_t event_suites[] = {
+	{"Event", NULL, NULL, event_suite},
+	ODP_SUITE_INFO_NULL,
+};
+
+int event_main(int argc, char *argv[])
+{
+	int ret;
+
+	/* parse common options: */
+	if (odp_cunit_parse_options(argc, argv))
+		return -1;
+
+	ret = odp_cunit_register(event_suites);
+
+	if (ret == 0)
+		ret = odp_cunit_run();
+
+	return ret;
+}

--- a/test/validation/api/event/event.h
+++ b/test/validation/api/event/event.h
@@ -1,0 +1,12 @@
+/* Copyright (c) 2017, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef _ODP_TEST_EVENT_H_
+#define _ODP_TEST_EVENT_H_
+
+int event_main(int argc, char *argv[]);
+
+#endif

--- a/test/validation/api/event/event_main.c
+++ b/test/validation/api/event/event_main.c
@@ -1,0 +1,13 @@
+/* Copyright (c) 2017, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include "config.h"
+#include "event.h"
+
+int main(int argc, char *argv[])
+{
+	return event_main(argc, argv);
+}

--- a/test/validation/api/packet/packet.h
+++ b/test/validation/api/packet/packet.h
@@ -12,6 +12,7 @@
 /* test functions: */
 void packet_test_alloc_free(void);
 void packet_test_alloc_free_multi(void);
+void packet_test_free_sp(void);
 void packet_test_alloc_segmented(void);
 void packet_test_event_conversion(void);
 void packet_test_basic_metadata(void);


### PR DESCRIPTION
Extended common event / packet functions with multi versions. It's more efficient to process multiple events / packets with a single call than with separate calls. Event / packet free implementation can be more efficient when all events / packets are from the same pool (xxx_free_sp()). Event conversion to packets one of the most used ODP functions, added a functions to convert and filter (check event type + convert) multiple packets at a time.

All implementation may be optimized later. Multi APIs for buffers could be added also, but event / packet APIs are higher priority.
 