### PR TITLE
[PATCH v1] test: validation: correct comparison in packet_test_ref()

### DIFF
--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -2354,7 +2354,7 @@ void packet_test_ref(void)
 	ref_pkt[0] = odp_packet_ref(base_pkt, offset[0]);
 	CU_ASSERT_FATAL(ref_pkt[0] != ODP_PACKET_INVALID);
 	ref_len[0] = odp_packet_len(ref_pkt[0]);
-	CU_ASSERT(ref_len[0] = odp_packet_len(base_pkt) - offset[0]);
+	CU_ASSERT(ref_len[0] == odp_packet_len(base_pkt) - offset[0]);
 
 	CU_ASSERT(odp_packet_push_head(base_pkt,
 				       base_hr - base_hr / 2) != NULL);


### PR DESCRIPTION
Fix typo in CU_ASSERT() that used an assignment instead of a
comparison in testing reference length.

This fixes Bug https://bugs.linaro.org/show_bug.cgi?id=3466

Signed-off-by: Bill Fischofer <bill.fischofer@linaro.org>