### PR TITLE
[PATCH 2.0 v1] Fix 2.0 linux-dpdk make check

### DIFF
--- a/platform/linux-dpdk/include/odp/api/plat/buffer_types.h
+++ b/platform/linux-dpdk/include/odp/api/plat/buffer_types.h
@@ -31,7 +31,7 @@ extern "C" {
 
 typedef ODP_HANDLE_T(odp_buffer_t);
 
-#define ODP_BUFFER_INVALID _odp_cast_scalar(odp_buffer_t, 0xffffffff)
+#define ODP_BUFFER_INVALID _odp_cast_scalar(odp_buffer_t, NULL)
 
 typedef ODP_HANDLE_T(odp_buffer_seg_t);
 

--- a/platform/linux-dpdk/include/odp/api/plat/event_types.h
+++ b/platform/linux-dpdk/include/odp/api/plat/event_types.h
@@ -32,7 +32,7 @@ extern "C" {
 
 typedef ODP_HANDLE_T(odp_event_t);
 
-#define ODP_EVENT_INVALID _odp_cast_scalar(odp_event_t, 0xffffffff)
+#define ODP_EVENT_INVALID _odp_cast_scalar(odp_event_t, NULL)
 
 /**
  * Event types

--- a/platform/linux-dpdk/include/odp/api/plat/timer_types.h
+++ b/platform/linux-dpdk/include/odp/api/plat/timer_types.h
@@ -37,7 +37,7 @@ typedef ODP_HANDLE_T(odp_timer_t);
 
 typedef ODP_HANDLE_T(odp_timeout_t);
 
-#define ODP_TIMEOUT_INVALID  _odp_cast_scalar(odp_timeout_t, 0xffffffff)
+#define ODP_TIMEOUT_INVALID  _odp_cast_scalar(odp_timeout_t, NULL)
 
 /**
  * @}

--- a/platform/linux-dpdk/test/Makefile.am
+++ b/platform/linux-dpdk/test/Makefile.am
@@ -14,8 +14,6 @@ SUBDIRS += validation/api/pktio
 endif
 endif
 
-TEST_EXTENSIONS = .sh
-
 TESTNAME = linux-dpdk
 
 TESTENV = tests-$(TESTNAME).env

--- a/platform/linux-dpdk/test/validation/api/pktio/pktio_run.sh
+++ b/platform/linux-dpdk/test/validation/api/pktio/pktio_run.sh
@@ -23,7 +23,7 @@
 # running stand alone out of tree requires setting PATH
 PATH=${TEST_DIR}/api/pktio:$PATH
 PATH=$(dirname $0):$PATH
-PATH=$(dirname $0)/../../../../common_plat/validation/api/pktio:$PATH
+PATH=$(dirname $0)/../../../../../../test/validation/api/pktio:$PATH
 PATH=.:$PATH
 
 pktio_main_path=$(which pktio_main${EXEEXT})

--- a/platform/linux-generic/test/wrapper-script.sh
+++ b/platform/linux-generic/test/wrapper-script.sh
@@ -1,0 +1,3 @@
+#wrapper script for pre setting environment for validation suit.
+#currently this is empty but needs to be created to make it align with
+#linux-dpdk.

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -20,6 +20,8 @@ AM_CFLAGS = $(CUNIT_CFLAGS)
 
 AM_LDFLAGS = -L$(LIB) -static
 
+LOG_COMPILER = $(top_srcdir)/platform/@with_platform@/test/wrapper-script.sh
+
 @VALGRIND_CHECK_RULES@
 
 TESTS_ENVIRONMENT = ODP_PLATFORM=${with_platform} \

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -31,6 +31,6 @@ odp_sched_latency_SOURCES = odp_sched_latency.c
 odp_scheduling_SOURCES = odp_scheduling.c
 odp_pktio_perf_SOURCES = odp_pktio_perf.c
 
-dist_check_SCRIPTS = $(TESTSCRIPTS)
+dist_check_SCRIPTS = $(TESTSCRIPTS) $(LOG_COMPILER)
 
 dist_check_DATA = udp64.pcap


### PR DESCRIPTION
This PR includes @GBalakrishna 's #317 commits to fix linux-dpdk crypto impl for ipsec validations, and after then fixed the timer_main validation failure caused by inconsistent *_INVALIDS definitions and the linux-dpdk platform validation (pktio_run.sh).

