### PR TITLE
[PATCH API-NEXT v3] Deprecate odp_pktio_parser_layer_t

### DIFF
--- a/example/l2fwd_simple/odp_l2fwd_simple.c
+++ b/example/l2fwd_simple/odp_l2fwd_simple.c
@@ -52,7 +52,7 @@ static odp_pktio_t create_pktio(const char *name, odp_pool_t pool,
 	}
 
 	odp_pktio_config_init(&config);
-	config.parser.layer = ODP_PKTIO_PARSER_LAYER_L2;
+	config.parser.layer = ODP_PROTO_LAYER_L2;
 	odp_pktio_config(pktio, &config);
 
 	odp_pktin_queue_param_init(&in_queue_param);

--- a/example/l3fwd/odp_l3fwd.c
+++ b/example/l3fwd/odp_l3fwd.c
@@ -123,8 +123,8 @@ static int create_pktio(const char *name, odp_pool_t pool,
 
 	odp_pktio_config_init(&config);
 	config.parser.layer = global.cmd_args.error_check ?
-			ODP_PKTIO_PARSER_LAYER_ALL :
-			ODP_PKTIO_PARSER_LAYER_L4;
+			ODP_PROTO_LAYER_ALL :
+			ODP_PROTO_LAYER_L4;
 	odp_pktio_config(pktio, &config);
 
 	fwd_pktio->nb_rxq = (int)capa.max_input_queues;

--- a/example/switch/odp_switch.c
+++ b/example/switch/odp_switch.c
@@ -240,7 +240,7 @@ static int create_pktio(const char *dev, int idx, int num_rx, int num_tx,
 	}
 
 	odp_pktio_config_init(&config);
-	config.parser.layer = ODP_PKTIO_PARSER_LAYER_L2;
+	config.parser.layer = ODP_PROTO_LAYER_L2;
 	odp_pktio_config(pktio, &config);
 
 	odp_pktin_queue_param_init(&pktin_param);

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -272,8 +272,8 @@ typedef struct odp_pktio_param_t {
  * not checked.
  *
  * IPv4 checksum checking may be enabled only when parsing level is
- * ODP_PKTIO_PARSER_LAYER_L3 or higher. Similarly, L4 level checksum checking
- * may be enabled only with parsing level ODP_PKTIO_PARSER_LAYER_L4 or higher.
+ * ODP_PROTO_LAYER_L3 or higher. Similarly, L4 level checksum checking
+ * may be enabled only with parsing level ODP_PROTO_LAYER_L4 or higher.
  *
  * Whether checksum checking was done and whether a checksum was correct
  * can be queried for each received packet with odp_packet_l3_chksum_status()
@@ -405,24 +405,30 @@ typedef union odp_pktout_config_opt_t {
 
 /**
  * Parser layers
+ *
+ * @deprecated Use odp_proto_layer_t instead
  */
-typedef enum odp_pktio_parser_layer_t {
-	/** No layers */
-	ODP_PKTIO_PARSER_LAYER_NONE = ODP_PROTO_LAYER_NONE,
+typedef odp_proto_layer_t odp_pktio_parser_layer_t;
 
-	/** Layer L2 protocols (Ethernet, VLAN, ARP, etc) */
-	ODP_PKTIO_PARSER_LAYER_L2 = ODP_PROTO_LAYER_L2,
+/** No layers
+ *  @deprecated Use ODP_PROTO_LAYER_NONE, instead */
+#define ODP_PKTIO_PARSER_LAYER_NONE ODP_PROTO_LAYER_NONE
 
-	/** Layer L3 protocols (IPv4, IPv6, ICMP, IPsec, etc) */
-	ODP_PKTIO_PARSER_LAYER_L3 = ODP_PROTO_LAYER_L3,
+/** Layer L2 protocols (Ethernet, VLAN, ARP, etc)
+ *  @deprecated Use ODP_PROTO_LAYER_L2, instead */
+#define ODP_PKTIO_PARSER_LAYER_L2 ODP_PROTO_LAYER_L2
 
-	/** Layer L4 protocols (UDP, TCP, SCTP) */
-	ODP_PKTIO_PARSER_LAYER_L4 = ODP_PROTO_LAYER_L4,
+/** Layer L3 protocols (IPv4, IPv6, ICMP, IPsec, etc)
+ *  @deprecated Use ODP_PROTO_LAYER_L3, instead */
+#define ODP_PKTIO_PARSER_LAYER_L3 ODP_PROTO_LAYER_L3
 
-	/** All layers */
-	ODP_PKTIO_PARSER_LAYER_ALL = ODP_PROTO_LAYER_ALL
+/** Layer L4 protocols (UDP, TCP, SCTP)
+ *  @deprecated Use ODP_PROTO_LAYER_L4, instead */
+#define ODP_PKTIO_PARSER_LAYER_L4 ODP_PROTO_LAYER_L4
 
-} odp_pktio_parser_layer_t;
+/** All layers
+ *  @deprecated Use ODP_PROTO_LAYER_ALL instead */
+#define ODP_PKTIO_PARSER_LAYER_ALL ODP_PROTO_LAYER_ALL
 
 /**
  * Parser configuration
@@ -436,8 +442,8 @@ typedef struct odp_pktio_parser_config_t {
 	  * set. In addition, offset (and pointer) to the next layer is set.
 	  * Other layer/protocol specific metadata have undefined values.
 	  *
-	  * The default value is ODP_PKTIO_PARSER_LAYER_ALL. */
-	odp_pktio_parser_layer_t layer;
+	  * The default value is ODP_PROTO_LAYER_ALL. */
+	odp_proto_layer_t layer;
 
 } odp_pktio_parser_config_t;
 

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -296,11 +296,11 @@ int packet_alloc_multi(odp_pool_t pool_hdl, uint32_t len,
 
 /* Perform packet parse up to a given protocol layer */
 int packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
-		       odp_pktio_parser_layer_t layer);
+		       odp_proto_layer_t layer);
 
 /* Perform L3 and L4 parsing up to a given protocol layer */
 int packet_parse_l3_l4(odp_packet_hdr_t *pkt_hdr,
-		       odp_pktio_parser_layer_t layer,
+		       odp_proto_layer_t layer,
 		       uint32_t l3_offset,
 		       uint16_t ethtype);
 

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -973,7 +973,7 @@ int cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 	packet_set_len(pkt_hdr, pkt_len);
 
 	packet_parse_common(&pkt_hdr->p, base, pkt_len, seg_len,
-			    ODP_PKTIO_PARSER_LAYER_ALL);
+			    ODP_PROTO_LAYER_ALL);
 	cos = cls_select_cos(entry, base, pkt_hdr);
 
 	if (cos == NULL)

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2211,7 +2211,7 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 
 	prs->l3_offset = offset;
 
