### PR TITLE
[PATCH v3] test: workaround buggy CUnit header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,8 +138,6 @@ before_install:
             curl -sSOL https://github.com/Linaro/libcunit/releases/download/${CUNIT_VERSION}/CUnit-${CUNIT_VERSION}.tar.bz2
             tar -jxf *.bz2
             pushd CUnit*
-            # Using the latest stable CUNIT but new compillers are more strict to functions declaration.
-            sed -i s/\(\)/\(void\)/g ./CUnit/Headers/Automated.h
             libtoolize --force --copy
             aclocal
             autoheader

--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -12,6 +12,18 @@
 #include <odp_api.h>
 #include "odp_cunit_common.h"
 #include <odp/helper/odph_api.h>
+
+#include <CUnit/TestDB.h>
+
+#if defined __GNUC__ && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4)) || (__GNUC__ > 4))
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
+#endif
+#include <CUnit/Automated.h>
+#if defined __GNUC__ && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4)) || (__GNUC__ > 4))
+#pragma GCC diagnostic pop
+#endif
+
 /* Globals */
 static odph_odpthread_t thread_tbl[MAX_WORKERS];
 static odp_instance_t instance;

--- a/test/common/odp_cunit_common.h
+++ b/test/common/odp_cunit_common.h
@@ -16,8 +16,6 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <CUnit/Basic.h>
-#include <CUnit/TestDB.h>
-#include <CUnit/Automated.h>
 #include <odp_api.h>
 
 #define MAX_WORKERS 32 /**< Maximum number of work threads */


### PR DESCRIPTION
Make GCC ignore following error:
In file included from odp_cunit_common.h:20:0,
                 from odp_cunit_common.c:13:
/home/travis/cunit-install/include/CUnit/Automated.h:90:1: error: function declaration isn’t a prototype [-Werror=strict-prototypes]
 const char *CU_automated_package_name_get();
 ^
cc1: all warnings being treated as errors

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>