### PR TITLE
[PATCH API-NEXT v3] api: crypto: deprecate DES algorithm

### DIFF
--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -71,9 +71,6 @@ typedef enum {
 	/** No cipher algorithm specified */
 	ODP_CIPHER_ALG_NULL,
 
-	/** DES */
-	ODP_CIPHER_ALG_DES,
-
 	/** Triple DES with cipher block chaining */
 	ODP_CIPHER_ALG_3DES_CBC,
 
@@ -94,6 +91,9 @@ typedef enum {
 
 	/** @deprecated  Use ODP_CIPHER_ALG_AES_GCM instead */
 	ODP_DEPRECATE(ODP_CIPHER_ALG_AES128_GCM),
+
+	/** @deprecated  Do not use DES, 56-bit keys are too weak nowadays */
+	ODP_DEPRECATE(ODP_CIPHER_ALG_DES),
 
 } odp_cipher_alg_t;
 
@@ -168,9 +168,6 @@ typedef union odp_crypto_cipher_algos_t {
 		/** ODP_CIPHER_ALG_NULL */
 		uint32_t null        : 1;
 
-		/** ODP_CIPHER_ALG_DES */
-		uint32_t des         : 1;
-
 		/** ODP_CIPHER_ALG_3DES_CBC */
 		uint32_t trides_cbc  : 1;
 
@@ -188,6 +185,9 @@ typedef union odp_crypto_cipher_algos_t {
 
 		/** @deprecated  Use aes_gcm instead */
 		uint32_t ODP_DEPRECATE(aes128_gcm) : 1;
+
+		/** @deprecated  Too weak, do not use */
+		uint32_t ODP_DEPRECATE(des)        : 1;
 
 	} bit;
 

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -196,7 +196,6 @@ uint32_t _odp_ipsec_cipher_iv_len(odp_cipher_alg_t cipher)
 	switch (cipher) {
 	case ODP_CIPHER_ALG_NULL:
 		return 0;
-	case ODP_CIPHER_ALG_DES:
 	case ODP_CIPHER_ALG_3DES_CBC:
 		return 8;
 #if ODP_DEPRECATED_API
@@ -366,7 +365,6 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 		ipsec_sa->esp_iv_len = 0;
 		ipsec_sa->esp_block_len = 1;
 		break;
-	case ODP_CIPHER_ALG_DES:
 	case ODP_CIPHER_ALG_3DES_CBC:
 		ipsec_sa->esp_iv_len = 8;
 		ipsec_sa->esp_block_len = 8;

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -62,8 +62,6 @@ static const char *cipher_alg_name(odp_cipher_alg_t cipher)
 	switch (cipher) {
 	case ODP_CIPHER_ALG_NULL:
 		return "ODP_CIPHER_ALG_NULL";
-	case ODP_CIPHER_ALG_DES:
-		return "ODP_CIPHER_ALG_DES";
 	case ODP_CIPHER_ALG_3DES_CBC:
 		return "ODP_CIPHER_ALG_3DES_CBC";
 	case ODP_CIPHER_ALG_AES_CBC:
@@ -339,9 +337,6 @@ static void alg_test(odp_crypto_op_t op,
 	if (cipher_alg == ODP_CIPHER_ALG_AES_GCM &&
 	    !(capa.ciphers.bit.aes_gcm))
 		rc = -1;
-	if (cipher_alg == ODP_CIPHER_ALG_DES &&
-	    !(capa.ciphers.bit.des))
-		rc = -1;
 	if (cipher_alg == ODP_CIPHER_ALG_NULL &&
 	    !(capa.ciphers.bit.null))
 		rc = -1;
@@ -558,10 +553,6 @@ static int check_alg_support(odp_cipher_alg_t cipher, odp_auth_alg_t auth)
 	switch (cipher) {
 	case ODP_CIPHER_ALG_NULL:
 		if (!capability.ciphers.bit.null)
-			return ODP_TEST_INACTIVE;
-		break;
-	case ODP_CIPHER_ALG_DES:
-		if (!capability.ciphers.bit.des)
 			return ODP_TEST_INACTIVE;
 		break;
 	case ODP_CIPHER_ALG_3DES_CBC:

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -157,10 +157,6 @@ int ipsec_check(odp_bool_t ah,
 		if (!capa.ciphers.bit.null)
 			return ODP_TEST_INACTIVE;
 		break;
-	case ODP_CIPHER_ALG_DES:
-		if (!capa.ciphers.bit.des)
-			return ODP_TEST_INACTIVE;
-		break;
 	case ODP_CIPHER_ALG_3DES_CBC:
 		if (!capa.ciphers.bit.trides_cbc)
 			return ODP_TEST_INACTIVE;


### PR DESCRIPTION
DES is too weak, 56-bit keys, 64-bit blocks. Can be cracked nearly
bare-handed nowdays. Depreate it now, to be dropped in next release.
Note: Tripple-DES (TDES) remains in place.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>