### PR TITLE
[PATCH API-NEXT v2] api: refine parser metadata specifications

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -148,10 +148,15 @@ typedef struct odp_ipsec_inbound_config_t {
 	/** Parse packet headers after IPSEC transformation
 	 *
 	 *  Select header parsing level after inbound processing. Headers of the
-	 *  resulting packet must be parsed (at least) up to this level. Parsing
-	 *  starts from IP (layer 3). Each successfully transformed packet has
-	 *  a valid value for L3 offset regardless of the parse configuration.
-	 *  Default value is ODP_IPSEC_LAYER_NONE.
+	 *  resulting packet must be checked (at least) up to this level.
+	 *  Parsing starts from IP (layer 3). Packet metadata from IP to this
+	 *  layer is set. In addition, offset (and pointer) to the next layer
+	 *  is set. Other layer/protocol specific metadata have undefined
+	 *  values.
+	 *
+	 *  Each successfully transformed packet has a valid value for L3 offset
+	 *  regardless of the parse configuration. Default value is
+	 *  ODP_IPSEC_LAYER_NONE. ODP_IPSEC_LAYER_L2 is not a valid value.
 	 */
 	odp_ipsec_proto_layer_t parse;
 

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1347,15 +1347,16 @@ uint32_t odp_packet_user_area_size(odp_packet_t pkt);
 /**
  * Layer 2 start pointer
  *
- * Returns pointer to the start of the layer 2 header. Optionally, outputs
- * number of data bytes in the segment following the pointer.
+ * Returns pointer to the start of layer 2. Optionally, outputs number of data
+ * bytes in the segment following the pointer. The pointer value is generated
+ * from the current layer 2 offset.
  *
  * @param      pkt      Packet handle
  * @param[out] len      Number of data bytes remaining in the segment (output).
  *                      Ignored when NULL.
  *
- * @return  Layer 2 start pointer
- * @retval  NULL packet does not contain a valid L2 header
+ * @return Layer 2 start pointer
+ * @retval NULL  Layer 2 offset has not been set
  *
  * @see odp_packet_l2_offset(), odp_packet_l2_offset_set(), odp_packet_has_l2()
  */
@@ -1364,16 +1365,16 @@ void *odp_packet_l2_ptr(odp_packet_t pkt, uint32_t *len);
 /**
  * Layer 2 start offset
  *
- * Returns offset to the start of the layer 2 header. The offset is calculated
- * from the current odp_packet_data() position in bytes.
- *
- * User is responsible to update the offset when modifying the packet data
- * pointer position.
+ * Returns offset to the start of layer 2. The offset is calculated from the
+ * current odp_packet_data() position in bytes. Packet parsing sets the offset
+ * according to parse configuration and layers recognized in the packet. Data
+ * start position updating functions (e.g. odp_packet_push_head()) do not modify
+ * the offset, but user sets a new value when needed.
  *
  * @param pkt  Packet handle
  *
- * @return  Layer 2 start offset
- * @retval ODP_PACKET_OFFSET_INVALID packet does not contain a valid L2 header
+ * @return Layer 2 start offset
+ * @retval ODP_PACKET_OFFSET_INVALID  Layer 2 offset has not been set
  *
  * @see odp_packet_l2_offset_set(), odp_packet_has_l2()
  */
@@ -1382,9 +1383,9 @@ uint32_t odp_packet_l2_offset(odp_packet_t pkt);
 /**
  * Set layer 2 start offset
  *
- * Set offset to the start of the layer 2 header. The offset is calculated from
- * the current odp_packet_data() position in bytes. Offset must not exceed
- * packet data length. Packet is not modified on an error.
+ * Set offset to the start of layer 2. The offset is calculated from the current
+ * odp_packet_data() position in bytes. Offset must not exceed packet data
+ * length. Offset is not modified on an error.
  *
  * @param pkt     Packet handle
  * @param offset  Layer 2 start offset (0 ... odp_packet_len()-1)
@@ -1397,15 +1398,16 @@ int odp_packet_l2_offset_set(odp_packet_t pkt, uint32_t offset);
 /**
  * Layer 3 start pointer
  *
- * Returns pointer to the start of the layer 3 header. Optionally, outputs
- * number of data bytes in the segment following the pointer.
+ * Returns pointer to the start of layer 3. Optionally, outputs number of data
+ * bytes in the segment following the pointer. The pointer value is generated
+ * from the current layer 3 offset.
  *
  * @param      pkt      Packet handle
  * @param[out] len      Number of data bytes remaining in the segment (output).
  *                      Ignored when NULL.
  *
- * @return  Layer 3 start pointer
- * @retval NULL packet does not contain a valid L3 header
+ * @return Layer 3 start pointer
+ * @retval NULL  Layer 3 offset has not been set
  *
  * @see odp_packet_l3_offset(), odp_packet_l3_offset_set(), odp_packet_has_l3()
  */
@@ -1414,16 +1416,16 @@ void *odp_packet_l3_ptr(odp_packet_t pkt, uint32_t *len);
 /**
  * Layer 3 start offset
  *
- * Returns offset to the start of the layer 3 header. The offset is calculated
- * from the current odp_packet_data() position in bytes.
- *
- * User is responsible to update the offset when modifying the packet data
- * pointer position.
+ * Returns offset to the start of layer 3. The offset is calculated from the
+ * current odp_packet_data() position in bytes. Packet parsing sets the offset
+ * according to parse configuration and layers recognized in the packet. Data
+ * start position updating functions (e.g. odp_packet_push_head()) do not modify
+ * the offset, but user sets a new value when needed.
  *
  * @param pkt  Packet handle
  *
- * @return  Layer 3 start offset, or ODP_PACKET_OFFSET_INVALID when packet does
- *          not contain a valid L3 header.
+ * @return Layer 3 start offset
+ * @retval ODP_PACKET_OFFSET_INVALID  Layer 3 offset has not been set
  *
  * @see odp_packet_l3_offset_set(), odp_packet_has_l3()
  */
@@ -1432,9 +1434,9 @@ uint32_t odp_packet_l3_offset(odp_packet_t pkt);
 /**
  * Set layer 3 start offset
  *
- * Set offset to the start of the layer 3 header. The offset is calculated from
- * the current odp_packet_data() position in bytes. Offset must not exceed
- * packet data length. Packet is not modified on an error.
+ * Set offset to the start of layer 3. The offset is calculated from the current
+ * odp_packet_data() position in bytes. Offset must not exceed packet data
+ * length. Offset is not modified on an error.
  *
  * @param pkt     Packet handle
  * @param offset  Layer 3 start offset (0 ... odp_packet_len()-1)
@@ -1447,15 +1449,16 @@ int odp_packet_l3_offset_set(odp_packet_t pkt, uint32_t offset);
 /**
  * Layer 4 start pointer
  *
- * Returns pointer to the start of the layer 4 header. Optionally, outputs
- * number of data bytes in the segment following the pointer.
+ * Returns pointer to the start of layer 4. Optionally, outputs number of data
+ * bytes in the segment following the pointer. The pointer value is generated
+ * from the current layer 4 offset.
  *
  * @param      pkt      Packet handle
  * @param[out] len      Number of data bytes remaining in the segment (output).
  *                      Ignored when NULL.
  *
- * @return  Layer 4 start pointer
- * @retval NULL packet does not contain a valid L4 header
+ * @return Layer 4 start pointer
+ * @retval NULL  Layer 4 offset has not been set
  *
  * @see odp_packet_l4_offset(), odp_packet_l4_offset_set(), odp_packet_has_l4()
  */
@@ -1464,16 +1467,16 @@ void *odp_packet_l4_ptr(odp_packet_t pkt, uint32_t *len);
 /**
  * Layer 4 start offset
  *
- * Returns offset to the start of the layer 4 header. The offset is calculated
- * from the current odp_packet_data() position in bytes.
- *
- * User is responsible to update the offset when modifying the packet data
- * pointer position.
+ * Returns offset to the start of layer 4. The offset is calculated from the
+ * current odp_packet_data() position in bytes. Packet parsing sets the offset
+ * according to parse configuration and layers recognized in the packet. Data
+ * start position updating functions (e.g. odp_packet_push_head()) do not modify
+ * the offset, but user sets a new value when needed.
  *
  * @param pkt  Packet handle
  *
- * @return  Layer 4 start offset
- * @retval ODP_PACKET_OFFSET_INVALID packet does not contain a valid L4 header
+ * @return Layer 4 start offset
+ * @retval ODP_PACKET_OFFSET_INVALID  Layer 4 offset has not been set
  *
  * @see odp_packet_l4_offset_set(), odp_packet_has_l4()
  */
@@ -1482,9 +1485,9 @@ uint32_t odp_packet_l4_offset(odp_packet_t pkt);
 /**
  * Set layer 4 start offset
  *
- * Set offset to the start of the layer 4 header. The offset is calculated from
- * the current odp_packet_data() position in bytes. Offset must not exceed
- * packet data length. Packet is not modified on an error.
+ * Set offset to the start of layer 4. The offset is calculated from the current
+ * odp_packet_data() position in bytes. Offset must not exceed packet data
+ * length. Offset is not modified on an error.
  *
  * @param pkt     Packet handle
  * @param offset  Layer 4 start offset (0 ... odp_packet_len()-1)

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1188,7 +1188,7 @@ typedef struct odp_packet_parse_param_t {
 
 	/** Continue parsing until this layer. Must be the same or higher
 	 *  layer than the layer of 'proto'. */
-	odp_proto_layer_t layer;
+	odp_proto_layer_t last_layer;
 
 	/** Flags to control payload data checks up to the selected parse
 	 *  layer. Checksum checking status can be queried for each packet with
@@ -1220,19 +1220,21 @@ typedef struct odp_packet_parse_param_t {
 /**
  * Parse packet
  *
- * Parse protocol headers in packet data. Parsing starts at 'offset', which
- * is the first header byte of protocol 'param.proto'. Parameter 'param.layer'
- * defines the last layer application is interested about.
- * Use ODP_PROTO_LAYER_ALL for all layers. A successful operation sets or resets
- * packet metadata for all layers from the layer of 'param.proto' to the
- * application defined last layer. Metadata of other layers have undefined
- * values. When operation fails, metadata of all protocol layers have undefined
- * values.
+ * Parse protocol headers in packet data and update layer/protocol specific
+ * metadata (e.g. offsets, errors, protocols, checksum statuses, etc). Parsing
+ * starts at 'offset', which is the first header byte of protocol 'param.proto'.
+ * Parameter 'param.last_layer' defines the last layer application requests
+ * to check. Use ODP_PROTO_LAYER_ALL for all layers. A successful operation
+ * sets (or resets) packet metadata for all layers from the layer of
+ * 'param.proto' to the application defined last layer. In addition, offset
+ * (and pointer) to the next layer is set. Other layer/protocol specific
+ * metadata have undefined values. When operation fails, all layer/protocol
+ * specific metadata have undefined values.
  *
  * @param pkt     Packet handle
  * @param offset  Byte offset into the packet
- * @param param   Parse parameters. Proto and layer fields must be set. Clear
- *                all check bits that are not used.
+ * @param param   Parse parameters. Proto and last_layer fields must be set.
+ *                Clear all check bits that are not used.
  *
  * @retval 0 on success
  * @retval <0 on failure
@@ -1244,14 +1246,14 @@ int odp_packet_parse(odp_packet_t pkt, uint32_t offset,
  * Parse multiple packets
  *
  * Otherwise like odp_packet_parse(), but parses multiple packets. Packets may
- * have unique offsets, but must start with the same protocol. Also, packets are
- * parsed up to the same protocol layer.
+ * have unique offsets, but must start with the same protocol. The same
+ * parse parameters are applied to all packets.
  *
  * @param pkt     Packet handle array
  * @param offset  Byte offsets into the packets
  * @param num     Number of packets and offsets
- * @param param   Parse parameters. Proto and layer fields must be set. Clear
- *                all check bits that are not used.
+ * @param param   Parse parameters. Proto and last_layer fields must be set.
+ *                Clear all check bits that are not used.
  *
  * @return Number of packets parsed successfully (0 ... num)
  * @retval <0 on failure

--- a/include/odp/api/spec/packet_flags.h
+++ b/include/odp/api/spec/packet_flags.h
@@ -23,87 +23,111 @@ extern "C" {
 #include <odp/api/packet.h>
 
 /** @addtogroup odp_packet
- *  Boolean operations on a packet.
+ *  Operations on packet metadata flags.
  *  @{
  */
 
 /**
- * Check for packet errors
+ * Check for all errors in packet
  *
- * Checks all error flags at once.
+ * Check if packet parsing has found any errors in the packet. The level of
+ * error checking depends on the parse configuration (e.g. included layers and
+ * checksums). Protocol layer functions (e.g. odp_packet_has_l3()) indicate
+ * which layers have been checked, and layer error functions
+ * (e.g. odp_packet_has_l3_error()) which layers have errors.
  *
- * @param pkt Packet handle
- * @retval non-zero packet has errors
- * @retval 0 packet has no errors
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet has errors
+ * @retval 0           No errors were found
  */
 int odp_packet_has_error(odp_packet_t pkt);
 
 /**
- * Check for packet L2 errors
+ * Check for errors in layer 2
  *
- * check for all L2 errors
+ * When layer 2 is included in the parse configuration, check if any errors were
+ * found in layer 2 of the packet.
  *
- * @param pkt Packet handle
- * @retval non-zero packet has L2 errors
- * @retval 0 packet has no L2 error
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet has errors in layer 2
+ * @retval 0           No errors were found in layer 2
  */
 int odp_packet_has_l2_error(odp_packet_t pkt);
 
 /**
- * Check for L2 header, e.g. ethernet
+ * Check for errors in layer 3
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains a valid & known L2 header
- * @retval 0 if packet does not contain a valid & known L2 header
- */
-int odp_packet_has_l2(odp_packet_t pkt);
-
-/**
- * Check for packet L3 errors
+ * When layer 3 is included in the parse configuration, check if any errors were
+ * found in layer 3 of the packet.
  *
- * check for all L3 errors
+ * @param pkt          Packet handle
  *
- * @param pkt Packet handle
- * @retval non-zero packet has L3 errors
- * @retval 0 packet has no L3 error
+ * @retval non-zero    Packet has errors in layer 3
+ * @retval 0           No errors found in layer 3
  */
 int odp_packet_has_l3_error(odp_packet_t pkt);
 
 /**
- * Check for L3 header, e.g. IPv4, IPv6
+ * Check for errors in layer 4
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains a valid & known L3 header
- * @retval 0 if packet does not contain a valid & known L3 header
- */
-int odp_packet_has_l3(odp_packet_t pkt);
-
-/**
- * Check for packet L4 errors
+ * When layer 4 is included in the parse configuration, check if any errors were
+ * found in layer 4 of the packet.
  *
- * check for all L4 errors
+ * @param pkt          Packet handle
  *
- * @param pkt Packet handle
- * @retval non-zero packet has L4 errors
- * @retval 0 packet has no L4 error
+ * @retval non-zero    Packet has errors in layer 4
+ * @retval 0           No errors were found in layer 4
  */
 int odp_packet_has_l4_error(odp_packet_t pkt);
 
 /**
- * Check for L4 header, e.g. UDP, TCP, SCTP (also ICMP)
+ * Check for layer 2 protocols
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains a valid & known L4 header
- * @retval 0 if packet does not contain a valid & known L4 header
+ * When layer 2 is included in the parse configuration, check if packet parsing
+ * has found and checked a layer 2 protocol (e.g. Ethernet) in the packet.
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    A layer 2 protocol header was found and checked
+ * @retval 0           No layer 2 protocol was found
+ */
+int odp_packet_has_l2(odp_packet_t pkt);
+
+/**
+ * Check for layer 3 protocols
+ *
+ * When layer 3 is included in the parse configuration, check if packet parsing
+ * has found and checked a layer 3 protocol (e.g. IPv4, IPv6) in the packet.
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    A layer 3 protocol header was found and checked
+ * @retval 0           No layer 3 protocol was found
+ */
+int odp_packet_has_l3(odp_packet_t pkt);
+
+/**
+ * Check for layer 4 protocols
+ *
+ * When layer 4 is included in the parse configuration, check if packet parsing
+ * has found and checked a layer 4 protocol (e.g. UDP, TCP, SCTP) in the packet.
+ *
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    A layer 4 protocol header was found and checked
+ * @retval 0           No layer 4 protocol was found
  */
 int odp_packet_has_l4(odp_packet_t pkt);
 
 /**
  * Check for Ethernet header
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains a valid eth header
- * @retval 0 if packet does not contain a valid eth header
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains an Ethernet header
+ * @retval 0           Packet does not contain an Ethernet header
  */
 int odp_packet_has_eth(odp_packet_t pkt);
 

--- a/include/odp/api/spec/packet_flags.h
+++ b/include/odp/api/spec/packet_flags.h
@@ -137,9 +137,10 @@ int odp_packet_has_eth(odp_packet_t pkt);
  * ODP recognizes the destination MAC address FF:FF:FF:FF:FF:FF as
  * a broadcast address. All others are considered non-broadcast.
  *
- * @param pkt Packet handle
- * @retval non-zero if Ethernet destination address is the broadcast address
- * @retval 0 if Ethernet destination address is not the broadcast address
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Ethernet destination address is the broadcast address
+ * @retval 0           Ethernet destination address is not the broadcast address
  */
 int odp_packet_has_eth_bcast(odp_packet_t pkt);
 
@@ -148,63 +149,70 @@ int odp_packet_has_eth_bcast(odp_packet_t pkt);
  *
  * ODP recognizes the destination MAC address as multicast if bit 7 is 1.
  *
- * @param pkt Packet handle
- * @retval non-zero if Ethernet destination address is a multicast address
- * @retval 0 if Ethernet destination address is not a multicast address
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Ethernet destination address is a multicast address
+ * @retval 0           Ethernet destination address is not a multicast address
  */
 int odp_packet_has_eth_mcast(odp_packet_t pkt);
 
 /**
  * Check for jumbo frame
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains a jumbo frame
- * @retval 0 if packet does not contain a jumbo frame
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet is a jumbo frame
+ * @retval 0           Packet is not a jumbo frame
  */
 int odp_packet_has_jumbo(odp_packet_t pkt);
 
 /**
  * Check for VLAN
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains a VLAN header
- * @retval 0 if packet does not contain a VLAN header
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains a VLAN header
+ * @retval 0           Packet does not contain a VLAN header
  */
 int odp_packet_has_vlan(odp_packet_t pkt);
 
 /**
  * Check for VLAN QinQ (stacked VLAN)
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains a VLAN QinQ header
- * @retval 0 if packet does not contain a VLAN QinQ header
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains a VLAN QinQ header
+ * @retval 0           Packet does not contain a VLAN QinQ header
  */
 int odp_packet_has_vlan_qinq(odp_packet_t pkt);
 
 /**
  * Check for ARP
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains an ARP message
- * @retval 0 if packet does not contain an ARP message
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains an ARP message
+ * @retval 0           Packet does not contain an ARP message
  */
 int odp_packet_has_arp(odp_packet_t pkt);
 
 /**
  * Check for IPv4
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains an IPv4 header
- * @retval 0 if packet does not contain an IPv4 header
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains an IPv4 header
+ * @retval 0           Packet does not contain an IPv4 header
  */
 int odp_packet_has_ipv4(odp_packet_t pkt);
 
 /**
  * Check for IPv6
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains an IPv6 header
- * @retval 0 if packet does not contain an IPv6 header
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains an IPv6 header
+ * @retval 0           Packet does not contain an IPv6 header
  */
 int odp_packet_has_ipv6(odp_packet_t pkt);
 
@@ -216,9 +224,10 @@ int odp_packet_has_ipv6(odp_packet_t pkt);
  *
  * For IPv6, no destination addresses are recognized as broadcast addresses.
  *
- * @param pkt Packet handle
- * @retval non-zero if IP destination address is a broadcast address
- * @retval 0 if IP destination address is not a broadcast address
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    IP destination address is a broadcast address
+ * @retval 0           IP destination address is not a broadcast address
  */
 int odp_packet_has_ip_bcast(odp_packet_t pkt);
 
@@ -231,91 +240,100 @@ int odp_packet_has_ip_bcast(odp_packet_t pkt);
  * For IPv6 ODP recognizes destination IP addresses with prefixes FF00::
  * through FFFF:: as multicast addresses.
  *
- * @param pkt Packet handle
- * @retval non-zero if IP destination address is a multicast address
- * @retval 0 if IP destination address is not a multicast address
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    IP destination address is a multicast address
+ * @retval 0           IP destination address is not a multicast address
  */
 int odp_packet_has_ip_mcast(odp_packet_t pkt);
 
 /**
  * Check for IP fragment
  *
- * @param pkt Packet handle
- * @retval non-zero if packet is an IP fragment
- * @retval 0 if packet is not an IP fragment
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet is an IP fragment
+ * @retval 0           Packet is not an IP fragment
  */
 int odp_packet_has_ipfrag(odp_packet_t pkt);
 
 /**
  * Check for IP options
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains IP options
- * @retval 0 if packet does not contain IP options
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains IP options
+ * @retval 0           Packet does not contain IP options
  */
 int odp_packet_has_ipopt(odp_packet_t pkt);
 
 /**
  * Check for IPSec
  *
- * @param pkt Packet handle
- * @retval non-zero if packet requires IPSec processing
- * @retval 0 if packet does not require IPSec processing
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet requires IPSec processing
+ * @retval 0           Packet does not require IPSec processing
  */
 int odp_packet_has_ipsec(odp_packet_t pkt);
 
 /**
  * Check for UDP
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains a UDP header
- * @retval 0 if packet does not contain a UDP header
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains a UDP header
+ * @retval 0           Packet does not contain a UDP header
  */
 int odp_packet_has_udp(odp_packet_t pkt);
 
 /**
  * Check for TCP
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains a TCP header
- * @retval 0 if packet does not contain a TCP header
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains a TCP header
+ * @retval 0           Packet does not contain a TCP header
  */
 int odp_packet_has_tcp(odp_packet_t pkt);
 
 /**
  * Check for SCTP
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains a SCTP header
- * @retval 0 if packet does not contain a SCTP header
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains a SCTP header
+ * @retval 0           Packet does not contain a SCTP header
  */
 int odp_packet_has_sctp(odp_packet_t pkt);
 
 /**
  * Check for ICMP
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains an ICMP header
- * @retval 0 if packet does not contain an ICMP header
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains an ICMP header
+ * @retval 0           Packet does not contain an ICMP header
  */
 int odp_packet_has_icmp(odp_packet_t pkt);
 
 /**
  * Check for packet flow hash
  *
- * @param pkt Packet handle
- * @retval non-zero if packet contains a hash value
- * @retval 0 if packet does not contain a hash value
+ * @param pkt          Packet handle
+ *
+ * @retval non-zero    Packet contains a hash value
+ * @retval 0           Packet does not contain a hash value
  */
 int odp_packet_has_flow_hash(odp_packet_t pkt);
 
 /**
  * Check for packet timestamp
  *
- * @param pkt Packet handle
+ * @param pkt          Packet handle
  *
- * @retval non-zero if packet contains a timestamp value
- * @retval 0 if packet does not contain a timestamp value
+ * @retval non-zero    Packet contains a timestamp value
+ * @retval 0           Packet does not contain a timestamp value
  *
  * @see odp_packet_has_ts_clr()
  */

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -404,8 +404,13 @@ typedef enum odp_pktio_parser_layer_t {
 typedef struct odp_pktio_parser_config_t {
 	/** Protocol parsing level in packet input
 	  *
-	  * Parse protocol layers in minimum up to this level during packet
-	  * input. The default value is ODP_PKTIO_PARSER_LAYER_ALL. */
+	  * Application requires that protocol headers in a packet are checked
+	  * up to this layer during packet input. Use ODP_PROTO_LAYER_ALL for
+	  * all layers. Packet metadata for this and all preceding layers are
+	  * set. In addition, offset (and pointer) to the next layer is set.
+	  * Other layer/protocol specific metadata have undefined values.
+	  *
+	  * The default value is ODP_PKTIO_PARSER_LAYER_ALL. */
 	odp_pktio_parser_layer_t layer;
 
 } odp_pktio_parser_config_t;

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2154,11 +2154,12 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 {
 	uint8_t  ip_proto;
 
+	prs->l3_offset = offset;
+
 	if (layer <= ODP_PKTIO_PARSER_LAYER_L2)
 		return prs->error_flags.all != 0;
 
-	/* Set l3_offset+flag only for known ethtypes */
-	prs->l3_offset = offset;
+	/* Set l3 flag only for known ethtypes */
 	prs->input_flags.l3 = 1;
 
 	/* Parse Layer 3 headers */
@@ -2166,12 +2167,14 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 	case _ODP_ETHTYPE_IPV4:
 		prs->input_flags.ipv4 = 1;
 		ip_proto = parse_ipv4(prs, &parseptr, &offset, frame_len);
+		prs->l4_offset = offset;
 		break;
 
 	case _ODP_ETHTYPE_IPV6:
 		prs->input_flags.ipv6 = 1;
 		ip_proto = parse_ipv6(prs, &parseptr, &offset, frame_len,
 				      seg_len);
+		prs->l4_offset = offset;
 		break;
 
 	case _ODP_ETHTYPE_ARP:
@@ -2181,15 +2184,13 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 
 	default:
 		prs->input_flags.l3 = 0;
-		prs->l3_offset = ODP_PACKET_OFFSET_INVALID;
 		ip_proto = 255;  /* Reserved invalid by IANA */
 	}
 
 	if (layer == ODP_PKTIO_PARSER_LAYER_L3)
 		return prs->error_flags.all != 0;
 
-	/* Set l4_offset+flag only for known ip_proto */
-	prs->l4_offset = offset;
+	/* Set l4 flag only for known ip_proto */
 	prs->input_flags.l4 = 1;
 
 	/* Parse Layer 4 headers */
@@ -2235,7 +2236,6 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 
 	default:
 		prs->input_flags.l4 = 0;
-		prs->l4_offset = ODP_PACKET_OFFSET_INVALID;
 		break;
 	}
 

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2311,7 +2311,7 @@ int odp_packet_parse(odp_packet_t pkt, uint32_t offset,
 	uint32_t seg_len;
 	uint32_t packet_len = pkt_hdr->frame_len;
 	odp_proto_t proto = param->proto;
-	odp_proto_layer_t layer = param->layer;
+	odp_proto_layer_t layer = param->last_layer;
 	int ret;
 	uint16_t ethtype;
 

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -2450,7 +2450,7 @@ void packet_test_parse(void)
 	}
 
 	parse.proto = ODP_PROTO_ETH;
-	parse.layer = ODP_PROTO_LAYER_ALL;
+	parse.last_layer = ODP_PROTO_LAYER_ALL;
 	parse.all_check = 0;
 
 	CU_ASSERT(odp_packet_parse(pkt[0], offset[0], &parse) == 0);
@@ -2481,7 +2481,7 @@ void packet_test_parse(void)
 	}
 
 	parse.proto = ODP_PROTO_IPV4;
