### PR TITLE
[PATCH v5] enable linux helpers by default

### DIFF
--- a/helper/m4/configure.m4
+++ b/helper/m4/configure.m4
@@ -8,15 +8,12 @@ AC_ARG_ENABLE([test-helper],
 AM_CONDITIONAL([test_helper], [test x$test_helper = xyes ])
 
 ##########################################################################
-# Enable/disable helper-ext
-# platform specific non portable extensions
+# Enable/disable Linux helpers
 ##########################################################################
-helper_linux=no
 AC_ARG_ENABLE([helper-linux],
-	[  --enable-helper-linux	build helper platform extensions (not portable)],
-	[if test "x$enableval" = "xyes"; then
-		helper_linux=yes
-	fi])
+    [AS_HELP_STRING([--disable-helper-linux], [disable Linux helpers])],
+    [helper_linux=$enableval],
+    [helper_linux=yes])
 
 AC_CONFIG_FILES([helper/Makefile
 		 helper/libodphelper.pc


### PR DESCRIPTION
Enable Linux helpers by default as e.g. OFP uses those. Build
and test helper code does not add significant overhead, but
catches potential issues early.

Signed-off-by: Petri Savolainen <petri.savolainen@linaro.org>