### PR TITLE
[PATCH v2] Packet offset inline

### DIFF
--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -109,6 +109,24 @@ static inline uint32_t _odp_packet_user_area_size(odp_packet_t pkt)
 }
 
 /** @internal Inline function @param pkt @return */
+static inline uint32_t _odp_packet_l2_offset(odp_packet_t pkt)
+{
+	return _odp_pkt_get(pkt, uint16_t, l2_offset);
+}
+
+/** @internal Inline function @param pkt @return */
+static inline uint32_t _odp_packet_l3_offset(odp_packet_t pkt)
+{
+	return _odp_pkt_get(pkt, uint16_t, l3_offset);
+}
+
+/** @internal Inline function @param pkt @return */
+static inline uint32_t _odp_packet_l4_offset(odp_packet_t pkt)
+{
+	return _odp_pkt_get(pkt, uint16_t, l4_offset);
+}
+
+/** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_flow_hash(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint32_t, flow_hash);

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -18,6 +18,11 @@
 #include <odp/api/packet_io.h>
 #include <odp/api/hints.h>
 
+/** @internal Inline function @param pkt_ptr @param offset @param seg_len
+ *  @param seg_idx @return */
+void *_odp_packet_map(void *pkt_ptr, uint32_t offset, uint32_t *seg_len,
+		      int *seg_idx);
+
 /** @internal Inline function offsets */
 extern const _odp_packet_inline_offset_t _odp_packet_inline;
 
@@ -124,6 +129,63 @@ static inline uint32_t _odp_packet_l3_offset(odp_packet_t pkt)
 static inline uint32_t _odp_packet_l4_offset(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint16_t, l4_offset);
+}
+
+/** @internal Inline function @param pkt @param len @return */
+static inline void *_odp_packet_l2_ptr(odp_packet_t pkt, uint32_t *len)
+{
+	uint32_t offset  = _odp_packet_l2_offset(pkt);
+	uint32_t seg_len = _odp_packet_seg_len(pkt);
+	uint8_t *data    = (uint8_t *)_odp_packet_data(pkt);
+
+	if (odp_unlikely(offset >= seg_len)) {
+		void *pkt_hdr = (void *)pkt;
+
+		return _odp_packet_map(pkt_hdr, offset, len, NULL);
+	}
+
+	if (len)
+		*len = seg_len - offset;
+
+	return data + offset;
+}
+
+/** @internal Inline function @param pkt @param len @return */
+static inline void *_odp_packet_l3_ptr(odp_packet_t pkt, uint32_t *len)
+{
+	uint32_t offset  = _odp_packet_l3_offset(pkt);
+	uint32_t seg_len = _odp_packet_seg_len(pkt);
+	uint8_t *data    = (uint8_t *)_odp_packet_data(pkt);
+
+	if (odp_unlikely(offset >= seg_len)) {
+		void *pkt_hdr = (void *)pkt;
+
+		return _odp_packet_map(pkt_hdr, offset, len, NULL);
+	}
+
+	if (len)
+		*len = seg_len - offset;
+
+	return data + offset;
+}
+
+/** @internal Inline function @param pkt @param len @return */
+static inline void *_odp_packet_l4_ptr(odp_packet_t pkt, uint32_t *len)
+{
+	uint32_t offset  = _odp_packet_l4_offset(pkt);
+	uint32_t seg_len = _odp_packet_seg_len(pkt);
+	uint8_t *data    = (uint8_t *)_odp_packet_data(pkt);
+
+	if (odp_unlikely(offset >= seg_len)) {
+		void *pkt_hdr = (void *)pkt;
+
+		return _odp_packet_map(pkt_hdr, offset, len, NULL);
+	}
+
+	if (len)
+		*len = seg_len - offset;
+
+	return data + offset;
 }
 
 /** @internal Inline function @param pkt @return */

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
@@ -83,6 +83,21 @@ _ODP_INLINE uint32_t odp_packet_l4_offset(odp_packet_t pkt)
 	return _odp_packet_l4_offset(pkt);
 }
 
