### PR TITLE
[PATCH CATERPILLAR v5] linux-dpdk: crypto support for cipher & auth only feature

### DIFF
--- a/platform/linux-dpdk/test/wrapper-script.sh
+++ b/platform/linux-dpdk/test/wrapper-script.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-export ODP_PLATFORM_PARAMS=${ODP_PLATFORM_PARAMS:--n 4 --vdev "crypto_openssl"}
+export ODP_PLATFORM_PARAMS=${ODP_PLATFORM_PARAMS:--n 4 "--vdev \
+"crypto_openssl" --vdev "crypto_null""}
 # where to mount huge pages
 export HUGEPAGEDIR=${HUGEPAGEDIR:-/mnt/huge}
 

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -303,6 +303,7 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 	case ODP_CIPHER_ALG_3DES_CBC:
 		ipsec_sa->esp_iv_len = 8;
 		ipsec_sa->esp_block_len = 8;
+		crypto_param.iv.length = 8;
 		break;
 #if ODP_DEPRECATED_API
 	case ODP_CIPHER_ALG_AES128_CBC:
@@ -310,6 +311,7 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 	case ODP_CIPHER_ALG_AES_CBC:
 		ipsec_sa->esp_iv_len = 16;
 		ipsec_sa->esp_block_len = 16;
+		crypto_param.iv.length = 16;
 		break;
 #if ODP_DEPRECATED_API
 	case ODP_CIPHER_ALG_AES128_GCM:

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -429,6 +429,7 @@ create_session_from_config(odp_crypto_session_t *session,
 	odp_crypto_session_param_init(&params);
 	memcpy(&params, &config->session, sizeof(odp_crypto_session_param_t));
 	params.op = ODP_CRYPTO_OP_ENCODE;
+	params.auth_cipher_text = 1;
 	params.pref_mode   = ODP_CRYPTO_SYNC;
 
 	/* Lookup the packet pool */

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -119,7 +119,8 @@ static void pktio_stop(odp_pktio_t pktio)
 int ipsec_check(odp_bool_t ah,
 		odp_cipher_alg_t cipher,
 		uint32_t cipher_bits,
-		odp_auth_alg_t auth)
+		odp_auth_alg_t auth,
+		uint32_t auth_bits)
 {
 	odp_ipsec_capability_t capa;
 	odp_crypto_cipher_capability_t cipher_capa[MAX_ALG_CAPA];
@@ -220,13 +221,26 @@ int ipsec_check(odp_bool_t ah,
 	}
 
 	if (!found) {
-		fprintf(stderr, "Unsupported key length\n");
+		fprintf(stderr, "Unsupported cipher key length\n");
 		return ODP_TEST_INACTIVE;
 	}
 
+	found = false;
 	num = odp_ipsec_auth_capability(auth, auth_capa, MAX_ALG_CAPA);
 	if (num <= 0) {
 		fprintf(stderr, "Wrong auth capabilities\n");
+		return ODP_TEST_INACTIVE;
+	}
+
+	for (i = 0; i < num; i++) {
+		if (auth_capa[i].key_len == auth_bits / 8) {
+			found = 1;
+			break;
+		}
+	}
+
+	if (!found) {
+		fprintf(stderr, "Unsupported auth key length\n");
 		return ODP_TEST_INACTIVE;
 	}
 
@@ -235,37 +249,37 @@ int ipsec_check(odp_bool_t ah,
 
 int ipsec_check_ah_sha256(void)
 {
-	return ipsec_check_ah(ODP_AUTH_ALG_SHA256_HMAC);
+	return ipsec_check_ah(ODP_AUTH_ALG_SHA256_HMAC, 256);
 }
 
 int ipsec_check_esp_null_sha256(void)
 {
 	return  ipsec_check_esp(ODP_CIPHER_ALG_NULL, 0,
-				ODP_AUTH_ALG_SHA256_HMAC);
+				ODP_AUTH_ALG_SHA256_HMAC, 256);
 }
 
 int ipsec_check_esp_aes_cbc_128_null(void)
 {
 	return  ipsec_check_esp(ODP_CIPHER_ALG_AES_CBC, 128,
-				ODP_AUTH_ALG_NULL);
+				ODP_AUTH_ALG_NULL, 0);
 }
 
 int ipsec_check_esp_aes_cbc_128_sha256(void)
 {
 	return  ipsec_check_esp(ODP_CIPHER_ALG_AES_CBC, 128,
-				ODP_AUTH_ALG_SHA256_HMAC);
+				ODP_AUTH_ALG_SHA256_HMAC, 256);
 }
 
 int ipsec_check_esp_aes_gcm_128(void)
 {
 	return  ipsec_check_esp(ODP_CIPHER_ALG_AES_GCM, 128,
-				ODP_AUTH_ALG_AES_GCM);
+				ODP_AUTH_ALG_AES_GCM, 128);
 }
 
 int ipsec_check_esp_aes_gcm_256(void)
 {
 	return  ipsec_check_esp(ODP_CIPHER_ALG_AES_GCM, 256,
-				ODP_AUTH_ALG_AES_GCM);
+				ODP_AUTH_ALG_AES_GCM, 256);
 }
 
 void ipsec_sa_param_fill(odp_ipsec_sa_param_t *param,

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -74,16 +74,16 @@ void ipsec_check_out_in_one(const ipsec_test_part *part,
 int ipsec_check(odp_bool_t ah,
 		odp_cipher_alg_t cipher,
 		uint32_t cipher_bits,
-		odp_auth_alg_t auth);
-#define ipsec_check_ah(auth) \
-	ipsec_check(true, ODP_CIPHER_ALG_NULL, 0, auth)
-#define ipsec_check_esp(cipher, cipher_bits, auth) \
-	ipsec_check(false, cipher, cipher_bits, auth)
+		odp_auth_alg_t auth,
+		uint32_t auth_bits);
+#define ipsec_check_ah(auth, auth_bits) \
+	ipsec_check(true, ODP_CIPHER_ALG_NULL, 0, auth, auth_bits)
+#define ipsec_check_esp(cipher, cipher_bits, auth, auth_bits) \
+	ipsec_check(false, cipher, cipher_bits, auth, auth_bits)
 int ipsec_check_ah_sha256(void);
 int ipsec_check_esp_null_sha256(void);
 int ipsec_check_esp_aes_cbc_128_null(void);
 int ipsec_check_esp_aes_cbc_128_sha256(void);
 int ipsec_check_esp_aes_gcm_128(void);
 int ipsec_check_esp_aes_gcm_256(void);
-
 #endif


### PR DESCRIPTION
This patch introduces the support for Cipher only & Auth only crypto operation