-	if (layer <= ODP_PKTIO_PARSER_LAYER_L2)
+	if (layer <= ODP_PROTO_LAYER_L2)
 		return prs->error_flags.all != 0;
 
 	/* Set l3 flag only for known ethtypes */
@@ -2242,7 +2242,7 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 		ip_proto = 255;  /* Reserved invalid by IANA */
 	}
 
-	if (layer == ODP_PKTIO_PARSER_LAYER_L3)
+	if (layer == ODP_PROTO_LAYER_L3)
 		return prs->error_flags.all != 0;
 
 	/* Set l4 flag only for known ip_proto */
@@ -2314,7 +2314,7 @@ int packet_parse_common(packet_parser_t *prs, const uint8_t *ptr,
 	parseptr = ptr;
 	offset = 0;
 
-	if (layer == ODP_PKTIO_PARSER_LAYER_NONE)
+	if (layer == ODP_PROTO_LAYER_NONE)
 		return 0;
 
 	/* Assume valid L2 header, no CRC/FCS check in SW */
@@ -2333,7 +2333,7 @@ int packet_parse_common(packet_parser_t *prs, const uint8_t *ptr,
  * Simple packet parser
  */
 int packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
-		       odp_pktio_parser_layer_t layer)
+		       odp_proto_layer_t layer)
 {
 	uint32_t seg_len = packet_first_seg_len(pkt_hdr);
 	void *base = packet_data(pkt_hdr);
@@ -2343,7 +2343,7 @@ int packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
 }
 
 int packet_parse_l3_l4(odp_packet_hdr_t *pkt_hdr,
-		       odp_pktio_parser_layer_t layer,
+		       odp_proto_layer_t layer,
 		       uint32_t l3_offset,
 		       uint16_t ethtype)
 {

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -998,7 +998,7 @@ void odp_pktio_config_init(odp_pktio_config_t *config)
 {
 	memset(config, 0, sizeof(odp_pktio_config_t));
 
-	config->parser.layer = ODP_PKTIO_PARSER_LAYER_ALL;
+	config->parser.layer = ODP_PROTO_LAYER_ALL;
 }
 
 int odp_pktio_info(odp_pktio_t hdl, odp_pktio_info_t *info)
@@ -1203,7 +1203,7 @@ int odp_pktio_capability(odp_pktio_t pktio, odp_pktio_capability_t *capa)
 
 	/* The same parser is used for all pktios */
 	if (ret == 0)
-		capa->config.parser.layer = ODP_PKTIO_PARSER_LAYER_ALL;
+		capa->config.parser.layer = ODP_PROTO_LAYER_ALL;
 
 	return ret;
 }

