### PR TITLE
[PATCH CATERPILLAR v1] Pad pool cache to cache line

### DIFF
--- a/platform/linux-generic/buffer/generic.c
+++ b/platform/linux-generic/buffer/generic.c
@@ -117,7 +117,7 @@ int buffer_alloc_multi(pool_t *pool, odp_buffer_hdr_t *buf_hdr[], int max_num)
 
 	cache = local.cache[pool->pool_idx];
 
-	cache_num = cache->num;
+	cache_num = cache->s.num;
 	num_ch    = max_num;
 	num_deq   = 0;
 	burst     = CACHE_BURST;
@@ -135,7 +135,7 @@ int buffer_alloc_multi(pool_t *pool, odp_buffer_hdr_t *buf_hdr[], int max_num)
 	for (i = 0; i < num_ch; i++) {
 		uint32_t j = cache_num - num_ch + i;
 
-		buf_hdr[i] = buf_hdr_from_index(pool, cache->buf_index[j]);
+		buf_hdr[i] = buf_hdr_from_index(pool, cache->s.buf_index[j]);
 	}
 
 	/* If needed, get more from the global pool */
@@ -164,11 +164,11 @@ int buffer_alloc_multi(pool_t *pool, odp_buffer_hdr_t *buf_hdr[], int max_num)
 
 		/* Cache extra buffers. Cache is currently empty. */
 		for (i = 0; i < cache_num; i++)
-			cache->buf_index[i] = data[num_deq + i];
+			cache->s.buf_index[i] = data[num_deq + i];
 
-		cache->num = cache_num;
+		cache->s.num = cache_num;
 	} else {
-		cache->num = cache_num - num_ch;
+		cache->s.num = cache_num - num_ch;
 	}
 
 	return num_ch + num_deq;
@@ -202,7 +202,7 @@ static inline void buffer_free_to_pool(pool_t *pool,
 
 	/* Make room into local cache if needed. Do at least burst size
 	 * transfer. */
-	cache_num = cache->num;
+	cache_num = cache->s.num;
 
 	if (odp_unlikely((int)(CONFIG_POOL_CACHE_SIZE - cache_num) < num)) {
 		uint32_t index;
@@ -224,7 +224,7 @@ static inline void buffer_free_to_pool(pool_t *pool,
 			index = cache_num - burst;
 
 			for (i = 0; i < burst; i++)
-				data[i] = cache->buf_index[index + i];
+				data[i] = cache->s.buf_index[index + i];
 
 			ring_enq_multi(ring, mask, data, burst);
 		}
@@ -233,9 +233,9 @@ static inline void buffer_free_to_pool(pool_t *pool,
 	}
 
 	for (i = 0; i < num; i++)
-		cache->buf_index[cache_num + i] = buf_hdr[i]->index;
+		cache->s.buf_index[cache_num + i] = buf_hdr[i]->index;
 
-	cache->num = cache_num + num;
+	cache->s.num = cache_num + num;
 }
 
 void buffer_free_multi(odp_buffer_hdr_t *buf_hdr[], int num_total)

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -29,10 +29,15 @@ extern "C" {
 
 #define CACHE_BURST    32
 
-typedef struct pool_cache_t {
+struct pool_cache_s {
 	uint32_t num;
 	uint32_t buf_index[CONFIG_POOL_CACHE_SIZE];
 
+};
+
+typedef union pool_cache_u {
+	struct pool_cache_s s;
+	uint8_t pad[ROUNDUP_CACHE_LINE(sizeof(struct pool_cache_s))];
 } pool_cache_t ODP_ALIGNED_CACHE;
 
 /* Buffer header ring */

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -816,10 +816,7 @@ odp_packet_t odp_packet_alloc(odp_pool_t pool_hdl, uint32_t len)
 	odp_packet_t pkt;
 	int num, num_seg;
 
-	if (odp_unlikely(pool->params.type != ODP_POOL_PACKET)) {
-		__odp_errno = EINVAL;
-		return ODP_PACKET_INVALID;
-	}
+	ODP_ASSERT(pool->params.type == ODP_POOL_PACKET);
 
 	if (odp_unlikely(len > pool->max_len))
 		return ODP_PACKET_INVALID;
@@ -839,10 +836,7 @@ int odp_packet_alloc_multi(odp_pool_t pool_hdl, uint32_t len,
 	pool_t *pool = pool_entry_from_hdl(pool_hdl);
 	int num, num_seg;
 
-	if (odp_unlikely(pool->params.type != ODP_POOL_PACKET)) {
-		__odp_errno = EINVAL;
-		return -1;
-	}
+	ODP_ASSERT(pool->params.type == ODP_POOL_PACKET);
 
 	if (odp_unlikely(len > pool->max_len))
 		return -1;

--- a/platform/linux-generic/pool/generic.c
+++ b/platform/linux-generic/pool/generic.c
@@ -120,7 +120,7 @@ static int generic_pool_init_local(void)
 	for (i = 0; i < ODP_CONFIG_POOLS; i++) {
 		pool           = pool_entry(i);
 		local.cache[i] = &pool->local_cache[thr_id];
-		local.cache[i]->num = 0;
+		local.cache[i]->s.num = 0;
 	}
 
 	local.thr_id = thr_id;
@@ -135,12 +135,12 @@ static void flush_cache(pool_cache_t *cache, pool_t *pool)
 
 	ring = &pool->ring->hdr;
 	mask = pool->ring_mask;
-	cache_num = cache->num;
+	cache_num = cache->s.num;
 
 	for (i = 0; i < cache_num; i++)
-		ring_enq(ring, mask, cache->buf_index[i]);
+		ring_enq(ring, mask, cache->s.buf_index[i]);
 
-	cache->num = 0;
+	cache->s.num = 0;
 }
 
 static int generic_pool_term_local(void)


### PR DESCRIPTION
1) Pad pool cache such that, the next pool cache in an array always starts at a cache line
2) Convert checks for programming errors to ODP_ASSERT.