### PR TITLE
[PATCH v19] Validate checksums during packet parsing

### DIFF
--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -98,6 +98,7 @@ typedef union {
 		uint64_t l3_chksum_done:1; /* L3 checksum validation done */
 		uint64_t l4_chksum_done:1; /* L4 checksum validation done */
 		uint64_t ipsec_udp:1; /* UDP-encapsulated IPsec packet */
+		uint64_t udp_chksum_zero:1; /* UDP header had 0 as chksum */
 	};
 
 } _odp_packet_input_flags_t;

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -252,7 +252,8 @@ int packet_alloc_multi(odp_pool_t pool_hdl, uint32_t len,
 
 /* Perform packet parse up to a given protocol layer */
 int packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
-		       odp_proto_layer_t layer);
+		       odp_proto_layer_t layer,
+		       odp_proto_chksums_t chksums);
 
 /* Reset parser metadata for a new parse */
 void packet_parse_reset(odp_packet_hdr_t *pkt_hdr);
@@ -293,7 +294,8 @@ static inline void packet_set_ts(odp_packet_hdr_t *pkt_hdr, odp_time_t *ts)
 }
 
 int packet_parse_common(packet_parser_t *pkt_hdr, const uint8_t *ptr,
-			uint32_t pkt_len, uint32_t seg_len, int layer);
+			uint32_t pkt_len, uint32_t seg_len, int layer,
+			odp_proto_chksums_t chksums);
 
 int _odp_cls_parse(odp_packet_hdr_t *pkt_hdr, const uint8_t *parseptr);
 

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -155,6 +155,7 @@ struct pktio_entry {
 	odp_pktio_config_t config;	/**< Device configuration */
 	classifier_t cls;		/**< classifier linked with this pktio*/
 	odp_pktio_stats_t stats;	/**< statistic counters for pktio */
+	odp_proto_chksums_t in_chksums; /**< Checksums validation settings */
 	enum {
 		STATS_SYSFS = 0,
 		STATS_ETHTOOL,

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -998,7 +998,8 @@ int cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 		packet_set_len(pkt_hdr, pkt_len);
 
 		packet_parse_common(&pkt_hdr->p, base, pkt_len, seg_len,
-				    ODP_PROTO_LAYER_ALL);
+				    ODP_PROTO_LAYER_ALL,
+				    entry->s.in_chksums);
 	}
 	cos = cls_select_cos(entry, base, pkt_hdr);
 

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -456,6 +456,12 @@ int odp_pktio_config(odp_pktio_t hdl, const odp_pktio_config_t *config)
 
 	entry->s.config = *config;
 
+	entry->s.in_chksums.all_chksum = 0;
+	entry->s.in_chksums.chksum.ipv4 = config->pktin.bit.ipv4_chksum;
+	entry->s.in_chksums.chksum.tcp = config->pktin.bit.tcp_chksum;
+	entry->s.in_chksums.chksum.udp = config->pktin.bit.udp_chksum;
+	entry->s.in_chksums.chksum.sctp = config->pktin.bit.sctp_chksum;
+
 	if (entry->s.ops->config)
 		res = entry->s.ops->config(entry, config);
 

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -151,7 +151,8 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			}
 		} else {
 			packet_parse_layer(pkt_hdr,
-					   pktio_entry->s.config.parser.layer);
+					   pktio_entry->s.config.parser.layer,
+					   pktio_entry->s.in_chksums);
 		}
 
 		packet_set_ts(pkt_hdr, ts);

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -357,6 +357,9 @@ static int loopback_init_capability(pktio_entry_t *pktio_entry)
 	odp_pktio_config_init(&capa->config);
 	capa->config.pktin.bit.ts_all = 1;
 	capa->config.pktin.bit.ts_ptp = 1;
+	capa->config.pktin.bit.ipv4_chksum = 1;
+	capa->config.pktin.bit.tcp_chksum = 1;
+	capa->config.pktin.bit.udp_chksum = 1;
 	capa->config.pktout.bit.ipv4_chksum = 1;
 	capa->config.pktout.bit.tcp_chksum = 1;
 	capa->config.pktout.bit.udp_chksum = 1;

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -724,7 +724,8 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 			copy_packet_cls_metadata(&parsed_hdr, pkt_hdr);
 		else
 			packet_parse_layer(pkt_hdr,
-					   pktio_entry->s.config.parser.layer);
+					   pktio_entry->s.config.parser.layer,
+					   pktio_entry->s.in_chksums);
 
 		packet_set_ts(pkt_hdr, ts);
 	}

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -256,7 +256,8 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 		}
 
 		packet_parse_layer(pkt_hdr,
-				   pktio_entry->s.config.parser.layer);
+				   pktio_entry->s.config.parser.layer,
+				   pktio_entry->s.in_chksums);
 		pktio_entry->s.stats.in_octets += pkt_hdr->frame_len;
 
 		packet_set_ts(pkt_hdr, ts);

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -682,7 +682,8 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 		if (!pktio_cls_enabled(pktio_entry))
 			packet_parse_layer(pkt_hdr,
-					   pktio_entry->s.config.parser.layer);
+					   pktio_entry->s.config.parser.layer,
+					   pktio_entry->s.in_chksums);
 
 		pkt_hdr->input = pktio_entry->s.handle;
 		packet_set_ts(pkt_hdr, ts);

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -259,7 +259,8 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 			copy_packet_cls_metadata(&parsed_hdr, hdr);
 		else
 			packet_parse_layer(hdr,
-					   pktio_entry->s.config.parser.layer);
+					   pktio_entry->s.config.parser.layer,
+					   pktio_entry->s.in_chksums);
 
 		packet_set_ts(hdr, ts);
 

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -286,7 +286,8 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 		copy_packet_cls_metadata(&parsed_hdr, pkt_hdr);
 	else
 		packet_parse_layer(pkt_hdr,
-				   pktio_entry->s.config.parser.layer);
+				   pktio_entry->s.config.parser.layer,
+				   pktio_entry->s.in_chksums);
 
 	packet_set_ts(pkt_hdr, ts);
 	pkt_hdr->input = pktio_entry->s.handle;


### PR DESCRIPTION
software checksum validation/insertion.

TODO:
 - SCTP (also is not supported for hardware-based DPDK PktIO).