### PR TITLE
[PATCH CATERPILLAR v3] pktio: honor config.h settings

### DIFF
--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -145,7 +145,7 @@ typedef struct {
 	/* Result for crypto packet op */
 	odp_crypto_packet_result_t crypto_op_result;
 
-#ifdef ODP_PKTIO_DPDK
+#if defined(ODP_PKTIO_DPDK) && ODP_PKTIO_DPDK == 1
 	/* Type of extra data */
 	uint8_t extra_type;
 	/* Extra space for packet descriptors. E.g. DPDK mbuf  */

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -6,7 +6,7 @@
 
 #include "config.h"
 
-#ifdef ODP_PKTIO_DPDK
+#if defined(ODP_PKTIO_DPDK) && ODP_PKTIO_DPDK == 1
 
 #include <odp_posix_extensions.h>
 

--- a/platform/linux-generic/pktio/dpdk.h
+++ b/platform/linux-generic/pktio/dpdk.h
@@ -13,7 +13,7 @@
 
 #include <net/if.h>
 
-#ifdef ODP_PKTIO_DPDK
+#if defined(ODP_PKTIO_DPDK) && ODP_PKTIO_DPDK == 1
 #include <rte_config.h>
 #include <rte_mbuf.h>
 

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -6,7 +6,7 @@
 
 #include "config.h"
 
-#ifdef ODP_PKTIO_IPC
+#if defined(ODP_PKTIO_IPC) && ODP_PKTIO_IPC == 1
 
 #include <odp_debug_internal.h>
 #include <odp_packet_io_internal.h>

--- a/platform/linux-generic/pktio/mdev.c
+++ b/platform/linux-generic/pktio/mdev.c
@@ -6,7 +6,7 @@
 
 #include "config.h"
 
-#ifdef ODP_MDEV
+#if defined(ODP_MDEV) && ODP_MDEV == 1
 
 #include <dirent.h>
 #include <errno.h>

--- a/platform/linux-generic/pktio/mdev/cxgb4.c
+++ b/platform/linux-generic/pktio/mdev/cxgb4.c
@@ -6,7 +6,7 @@
 
 #include "config.h"
 
-#ifdef ODP_MDEV
+#if defined(ODP_MDEV) && ODP_MDEV == 1
 
 #include <linux/types.h>
 #include <protocols/eth.h>

--- a/platform/linux-generic/pktio/mdev/i40e.c
+++ b/platform/linux-generic/pktio/mdev/i40e.c
@@ -6,7 +6,7 @@
 
 #include "config.h"
 
-#ifdef ODP_MDEV
+#if defined(ODP_MDEV) && ODP_MDEV == 1
 
 #include <linux/types.h>
 #include <protocols/eth.h>

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -6,7 +6,7 @@
 
 #include "config.h"
 
-#ifdef ODP_NETMAP
+#if defined(ODP_NETMAP) && ODP_NETMAP == 1
 
 #include <odp_posix_extensions.h>
 

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -7,7 +7,7 @@
 
 #include "config.h"
 
-#ifdef ODP_PKTIO_SOCKET
+#if defined(ODP_PKTIO_SOCKET) && ODP_PKTIO_SOCKET == 1
 
 #include <odp_posix_extensions.h>
 

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -7,7 +7,7 @@
 
 #include "config.h"
 
-#ifdef ODP_PKTIO_SOCKET_MMAP
+#if defined(ODP_PKTIO_SOCKET_MMAP) && ODP_PKTIO_SOCKET_MMAP == 1
 
 #include <odp_posix_extensions.h>
 

--- a/platform/linux-generic/pktio/subsystem.c
+++ b/platform/linux-generic/pktio/subsystem.c
@@ -22,29 +22,29 @@ ODP_SUBSYSTEM_FOREACH_TEMPLATE(pktio_ops, term_global, ODP_ABORT)
 /* Temporary variable to enable link modules,
  * will remove in Makefile scheme changes.
  */
-#ifdef ODP_PKTIO_DPDK
+#if defined(ODP_PKTIO_DPDK) && ODP_PKTIO_DPDK == 1
 extern int enable_link_dpdk_pktio_ops;
 #endif
-#ifdef ODP_PKTIO_IPC
+#if defined(ODP_PKTIO_IPC) && ODP_PKTIO_IPC == 1
 extern int enable_link_ipc_pktio_ops;
 #endif
 extern int enable_link_loopback_pktio_ops;
-#ifdef ODP_NETMAP
+#if defined(ODP_NETMAP) && ODP_NETMAP == 1
 extern int enable_link_netmap_pktio_ops;
 #endif
-#ifdef HAVE_PCAP
+#if defined(HAVE_PCAP) && HAVE_PCAP == 1
 extern int enable_link_pcap_pktio_ops;
 #endif
-#ifdef ODP_PKTIO_SOCKET
+#if defined(ODP_PKTIO_SOCKET) && ODP_PKTIO_SOCKET == 1
 extern int enable_link_socket_pktio_ops;
 #endif
-#ifdef ODP_PKTIO_SOCKET_MMAP
+#if defined(ODP_PKTIO_SOCKET_MMAP) && ODP_PKTIO_SOCKET_MMAP == 1
 extern int enable_link_socket_mmap_pktio_ops;
 #endif
-#ifdef ODP_PKTIO_TAP
+#if defined(ODP_PKTIO_TAP) && ODP_PKTIO_TAP == 1
 extern int enable_link_tap_pktio_ops;
 #endif
-#ifdef ODP_MDEV
+#if defined(ODP_MDEV) && ODP_MDEV == 1
 extern int enable_link_cxgb4_pktio_ops;
 extern int enable_link_i40e_pktio_ops;
 #endif
@@ -55,29 +55,29 @@ ODP_SUBSYSTEM_CONSTRUCTOR(pktio_ops)
 
 	/* Further initialization per subsystem */
 
-#ifdef ODP_PKTIO_DPDK
+#if defined(ODP_PKTIO_DPDK) && ODP_PKTIO_DPDK == 1
 	enable_link_dpdk_pktio_ops = 1;
 #endif
-#ifdef ODP_PKTIO_IPC
+#if defined(ODP_PKTIO_IPC) && ODP_PKTIO_IPC == 1
 	enable_link_ipc_pktio_ops = 1;
 #endif
 	enable_link_loopback_pktio_ops = 1;
-#ifdef ODP_NETMAP
+#if defined(ODP_NETMAP) && ODP_NETMAP == 1
 	enable_link_netmap_pktio_ops = 1;
 #endif
-#ifdef HAVE_PCAP
+#if defined(HAVE_PCAP) && HAVE_PCAP == 1
 	enable_link_pcap_pktio_ops = 1;
 #endif
-#ifdef ODP_PKTIO_SOCKET
+#if defined(ODP_PKTIO_SOCKET) && ODP_PKTIO_SOCKET == 1
 	enable_link_socket_pktio_ops = 1;
 #endif
-#ifdef ODP_PKTIO_SOCKET_MMAP
+#if defined(ODP_PKTIO_SOCKET_MMAP) && ODP_PKTIO_SOCKET_MMAP == 1
 	enable_link_socket_mmap_pktio_ops = 1;
 #endif
-#ifdef ODP_PKTIO_TAP
+#if defined(ODP_PKTIO_TAP) && ODP_PKTIO_TAP == 1
 	enable_link_tap_pktio_ops = 1;
 #endif
-#ifdef ODP_MDEV
+#if defined(ODP_MDEV) && ODP_MDEV == 1
 	enable_link_cxgb4_pktio_ops = 1;
 	enable_link_i40e_pktio_ops = 1;
 #endif

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -6,7 +6,7 @@
 
 #include "config.h"
 
-#ifdef ODP_PKTIO_TAP
+#if defined(ODP_PKTIO_TAP) && ODP_PKTIO_TAP == 1
 
 /**
  * @file


### PR DESCRIPTION
It's not enough to chech if a macro is defined to enable or disable a
pktio, we also need to check if it is set to 1 as per its description.

Signed-off-by: Josep Puigdemont <josep.puigdemont@linaro.org>