### PR TITLE
[PATCH API-NEXT v2] Icmp camelcase

### DIFF
--- a/example/generator/odp_generator.c
+++ b/example/generator/odp_generator.c
@@ -426,7 +426,7 @@ static odp_packet_t setup_icmp_pkt_ref(odp_pool_t pool,
 	ip->ttl = 64;
 	ip->tot_len = odp_cpu_to_be_16(args->appl.payload + ODPH_ICMPHDR_LEN +
 				       ODPH_IPV4HDR_LEN);
-	ip->proto = ODPH_IPPROTO_ICMPv4;
+	ip->proto = ODPH_IPPROTO_ICMPV4;
 	ip->id = 0;
 	ip->chksum = 0;
 
@@ -806,7 +806,7 @@ static void print_pkts(int thr, thread_args_t *thr_args,
 			thr_args->counters.ctr_udp_rcv++;
 
 		/* icmp */
-		if (ip->proto == ODPH_IPPROTO_ICMPv4) {
+		if (ip->proto == ODPH_IPPROTO_ICMPV4) {
 			icmp = (odph_icmphdr_t *)(buf + offset);
 
 			process_icmp_pkt(thr_args, icmp, msg);

--- a/example/ipsec/odp_ipsec_stream.c
+++ b/example/ipsec/odp_ipsec_stream.c
@@ -217,7 +217,7 @@ odp_packet_t create_ipv4_packet(stream_db_entry_t *stream,
 		ip->src_addr = odp_cpu_to_be_32(entry->tun_src_ip);
 		ip->dst_addr = odp_cpu_to_be_32(entry->tun_dst_ip);
 	} else {
-		ip->proto = ODPH_IPPROTO_ICMPv4;
+		ip->proto = ODPH_IPPROTO_ICMPV4;
 		ip->src_addr = odp_cpu_to_be_32(stream->src_ip);
 		ip->dst_addr = odp_cpu_to_be_32(stream->dst_ip);
 	}
@@ -260,7 +260,7 @@ odp_packet_t create_ipv4_packet(stream_db_entry_t *stream,
 		inner_ip = (odph_ipv4hdr_t *)data;
 		memset((char *)inner_ip, 0, sizeof(*inner_ip));
 		inner_ip->ver_ihl = 0x45;
-		inner_ip->proto = ODPH_IPPROTO_ICMPv4;
+		inner_ip->proto = ODPH_IPPROTO_ICMPV4;
 		inner_ip->id = odp_cpu_to_be_16(stream->id);
 		inner_ip->ttl = 64;
 		inner_ip->tos = 0;
@@ -518,7 +518,7 @@ clear_packet:
 		icmp = (odph_icmphdr_t *)(inner_ip + 1);
 		data = (uint8_t *)icmp;
 	} else {
-		if (ODPH_IPPROTO_ICMPv4 != ip->proto)
+		if (ODPH_IPPROTO_ICMPV4 != ip->proto)
 			return FALSE;
 		icmp = (odph_icmphdr_t *)data;
 	}

--- a/helper/include/odp/helper/ip.h
+++ b/helper/include/odp/helper/ip.h
@@ -251,14 +251,14 @@ typedef struct ODP_PACKED {
  * IP protocol values (IPv4:'proto' or IPv6:'next_hdr')
  * @{*/
 #define ODPH_IPPROTO_HOPOPTS 0x00 /**< IPv6 hop-by-hop options */
-#define ODPH_IPPROTO_ICMPv4  0x01 /**< Internet Control Message Protocol (1) */
+#define ODPH_IPPROTO_ICMPV4  0x01 /**< Internet Control Message Protocol (1) */
 #define ODPH_IPPROTO_TCP     0x06 /**< Transmission Control Protocol (6) */
 #define ODPH_IPPROTO_UDP     0x11 /**< User Datagram Protocol (17) */
 #define ODPH_IPPROTO_ROUTE   0x2B /**< IPv6 Routing header (43) */
 #define ODPH_IPPROTO_FRAG    0x2C /**< IPv6 Fragment (44) */
 #define ODPH_IPPROTO_AH      0x33 /**< Authentication Header (51) */
 #define ODPH_IPPROTO_ESP     0x32 /**< Encapsulating Security Payload (50) */
-#define ODPH_IPPROTO_ICMPv6  0x3A /**< Internet Control Message Protocol (58) */
+#define ODPH_IPPROTO_ICMPV6  0x3A /**< Internet Control Message Protocol (58) */
 #define ODPH_IPPROTO_INVALID 0xFF /**< Reserved invalid by IANA */
 
 /**@}*/

--- a/platform/linux-generic/include/protocols/ip.h
+++ b/platform/linux-generic/include/protocols/ip.h
@@ -157,7 +157,7 @@ typedef struct ODP_PACKED {
  * IP protocol values (IPv4:'proto' or IPv6:'next_hdr')
  * @{*/
 #define _ODP_IPPROTO_HOPOPTS 0x00 /**< IPv6 hop-by-hop options */
-#define _ODP_IPPROTO_ICMPv4  0x01 /**< Internet Control Message Protocol (1) */
+#define _ODP_IPPROTO_ICMPV4  0x01 /**< Internet Control Message Protocol (1) */
 #define _ODP_IPPROTO_IPIP    0x04 /**< IP Encapsulation within IP (4) */
 #define _ODP_IPPROTO_TCP     0x06 /**< Transmission Control Protocol (6) */
 #define _ODP_IPPROTO_UDP     0x11 /**< User Datagram Protocol (17) */
@@ -166,7 +166,7 @@ typedef struct ODP_PACKED {
 #define _ODP_IPPROTO_FRAG    0x2C /**< IPv6 Fragment (44) */
 #define _ODP_IPPROTO_AH      0x33 /**< Authentication Header (51) */
 #define _ODP_IPPROTO_ESP     0x32 /**< Encapsulating Security Payload (50) */
-#define _ODP_IPPROTO_ICMPv6  0x3A /**< Internet Control Message Protocol (58) */
+#define _ODP_IPPROTO_ICMPV6  0x3A /**< Internet Control Message Protocol (58) */
 #define _ODP_IPPROTO_DEST    0x3C /**< IPv6 Destination header (60) */
 #define _ODP_IPPROTO_SCTP    0x84 /**< Stream Control Transmission protocol
 				       (132) */

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2220,10 +2220,10 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 
 	/* Parse Layer 4 headers */
 	switch (ip_proto) {
-	case _ODP_IPPROTO_ICMPv4:
+	case _ODP_IPPROTO_ICMPV4:
 	/* Fall through */
 
-	case _ODP_IPPROTO_ICMPv6:
+	case _ODP_IPPROTO_ICMPV6:
 		prs->input_flags.icmp = 1;
 		break;
 


### PR DESCRIPTION
Change ODP_PROTO_ICMPv4 and v6 to ODP_PROTO_ICMPV4/V6 to eliminate camelcase warnings.

Also add ODPH_PROTO_ICMPV4/V6 and update ODP examples that reference them. The original camelcase forms are retained for compatibility since helpers are part of the published API.