### PR TITLE
[PATCH 2.0 v1] linux-dpdk: pktio: Do not reset parse fields when parsing not enabled

### DIFF
--- a/platform/linux-dpdk/pktio/dpdk.c
+++ b/platform/linux-dpdk/pktio/dpdk.c
@@ -403,13 +403,14 @@ static int recv_pkt_dpdk(pktio_entry_t *pktio_entry, int index,
 	for (i = 0; i < nb_rx; ++i) {
 		odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt_table[i]);
 
-		packet_parse_reset(pkt_hdr);
 		pkt_hdr->input = pktio_entry->s.handle;
 
 		if (!pktio_cls_enabled(pktio_entry) &&
-		    pktio_entry->s.config.parser.layer)
+		    pktio_entry->s.config.parser.layer) {
+			packet_parse_reset(pkt_hdr);
 			packet_parse_layer(pkt_hdr,
 					   pktio_entry->s.config.parser.layer);
+		}
 		packet_set_ts(pkt_hdr, ts);
 	}
 


### PR DESCRIPTION
When parsing of the packet is not enabled, application will  not
look at parse meta data fields.

Signed-off-by: Honnappa Nagarahalli <honnappa.nagarahalli@arm.com>
Reviewed-by: Ola Liljedahl <ola.Liljedahl@arm.com>