### PR TITLE
[PATCH v1] example: generator: performance changes

### DIFF
--- a/example/generator/odp_generator.c
+++ b/example/generator/odp_generator.c
@@ -26,7 +26,8 @@
 #define POOL_NUM_PKT           2048  /* Number of packets in packet pool */
 #define POOL_PKT_LEN           1856  /* Max packet length */
 #define DEFAULT_PKT_INTERVAL   1000  /* Interval between each packet */
-#define MAX_UDP_TX_BURST	32
+#define DEFAULT_UDP_TX_BURST	16
+#define MAX_UDP_TX_BURST	512
 #define MAX_RX_BURST		32
 
 #define APPL_MODE_UDP    0			/**< UDP mode */
@@ -1311,7 +1312,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->payload = 56;
 	appl_args->timeout = -1;
 	appl_args->interval = DEFAULT_PKT_INTERVAL;
-	appl_args->udp_tx_burst = 16;
+	appl_args->udp_tx_burst = DEFAULT_UDP_TX_BURST;
 	appl_args->srcport = 0;
 	appl_args->dstport = 0;
 

--- a/example/generator/odp_generator.c
+++ b/example/generator/odp_generator.c
@@ -655,7 +655,6 @@ static int gen_send_thread(void *arg)
 						   burst_size - ret);
 				burst_start += ret;
 				burst_size -= ret;
-				odp_time_wait_ns(ODP_TIME_MSEC_IN_NS);
 				continue;
 			}
 			EXAMPLE_ERR("  [%02i] packet send failed\n", thr);


### PR DESCRIPTION
Various changes to increase performance of odp_generator example appliation.

- remove 1 ms sleep on send loop
- increase maximum TX burst size to 512
- add configuration option for checksum support
- replace atomic counter with per worker counters