### PR TITLE
[PATCH API-NEXT v3] api, linux-gen, validation: crypto change api.ptr to api_ptr in packe…

### DIFF
--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -407,14 +407,10 @@ typedef struct odp_crypto_op_param_t {
 	 */
 	uint32_t hash_result_offset;
 
-	/** Additional Authenticated Data (AAD) */
-	struct {
-		/** Pointer to AAD. AAD length is defined by 'auth_aad_len'
-		 *  session parameter.
-		 */
-		uint8_t *ptr;
-
-	} aad;
+	/** Pointer to AAD. AAD length is defined by 'auth_aad_len'
+	 *  session parameter.
+	 */
+	uint8_t *aad_ptr;
 
 	/** Data range to apply cipher */
 	odp_packet_data_range_t cipher_range;
@@ -447,14 +443,10 @@ typedef struct odp_crypto_packet_op_param_t {
 	 */
 	uint32_t hash_result_offset;
 
-	/** Additional Authenticated Data (AAD) */
-	struct {
-		/** Pointer to AAD. AAD length is defined by 'auth_aad_len'
-		 *  session parameter.
-		 */
-		uint8_t *ptr;
-
-	} aad;
+	/** Pointer to AAD. AAD length is defined by 'auth_aad_len'
+	 *  session parameter.
+	 */
+	uint8_t *aad_ptr;
 
 	/** Data range to apply cipher */
 	odp_packet_data_range_t cipher_range;

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -478,7 +478,7 @@ odp_crypto_alg_err_t aes_gcm_encrypt(odp_packet_t pkt,
 				     odp_crypto_generic_session_t *session)
 {
 	EVP_CIPHER_CTX *ctx;
-	const uint8_t *aad_head = param->aad.ptr;
+	const uint8_t *aad_head = param->aad_ptr;
 	uint32_t aad_len = session->p.auth_aad_len;
 	void *iv_ptr;
 	int dummy_len = 0;
@@ -525,7 +525,7 @@ odp_crypto_alg_err_t aes_gcm_decrypt(odp_packet_t pkt,
 				     odp_crypto_generic_session_t *session)
 {
 	EVP_CIPHER_CTX *ctx;
-	const uint8_t *aad_head = param->aad.ptr;
+	const uint8_t *aad_head = param->aad_ptr;
 	uint32_t aad_len = session->p.auth_aad_len;
 	int dummy_len = 0;
 	void *iv_ptr;
@@ -1057,7 +1057,7 @@ odp_crypto_operation(odp_crypto_op_param_t *param,
 	packet_param.session = param->session;
 	packet_param.override_iv_ptr = param->override_iv_ptr;
 	packet_param.hash_result_offset = param->hash_result_offset;
-	packet_param.aad.ptr = param->aad.ptr;
+	packet_param.aad_ptr = param->aad_ptr;
 	packet_param.cipher_range = param->cipher_range;
 	packet_param.auth_range = param->auth_range;
 

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -424,7 +424,7 @@ static int ipsec_in_esp(odp_packet_t *pkt,
 	state->esp.aad.seq_no = esp.seq_no;
 	state->in.seq_no = odp_be_to_cpu_32(esp.seq_no);
 
-	param->aad.ptr = (uint8_t *)&state->esp.aad;
+	param->aad_ptr = (uint8_t *)&state->esp.aad;
 
 	param->auth_range.offset = ipsec_offset;
 	param->auth_range.length = state->ip_tot_len -
@@ -1029,7 +1029,7 @@ static int ipsec_out_esp(odp_packet_t *pkt,
 	state->esp.aad.spi = esp.spi;
 	state->esp.aad.seq_no = esp.seq_no;
 
-	param->aad.ptr = (uint8_t *)&state->esp.aad;
+	param->aad_ptr = (uint8_t *)&state->esp.aad;
 
 	memset(&esptrl, 0, sizeof(esptrl));
 	esptrl.pad_len = encrypt_len - ip_data_len - _ODP_ESPTRL_LEN;

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -102,7 +102,7 @@ static int alg_op(odp_packet_t pkt,
 	if (op_iv_ptr)
 		op_params.override_iv_ptr = op_iv_ptr;
 
-	op_params.aad.ptr = aad;
+	op_params.aad_ptr = aad;
 
 	op_params.hash_result_offset = plaintext_len;
 
@@ -174,7 +174,7 @@ static int alg_packet_op(odp_packet_t pkt,
 	if (op_iv_ptr)
 		op_params.override_iv_ptr = op_iv_ptr;
 
-	op_params.aad.ptr = aad;
+	op_params.aad_ptr = aad;
 
 	op_params.hash_result_offset = plaintext_len;
 
@@ -232,7 +232,7 @@ static int alg_packet_op_enq(odp_packet_t pkt,
 	if (op_iv_ptr)
 		op_params.override_iv_ptr = op_iv_ptr;
 
-	op_params.aad.ptr = aad;
+	op_params.aad_ptr = aad;
 
 	op_params.hash_result_offset = plaintext_len;
 


### PR DESCRIPTION
…t params

In new odp_crypto_packet_op_param_t change AAD from struct with a single
pointer to just data pointer. This API is new, so there is no need to
deprecate and/or handle old pointer in any specific way.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>