### PR TITLE
[PATCH API-NEXT v5] Rework IPsec crypto capabilities

### DIFF
--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -281,6 +281,24 @@ typedef struct odp_ipsec_capability_t {
 } odp_ipsec_capability_t;
 
 /**
+ * Cipher algorithm capabilities
+ */
+typedef struct odp_ipsec_cipher_capability_t {
+	/** Key length in bytes */
+	uint32_t key_len;
+
+} odp_ipsec_cipher_capability_t;
+
+/**
+ * Authentication algorithm capabilities
+ */
+typedef struct odp_ipsec_auth_capability_t {
+	/** Key length in bytes */
+	uint32_t key_len;
+
+} odp_ipsec_auth_capability_t;
+
+/**
  * IPSEC configuration options
  */
 typedef struct odp_ipsec_config_t {
@@ -744,7 +762,7 @@ int odp_ipsec_capability(odp_ipsec_capability_t *capa);
  * @retval <0 on failure
  */
 int odp_ipsec_cipher_capability(odp_cipher_alg_t cipher,
-				odp_crypto_cipher_capability_t capa[], int num);
+				odp_ipsec_cipher_capability_t capa[], int num);
 
 /**
  * Query supported IPSEC authentication algorithm capabilities
@@ -766,7 +784,7 @@ int odp_ipsec_cipher_capability(odp_cipher_alg_t cipher,
  * @retval <0 on failure
  */
 int odp_ipsec_auth_capability(odp_auth_alg_t auth,
-			      odp_crypto_auth_capability_t capa[], int num);
+			      odp_ipsec_auth_capability_t capa[], int num);
 
 /**
  * Initialize IPSEC configuration options

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -206,6 +206,12 @@ typedef struct ODP_PACKED {
 	odp_u32be_t seq_no;  /**< Sequence Number */
 } ipsec_aad_t;
 
+/* Return IV length required for the cipher for IPsec use */
+uint32_t _odp_ipsec_cipher_iv_len(odp_cipher_alg_t cipher);
+
+/* Return digest length required for the cipher for IPsec use */
+uint32_t _odp_ipsec_auth_digest_len(odp_auth_alg_t auth);
+
 /**
  * Obtain SA reference
  */

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -126,8 +126,8 @@ int ipsec_check(odp_bool_t ah,
 		uint32_t auth_bits)
 {
 	odp_ipsec_capability_t capa;
-	odp_crypto_cipher_capability_t cipher_capa[MAX_ALG_CAPA];
-	odp_crypto_auth_capability_t   auth_capa[MAX_ALG_CAPA];
+	odp_ipsec_cipher_capability_t cipher_capa[MAX_ALG_CAPA];
+	odp_ipsec_auth_capability_t   auth_capa[MAX_ALG_CAPA];
 	int i, num;
 	odp_bool_t found;
 


### PR DESCRIPTION
Generic crypto caps provide too much information to be useful for IPsec applications (because some of the data is fixed). Rework respective functions to provide just necessary data.