--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -737,8 +737,8 @@ static int create_pktio(const char *dev, int idx, int num_rx, int num_tx,
 
 	odp_pktio_config_init(&config);
 	config.parser.layer = gbl_args->appl.extra_check ?
-			ODP_PKTIO_PARSER_LAYER_ALL :
-			ODP_PKTIO_PARSER_LAYER_NONE;
+			ODP_PROTO_LAYER_ALL :
+			ODP_PROTO_LAYER_NONE;
 
 	if (gbl_args->appl.chksum) {
 		printf("Checksum offload enabled\n");

--- a/test/performance/odp_pktio_ordered.c
+++ b/test/performance/odp_pktio_ordered.c
@@ -618,7 +618,7 @@ static int create_pktio(const char *dev, int idx, int num_rx, int num_tx,
 	}
 
 	odp_pktio_config_init(&config);
-	config.parser.layer = ODP_PKTIO_PARSER_LAYER_L2;
+	config.parser.layer = ODP_PROTO_LAYER_L2;
 	odp_pktio_config(pktio, &config);
 
 	odp_pktin_queue_param_init(&pktin_param);

--- a/test/performance/odp_pktio_perf.c
+++ b/test/performance/odp_pktio_perf.c
@@ -797,7 +797,7 @@ static int test_init(void)
 	 * affects scalability.
 	 */
 	odp_pktio_config_init(&cfg);
-	cfg.parser.layer = ODP_PKTIO_PARSER_LAYER_NONE;
+	cfg.parser.layer = ODP_PROTO_LAYER_NONE;
 	odp_pktio_config(gbl_args->pktio_rx, &cfg);
 
 	if (gbl_args->args.num_ifaces > 1) {

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -84,7 +84,7 @@ static int pktio_start(odp_pktio_t pktio, odp_bool_t in, odp_bool_t out)
 		return 0;
 
 	odp_pktio_config_init(&config);
-	config.parser.layer = ODP_PKTIO_PARSER_LAYER_ALL;
+	config.parser.layer = ODP_PROTO_LAYER_ALL;
 	config.inbound_ipsec = in;
 	config.outbound_ipsec = out;
 

--- a/test/validation/api/pktio/parser.c
+++ b/test/validation/api/pktio/parser.c
@@ -122,7 +122,7 @@ static odp_pktio_t create_pktio(int iface_idx, odp_pool_t pool)
 	}
 
 	odp_pktio_config_init(&config);
-	config.parser.layer = ODP_PKTIO_PARSER_LAYER_ALL;
+	config.parser.layer = ODP_PROTO_LAYER_ALL;
 	if (odp_pktio_config(pktio, &config)) {
 		printf("Error:  failed to configure %s\n", iface);
 		return ODP_PKTIO_INVALID;

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1230,7 +1230,7 @@ void pktio_test_pktio_config(void)
 
 	odp_pktio_config_init(&config);
 
-	CU_ASSERT(config.parser.layer == ODP_PKTIO_PARSER_LAYER_ALL);
+	CU_ASSERT(config.parser.layer == ODP_PROTO_LAYER_ALL);
 
 	CU_ASSERT(odp_pktio_config(pktio, NULL) == 0);
 


### PR DESCRIPTION
`odp_pktio_parser_layer_t` duplicates `odp_proto_layer_t`. So let's deprecate the former type in favour of later one.