+_ODP_INLINE void *odp_packet_l2_ptr(odp_packet_t pkt, uint32_t *len)
+{
+	return _odp_packet_l2_ptr(pkt, len);
+}
+
+_ODP_INLINE void *odp_packet_l3_ptr(odp_packet_t pkt, uint32_t *len)
+{
+	return _odp_packet_l3_ptr(pkt, len);
+}
+
+_ODP_INLINE void *odp_packet_l4_ptr(odp_packet_t pkt, uint32_t *len)
+{
+	return _odp_packet_l4_ptr(pkt, len);
+}
+
 _ODP_INLINE uint32_t odp_packet_flow_hash(odp_packet_t pkt)
 {
 	return _odp_packet_flow_hash(pkt);

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
@@ -68,6 +68,21 @@ _ODP_INLINE uint32_t odp_packet_user_area_size(odp_packet_t pkt)
 	return _odp_packet_user_area_size(pkt);
 }
 
+_ODP_INLINE uint32_t odp_packet_l2_offset(odp_packet_t pkt)
+{
+	return _odp_packet_l2_offset(pkt);
+}
+
+_ODP_INLINE uint32_t odp_packet_l3_offset(odp_packet_t pkt)
+{
+	return _odp_packet_l3_offset(pkt);
+}
+
+_ODP_INLINE uint32_t odp_packet_l4_offset(odp_packet_t pkt)
+{
+	return _odp_packet_l4_offset(pkt);
+}
+
 _ODP_INLINE uint32_t odp_packet_flow_hash(odp_packet_t pkt)
 {
 	return _odp_packet_flow_hash(pkt);

--- a/platform/linux-generic/include/odp/api/plat/packet_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_types.h
@@ -94,6 +94,12 @@ typedef struct _odp_packet_inline_offset_t {
 	/** @internal field offset */
 	uint16_t user_area;
 	/** @internal field offset */
+	uint16_t l2_offset;
+	/** @internal field offset */
+	uint16_t l3_offset;
+	/** @internal field offset */
+	uint16_t l4_offset;
+	/** @internal field offset */
 	uint16_t flow_hash;
 	/** @internal field offset */
 	uint16_t timestamp;

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -37,6 +37,9 @@ const _odp_packet_inline_offset_t _odp_packet_inline ODP_ALIGNED_CACHE = {
 	.segcount       = offsetof(odp_packet_hdr_t, buf_hdr.segcount),
 	.user_ptr       = offsetof(odp_packet_hdr_t, buf_hdr.buf_ctx),
 	.user_area      = offsetof(odp_packet_hdr_t, buf_hdr.uarea_addr),
+	.l2_offset      = offsetof(odp_packet_hdr_t, p.l2_offset),
+	.l3_offset      = offsetof(odp_packet_hdr_t, p.l3_offset),
+	.l4_offset      = offsetof(odp_packet_hdr_t, p.l4_offset),
 	.flow_hash      = offsetof(odp_packet_hdr_t, flow_hash),
 	.timestamp      = offsetof(odp_packet_hdr_t, timestamp),
 	.input_flags    = offsetof(odp_packet_hdr_t, p.input_flags)
@@ -1213,15 +1216,6 @@ void *odp_packet_l2_ptr(odp_packet_t pkt, uint32_t *len)
 	return packet_map(pkt_hdr, pkt_hdr->p.l2_offset, len, NULL);
 }
 
-uint32_t odp_packet_l2_offset(odp_packet_t pkt)
-{
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-
-	if (!packet_hdr_has_l2(pkt_hdr))
-		return ODP_PACKET_OFFSET_INVALID;
-	return pkt_hdr->p.l2_offset;
-}
-
 int odp_packet_l2_offset_set(odp_packet_t pkt, uint32_t offset)
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
@@ -1241,13 +1235,6 @@ void *odp_packet_l3_ptr(odp_packet_t pkt, uint32_t *len)
 	return packet_map(pkt_hdr, pkt_hdr->p.l3_offset, len, NULL);
 }
 
-uint32_t odp_packet_l3_offset(odp_packet_t pkt)
-{
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-
-	return pkt_hdr->p.l3_offset;
-}
-
 int odp_packet_l3_offset_set(odp_packet_t pkt, uint32_t offset)
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
@@ -1264,13 +1251,6 @@ void *odp_packet_l4_ptr(odp_packet_t pkt, uint32_t *len)
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
 	return packet_map(pkt_hdr, pkt_hdr->p.l4_offset, len, NULL);
-}
-
-uint32_t odp_packet_l4_offset(odp_packet_t pkt)
-{
-	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
-
-	return pkt_hdr->p.l4_offset;
 }
 
 int odp_packet_l4_offset_set(odp_packet_t pkt, uint32_t offset)

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -1928,7 +1928,7 @@ static void egress_vlan_marking(tm_vlan_marking_t *vlan_marking,
 	uint32_t        hdr_len;
 	uint16_t        old_tci, new_tci;
 
-	ether_hdr_ptr = odp_packet_l2_ptr(odp_pkt, &hdr_len);
+	ether_hdr_ptr = _odp_packet_l2_ptr(odp_pkt, &hdr_len);
 	vlan_hdr_ptr  = (_odp_vlanhdr_t *)(ether_hdr_ptr + 1);
 
 	/* If the split_hdr variable below is TRUE, then this indicates that
@@ -1968,7 +1968,7 @@ static void egress_ipv4_tos_marking(tm_tos_marking_t *tos_marking,
 	uint8_t        old_tos, new_tos, ecn;
 
 	l3_offset    = _odp_packet_l3_offset(odp_pkt);
-	ipv4_hdr_ptr = odp_packet_l3_ptr(odp_pkt, &hdr_len);
+	ipv4_hdr_ptr = _odp_packet_l3_ptr(odp_pkt, &hdr_len);
 
 	/* If the split_hdr variable below is TRUE, then this indicates that
 	 * for this odp (output) packet the IPv4 header is not all in the same
@@ -2034,7 +2034,7 @@ static void egress_ipv6_tc_marking(tm_tos_marking_t *tos_marking,
 	uint8_t        old_tc, new_tc, ecn;
 
 	l3_offset    = _odp_packet_l3_offset(odp_pkt);
-	ipv6_hdr_ptr = odp_packet_l3_ptr(odp_pkt, &hdr_len);
+	ipv6_hdr_ptr = _odp_packet_l3_ptr(odp_pkt, &hdr_len);
 
 	/* If the split_hdr variable below is TRUE, then this indicates that
 	 * for this odp (output) packet the IPv6 header is not all in the same

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -26,6 +26,7 @@
 #include <protocols/eth.h>
 #include <protocols/ip.h>
 #include <odp_traffic_mngr_internal.h>
+#include <odp/api/plat/packet_inlines.h>
 
 /* Local vars */
 static const
@@ -1966,7 +1967,7 @@ static void egress_ipv4_tos_marking(tm_tos_marking_t *tos_marking,
 	uint32_t       hdr_len, l3_offset, old_chksum, ones_compl_sum, tos_diff;
 	uint8_t        old_tos, new_tos, ecn;
 
-	l3_offset    = odp_packet_l3_offset(odp_pkt);
+	l3_offset    = _odp_packet_l3_offset(odp_pkt);
 	ipv4_hdr_ptr = odp_packet_l3_ptr(odp_pkt, &hdr_len);
 
 	/* If the split_hdr variable below is TRUE, then this indicates that
@@ -2032,7 +2033,7 @@ static void egress_ipv6_tc_marking(tm_tos_marking_t *tos_marking,
 	uint32_t       hdr_len, old_ver_tc_flow, new_ver_tc_flow, l3_offset;
 	uint8_t        old_tc, new_tc, ecn;
 
-	l3_offset    = odp_packet_l3_offset(odp_pkt);
+	l3_offset    = _odp_packet_l3_offset(odp_pkt);
 	ipv6_hdr_ptr = odp_packet_l3_ptr(odp_pkt, &hdr_len);
 
 	/* If the split_hdr variable below is TRUE, then this indicates that


### PR DESCRIPTION
Inline packet offset and pointer functions. These are used very often in applications. For example, packet rate of OFP fpm_burst application improved 3.5% with these inlines (odp-linux + dpdk packet IO with copy).