### PR TITLE
[PATCH v1] shippable: process test results in post_ci stage

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -39,6 +39,8 @@ build:
     - ./configure --disable-test-perf
     - make
     - sudo env ODP_SHM_DIR=/dev/shm/odp ODP_TEST_OUT_XML=yes make check
+
+  post_ci:
     - wget https://raw.githubusercontent.com/shawnliang/cunit-to-junit/master/cunit-to-junit.xsl
     - |
       for FILE in `find  ./test ./platform/ -name  "*.xml"`; do


### PR DESCRIPTION
Processing tests in ci stage ends up with empty test results in case of
failure (as ci stage will abort after failure). Process them in post_ci
stage to actually capture failed test results.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>