### PR TITLE
[PATCH v7] Support linking tests/examples dynamically with libodp-linux.so

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ env:
         - CONF="--enable-schedule-iquery"
         - CONF="--enable-schedule-scalable"
         - CONF="--enable-dpdk-zero-copy"
+        - CONF="--disable-static-applications"
         - CROSS_ARCH="arm64"
         - CROSS_ARCH="armhf" CFLAGS="-march=armv7-a"
         - CROSS_ARCH="powerpc"

--- a/configure.ac
+++ b/configure.ac
@@ -183,6 +183,16 @@ AC_DEFINE_UNQUOTED([IMPLEMENTATION_NAME], ["$IMPLEMENTATION_NAME"],
 		   [Define to the name of the implementation])
 
 ##########################################################################
+# Build examples/tests dynamically
+##########################################################################
+AC_ARG_ENABLE([static-applications],
+	      [AS_HELP_STRING([--disable-static-applications],
+			      [disable static linking of examples and tests]
+			      [ with ODP])], [],
+	      [enable_static_applications=yes])
+AM_CONDITIONAL([STATIC_APPS], [test "x$enable_static_applications" != "xno"])
+
+##########################################################################
 # Include m4 files
 ##########################################################################
 m4_include([./doc/m4/configure.m4])
@@ -393,6 +403,7 @@ AC_MSG_RESULT([
 	Deprecated APIs:	${deprecated}
 	debug:			${enable_debug}
 	cunit:			${cunit_support}
+	static tests linkage:	${enable_static_applications}
 	test_vald:		${test_vald}
 	test_perf:		${test_perf}
 	test_perf_proc:		${test_perf_proc}

--- a/example/Makefile.inc
+++ b/example/Makefile.inc
@@ -2,11 +2,21 @@ include $(top_srcdir)/Makefile.inc
 
 TESTS_ENVIRONMENT = EXEEXT=${EXEEXT}
 
-LDADD = $(LIB)/libodp-linux.la $(LIB)/libodphelper.la $(DPDK_LIBS_LT)
+LDADD = $(LIB)/libodp-linux.la $(LIB)/libodphelper.la
+
+# Do not link to DPDK twice in case of dynamic linking with ODP
+if STATIC_APPS
+LDADD += $(DPDK_LIBS_LT)
+endif
+
 AM_CFLAGS = \
 	-I$(srcdir) \
 	-I$(top_srcdir)/example \
 	$(ODP_INCLUDES) \
 	$(HELPER_INCLUDES)
 
+if STATIC_APPS
 AM_LDFLAGS = -L$(LIB) -static
+else
+AM_LDFLAGS =
+endif

--- a/platform/linux-generic/test/Makefile.am
+++ b/platform/linux-generic/test/Makefile.am
@@ -6,8 +6,7 @@ SUBDIRS = performance
 if test_vald
 TESTS = validation/api/pktio/pktio_run.sh \
 	validation/api/pktio/pktio_run_tap.sh \
-	validation/api/shmem/shmem_linux$(EXEEXT) \
-	ring/ring_main$(EXEEXT)
+	validation/api/shmem/shmem_linux$(EXEEXT)
 
 SUBDIRS += validation/api/pktio\
 	   validation/api/shmem\

--- a/platform/linux-generic/test/ring/Makefile.am
+++ b/platform/linux-generic/test/ring/Makefile.am
@@ -1,3 +1,7 @@
+# ring test uses internal symbols from libodp-linux which are not available
+# when linking test with libodp-linux.so
+if STATIC_APPS
+
 include $(top_srcdir)/test/Makefile.inc
 
 test_PROGRAMS = ring_main
@@ -6,7 +10,27 @@ ring_main_SOURCES = \
 		    ring_suites.c ring_suites.h \
 		    ring_basic.c ring_stress.c
 
+TESTS = ring_main$(EXEEXT)
+
 PRELDADD += $(LIBCUNIT_COMMON)
 
-AM_CPPFLAGS += \
-		     -I$(top_srcdir)/platform/linux-generic/include
+AM_CPPFLAGS += -I$(top_srcdir)/platform/linux-generic/include
+
+TESTNAME = linux-generic-ring
+
+TESTENV = tests-$(TESTNAME).env
+
+test_DATA = $(TESTENV)
+
+DISTCLEANFILES = $(TESTENV)
+.PHONY: $(TESTENV)
+$(TESTENV):
+	echo "TESTS=\"$(TESTS)\""    > $@
+	echo "$(TESTS_ENVIRONMENT)" >> $@
+	echo "$(LOG_COMPILER)"      >> $@
+
+if test_installdir
+installcheck-local:
+	$(DESTDIR)/$(testdir)/run-test.sh $(TESTNAME)
+endif
+endif

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -11,16 +11,26 @@ LIBTHRMASK_COMMON = $(COMMON_DIR)/libthrmask_common.la
 #in the following line, the libs using the symbols should come before
 #the libs containing them! The includer is given a chance to add things
 #before libodp by setting PRELDADD before the inclusion.
-LDADD = $(PRELDADD) $(LIBODP) $(DPDK_LIBS_LT)
+LDADD = $(PRELDADD) $(LIBODP)
 PRELDADD =
 
 AM_CPPFLAGS = \
 	$(ODP_INCLUDES) \
 	$(HELPER_INCLUDES) \
 	-I$(top_srcdir)/test/common
+
+# Do not link to DPDK twice in case of dynamic linking with ODP
+if STATIC_APPS
+LDADD += $(DPDK_LIBS_LT)
+endif
+
 AM_CFLAGS = $(CUNIT_CFLAGS)
 
+if STATIC_APPS
 AM_LDFLAGS = -L$(LIB) -static
+else
+AM_LDFLAGS =
+endif
 
 @VALGRIND_CHECK_RULES@
 


### PR DESCRIPTION
Distributions won't like statically-linked binaries. Provide configure switch to link examples and tests dynamically.