### PR TITLE
[PATCH 2.0 v1] linux-gen: pool: modify CONFIG_POOL_CACHE_SIZE from 256 to 255

### DIFF
--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -155,6 +155,6 @@
 /*
  * Maximum number of events in a thread local pool cache
  */
-#define CONFIG_POOL_CACHE_SIZE 256
+#define CONFIG_POOL_CACHE_SIZE 255
 
 #endif


### PR DESCRIPTION
CONFIG_POOL_CACHE_SIZE is used in pool_cache_t. In pool_cache_t,
there is another variable "num" which type is uint32_t. So if
set CONFIG_POOL_CACHE_SIZE to 256 here, the capacity of pool_cache_t
is 1028B which will waste 60B in one cache line. So reduce it to 255.

Signed-off-by: Kevin Wang <kevin.wang@arm.com>
Reviewed-by: Honnappa Nagarahalli <honnappa.nagarahalli@arm.com>
Reviewed-by: Ola Liljedahl <ola.Liljedahl@arm.com>