### PR TITLE
[PATCH API-NEXT v1] api: ipsec: require IPv4 or IPv6 flag to be set

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -1207,6 +1207,7 @@ typedef struct odp_ipsec_status_t {
  *
  * Each input packet must have a valid value for these metadata (other metadata
  * is ignored):
+ * - IPv4 or IPv6 flag: Set packet flag according to packet contents.
  * - L3 offset: Offset to the first byte of the (outmost) IP header
  * - L4 offset: When udp_encap is enabled, offset to the first byte of the
  *              encapsulating UDP header
@@ -1231,6 +1232,7 @@ typedef struct odp_ipsec_status_t {
  * Each successfully transformed packet has a valid value for these metadata
  * regardless of the inner packet parse configuration
  * (odp_ipsec_inbound_config_t):
+ * - IPv4 or IPv6 flag: Set packet flag according to packet contents.
  * - L3 offset: Offset to the first byte of the (outmost) IP header
  * - pktio:     For inline IPSEC processed packets, original packet input
  *              interface
@@ -1277,6 +1279,7 @@ int odp_ipsec_in(const odp_packet_t pkt_in[], int num_in,
  *
  * Each input packet must have a valid value for these metadata (other metadata
  * is ignored):
+ * - IPv4 or IPv6 flag: Set packet flag according to packet contents.
  * - L3 offset: Offset to the first byte of the (outmost) IP header
  * - L4 offset: Offset to the L4 header if L4 checksum offload is requested
  *
@@ -1294,6 +1297,7 @@ int odp_ipsec_in(const odp_packet_t pkt_in[], int num_in,
  * and content of packet data before the IP header is undefined.
  *
  * Each successfully transformed packet has a valid value for these metadata:
+ * - IPv4 or IPv6 flag: Set packet flag according to packet contents.
  * - L3 offset: Offset to the first byte of the (outmost) IP header
  *
  * @param          pkt_in   Packets to be processed


### PR DESCRIPTION
Require IPv4/IPv6 flag to be set for IPsec processing. Hardware usually
requires this, so require application to set flag that it knows.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>