-	parse.layer = ODP_PROTO_LAYER_L4;
+	parse.last_layer = ODP_PROTO_LAYER_L4;
 	parse.all_check = 0;
 
 	CU_ASSERT(odp_packet_parse(pkt[0], offset[0], &parse) == 0);
@@ -2511,7 +2511,7 @@ void packet_test_parse(void)
 	}
 
 	parse.proto = ODP_PROTO_ETH;
-	parse.layer = ODP_PROTO_LAYER_L4;
+	parse.last_layer = ODP_PROTO_LAYER_L4;
 	parse.all_check = 0;
 
 	CU_ASSERT(odp_packet_parse(pkt[0], offset[0], &parse) == 0);
@@ -2541,7 +2541,7 @@ void packet_test_parse(void)
 	}
 
 	parse.proto = ODP_PROTO_ETH;
-	parse.layer = ODP_PROTO_LAYER_L4;
+	parse.last_layer = ODP_PROTO_LAYER_L4;
 	parse.all_check = 0;
 
 	CU_ASSERT(odp_packet_parse(pkt[0], offset[0], &parse) == 0);
@@ -2572,7 +2572,7 @@ void packet_test_parse(void)
 	}
 
 	parse.proto = ODP_PROTO_ETH;
-	parse.layer = ODP_PROTO_LAYER_ALL;
+	parse.last_layer = ODP_PROTO_LAYER_ALL;
 	parse.all_check = 0;
 
 	CU_ASSERT(odp_packet_parse(pkt[0], offset[0], &parse) == 0);


### PR DESCRIPTION
Offset functions just point to the start of an layer. Offsets
may be set also when a layer does not have a known header or
a known header has an error. For example, L4 offset may be
set always after a successful parse of L3 (IP) layer. There
are other API calls to check if L4 is a known protocol
(e.g. packet_has_l4, packet_has_udp), or if it contain errors
(e.g. packet_has_l4_error).