### PR TITLE
[PATCH API-NEXT v5] api: ipsec: TFC padding and dummy packets

### DIFF
--- a/include/odp/api/abi-default/packet.h
+++ b/include/odp/api/abi-default/packet.h
@@ -30,6 +30,34 @@ typedef _odp_abi_packet_seg_t *odp_packet_seg_t;
 #define ODP_PACKET_SEG_INVALID    ((odp_packet_seg_t)0xffffffff)
 #define ODP_PACKET_OFFSET_INVALID 0xffff
 
+typedef uint8_t odp_proto_l3_type_t;
+
+#define ODP_PROTO_L3_TYPE_NONE   0
+#define ODP_PROTO_L3_TYPE_ARP    1
+#define ODP_PROTO_L3_TYPE_RARP   2
+#define ODP_PROTO_L3_TYPE_MPLS   3
+#define ODP_PROTO_L3_TYPE_IPV4   4
+#define ODP_PROTO_L3_TYPE_IPV6   6
+
+typedef uint8_t odp_proto_l4_type_t;
+
+/* Numbers from IANA Assigned Internet Protocol Numbers list */
+#define ODP_PROTO_L4_TYPE_NONE      0
+#define ODP_PROTO_L4_TYPE_ICMPV4    1
+#define ODP_PROTO_L4_TYPE_IGMP      2
+#define ODP_PROTO_L4_TYPE_IPV4      4
+#define ODP_PROTO_L4_TYPE_TCP       6
+#define ODP_PROTO_L4_TYPE_UDP       17
+#define ODP_PROTO_L4_TYPE_IPV6      41
+#define ODP_PROTO_L4_TYPE_GRE       47
+#define ODP_PROTO_L4_TYPE_ESP       50
+#define ODP_PROTO_L4_TYPE_AH        51
+#define ODP_PROTO_L4_TYPE_ICMPV6    58
+#define ODP_PROTO_L4_TYPE_NO_NEXT   59
+#define ODP_PROTO_L4_TYPE_IPCOMP    108
+#define ODP_PROTO_L4_TYPE_SCTP      132
+#define ODP_PROTO_L4_TYPE_ROHC      142
+
 typedef enum {
 	ODP_PACKET_GREEN = 0,
 	ODP_PACKET_YELLOW = 1,

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -1226,12 +1226,23 @@ typedef struct odp_ipsec_status_t {
  * e.g. RFC 4302 and 4303). Resulting packets are well formed, reconstructed
  * original IP packets, with IPSEC headers removed and valid header field values
  * restored. The amount and content of packet data before the IP header is
- * undefined.
+ * undefined. Some amount of TFC padding may follow the IP packet payload,
+ * in which case packet length is larger than protocol headers indicate.
+ * TFC dummy packets have l3_type set to ODP_PROTO_L3_TYPE_NONE in tunnel mode
+ * or l4_type set to ODP_PROTO_L4_TYPE_NO_NEXT in transport mode. Dummy
+ * packets contain implementation specific amount of (dummy) data. Furthermore,
+ * inline IPSEC processing may drop dummy packets.
  *
  * Each successfully transformed packet has a valid value for these metadata
  * regardless of the inner packet parse configuration
  * (odp_ipsec_inbound_config_t):
- * - L3 offset: Offset to the first byte of the (outmost) IP header
+ * - l3_offset: Offset to the first byte of the original IP packet. The value
+ *              is implementation specific for tunnel mode TFC dummy packets.
+ * - l3_type:   Specifies if the original packet is IPv4 or IPv6. For tunnel
+ *              mode TFC dummy packets set to ODP_PROTO_L3_TYPE_NONE.
+ * - l4_type:   Always set to ODP_PROTO_L4_TYPE_NO_NEXT for transport mode dummy
+ *              packets. Otherwise, depends on parse configuration. Default
+ *              value is ODP_PROTO_L4_TYPE_NONE.
  * - pktio:     For inline IPSEC processed packets, original packet input
  *              interface
  *

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -983,6 +983,20 @@ typedef struct odp_ipsec_op_flag_t {
  * These may be used to override some SA level options
  */
 typedef struct odp_ipsec_out_opt_t {
+	/** Union of all flag bits */
+	union {
+		/** Option flags. Set flag for those options that are
+		 *  used, all other options are ignored. */
+		struct {
+			/** Use fragmentation mode option */
+			uint32_t frag_mode: 1;
+
+		} flag;
+
+		/** All flag bits */
+		uint32_t all_flags;
+	};
+
 	/** Fragmentation mode */
 	odp_ipsec_frag_mode_t frag_mode;
 

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -238,6 +238,11 @@ typedef struct odp_ipsec_capability_t {
 	 */
 	odp_support_t retain_header;
 
+	/**
+	 * Inner packet checksum check offload support in inbound direction.
+	 */
+	odp_proto_chksums_t chksums_in;
+
 	/** Maximum number of different destination CoSes in classification
 	 *  pipelining. The same CoS may be used for many SAs. This is equal or
 	 *  less than 'max_cos' capability in classifier API.

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -984,7 +984,7 @@ typedef struct odp_ipsec_op_flag_t {
  */
 typedef struct odp_ipsec_out_opt_t {
 	/** Fragmentation mode */
-	odp_ipsec_frag_mode_t mode;
+	odp_ipsec_frag_mode_t frag_mode;
 
 } odp_ipsec_out_opt_t;
 

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -382,6 +382,44 @@ typedef struct odp_ipsec_crypto_param_t {
 
 } odp_ipsec_crypto_param_t;
 
+/** IPv4 header parameters */
+typedef struct odp_ipsec_ipv4_param_t {
+	/** IPv4 source address (NETWORK ENDIAN) */
+	void *src_addr;
+
+	/** IPv4 destination address (NETWORK ENDIAN) */
+	void *dst_addr;
+
+	/** IPv4 Differentiated Services Code Point */
+	uint8_t dscp;
+
+	/** IPv4 Don't Fragment bit */
+	uint8_t df;
+
+	/** IPv4 Time To Live */
+	uint8_t ttl;
+
+} odp_ipsec_ipv4_param_t;
+
+/** IPv6 header parameters */
+typedef struct odp_ipsec_ipv6_param_t {
+	/** IPv6 source address (NETWORK ENDIAN) */
+	void *src_addr;
+
+	/** IPv6 destination address (NETWORK ENDIAN) */
+	void *dst_addr;
+
+	/** IPv6 flow label */
+	uint32_t flabel;
+
+	/** IPv6 Differentiated Services Code Point */
+	uint8_t dscp;
+
+	/** IPv6 hop limit */
+	uint8_t hlimit;
+
+} odp_ipsec_ipv6_param_t;
+
 /**
  * IPSEC tunnel parameters
  *
@@ -397,40 +435,10 @@ typedef struct odp_ipsec_tunnel_param_t {
 	/** Variant mappings for tunnel parameters */
 	union {
 		/** IPv4 header parameters */
-		struct {
-			/** IPv4 source address (NETWORK ENDIAN) */
-			void *src_addr;
-
-			/** IPv4 destination address (NETWORK ENDIAN) */
-			void *dst_addr;
-
-			/** IPv4 Differentiated Services Code Point */
-			uint8_t dscp;
-
-			/** IPv4 Don't Fragment bit */
-			uint8_t df;
-
-			/** IPv4 Time To Live */
-			uint8_t ttl;
-		} ipv4;
+		odp_ipsec_ipv4_param_t ipv4;
 
 		/** IPv6 header parameters */
-		struct {
-			/** IPv6 source address (NETWORK ENDIAN) */
-			void *src_addr;
-
-			/** IPv6 destination address (NETWORK ENDIAN) */
-			void *dst_addr;
-
-			/** IPv6 Differentiated Services Code Point */
-			uint8_t dscp;
-
-			/** IPv6 flow label */
-			uint32_t flabel;
-
-			/** IPv6 hop limit */
-			uint8_t hlimit;
-		} ipv6;
+		odp_ipsec_ipv6_param_t ipv6;
 	};
 } odp_ipsec_tunnel_param_t;
 

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -72,6 +72,79 @@ extern "C" {
   */
 
 /**
+ * @typedef odp_proto_l3_type_t
+ * Layer 3 protocol type
+ */
+
+/**
+ * @def ODP_PROTO_L3_TYPE_NONE
+ * Layer 3 protocol type not defined
+ *
+ * @def ODP_PROTO_L3_TYPE_ARP
+ * Layer 3 protocol is ARP
+ *
+ * @def ODP_PROTO_L3_TYPE_RARP
+ * Layer 3 protocol is RARP
+ *
+ * @def ODP_PROTO_L3_TYPE_MPLS
+ * Layer 3 protocol is MPLS
+ *
+ * @def ODP_PROTO_L3_TYPE_IPV4
+ * Layer 3 protocol type is IPv4
+ *
+ * @def ODP_PROTO_L3_TYPE_IPV6
+ * Layer 3 protocol type is IPv6
+ */
+
+/**
+ * @def ODP_PROTO_L4_TYPE_NONE
+ * Layer 4 protocol type not defined
+ *
+ * @def ODP_PROTO_L4_TYPE_ICMPV4
+ * Layer 4 protocol type is ICMPv4
+ *
+ * @def ODP_PROTO_L4_TYPE_IGMP
+ * Layer 4 protocol type is IGMP
+ *
+ * @def ODP_PROTO_L4_TYPE_IPV4
+ * Layer 4 protocol type is IPv4
+ *
+ * @def ODP_PROTO_L4_TYPE_TCP
+ * Layer 4 protocol type is TCP
+ *
+ * @def ODP_PROTO_L4_TYPE_UDP
+ * Layer 4 protocol type is UDP
+ *
+ * @def ODP_PROTO_L4_TYPE_IPV6
+ * Layer 4 protocol type is IPv6
+ *
+ * @def ODP_PROTO_L4_TYPE_GRE
+ * Layer 4 protocol type is GRE
+ *
+ * @def ODP_PROTO_L4_TYPE_ESP
+ * Layer 4 protocol type is IPSEC ESP
+ *
+ * @def ODP_PROTO_L4_TYPE_AH
+ * Layer 4 protocol type is IPSEC AH
+ *
+ * @def ODP_PROTO_L4_TYPE_ICMPV6
+ * Layer 4 protocol type is ICMPv6
+ *
+ * @def ODP_PROTO_L4_TYPE_NO_NEXT
+ * Layer 4 protocol type is "No Next Header".
+ * Protocol / next header number is 59.
+ *
+ * @def ODP_PROTO_L4_TYPE_IPCOMP
+ * Layer 4 protocol type is IP Payload Compression Protocol
+ *
+ * @def ODP_PROTO_L4_TYPE_SCTP
+ * Layer 4 protocol type is SCTP
+ *
+ * @def ODP_PROTO_L4_TYPE_ROHC
+ * Layer 4 protocol type is ROHC
+ */
+
+/**
  * Protocol
  */
 typedef enum odp_proto_t {
@@ -1541,6 +1614,28 @@ uint32_t odp_packet_l4_offset(odp_packet_t pkt);
  * @retval <0 on failure
  */
 int odp_packet_l4_offset_set(odp_packet_t pkt, uint32_t offset);
+
+/**
+ * Layer 3 protocol type
+ *
+ * Returns layer 3 protocol type. Initial type value is ODP_PROTO_L3_TYPE_NONE.
+ *
+ * @param      pkt      Packet handle
+ *
+ * @return Layer 3 protocol type
+ */
+odp_proto_l3_type_t odp_packet_l3_type(odp_packet_t pkt);
+
+/**
+ * Layer 4 protocol type
+ *
+ * Returns layer 4 protocol type. Initial type value is ODP_PROTO_L4_TYPE_NONE.
+ *
+ * @param      pkt      Packet handle
+ *
+ * @return Layer 4 protocol type
+ */
+odp_proto_l4_type_t odp_packet_l4_type(odp_packet_t pkt);
 
 /**
  * Layer 3 checksum check status

--- a/platform/linux-generic/include-abi/odp/api/abi/packet.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet.h
@@ -47,6 +47,34 @@ static inline odp_packet_seg_t _odp_packet_seg_from_ndx(uint8_t ndx)
 
 #define ODP_PACKET_SEG_INVALID ((odp_packet_seg_t)-1)
 
+typedef uint8_t odp_proto_l3_type_t;
+
+#define ODP_PROTO_L3_TYPE_NONE   0
+#define ODP_PROTO_L3_TYPE_ARP    1
+#define ODP_PROTO_L3_TYPE_RARP   2
+#define ODP_PROTO_L3_TYPE_MPLS   3
+#define ODP_PROTO_L3_TYPE_IPV4   4
+#define ODP_PROTO_L3_TYPE_IPV6   6
+
+typedef uint8_t odp_proto_l4_type_t;
+
+/* Numbers from IANA Assigned Internet Protocol Numbers list */
+#define ODP_PROTO_L4_TYPE_NONE      0
+#define ODP_PROTO_L4_TYPE_ICMPV4    1
+#define ODP_PROTO_L4_TYPE_IGMP      2
+#define ODP_PROTO_L4_TYPE_IPV4      4
+#define ODP_PROTO_L4_TYPE_TCP       6
+#define ODP_PROTO_L4_TYPE_UDP       17
+#define ODP_PROTO_L4_TYPE_IPV6      41
+#define ODP_PROTO_L4_TYPE_GRE       47
+#define ODP_PROTO_L4_TYPE_ESP       50
+#define ODP_PROTO_L4_TYPE_AH        51
+#define ODP_PROTO_L4_TYPE_ICMPV6    58
+#define ODP_PROTO_L4_TYPE_NO_NEXT   59
+#define ODP_PROTO_L4_TYPE_IPCOMP    108
+#define ODP_PROTO_L4_TYPE_SCTP      132
+#define ODP_PROTO_L4_TYPE_ROHC      142
+
 typedef enum {
 	ODP_PACKET_GREEN = 0,
 	ODP_PACKET_YELLOW = 1,

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -1306,7 +1306,7 @@ static ipsec_sa_t *ipsec_out_single(odp_packet_t pkt,
 	ipsec_sa = _odp_ipsec_sa_use(sa);
 	ODP_ASSERT(NULL != ipsec_sa);
 
-	if ((opt && opt->mode == ODP_IPSEC_FRAG_CHECK) ||
+	if ((opt && opt->frag_mode == ODP_IPSEC_FRAG_CHECK) ||
 	    (!opt && ipsec_sa->out.frag_mode == ODP_IPSEC_FRAG_CHECK))
 		mtu = ipsec_sa->out.mtu;
 	else

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -530,7 +530,7 @@ static void test_out_ipv4_ah_sha256_frag_check(void)
 	ipsec_test_part test2 = {
 		.pkt_in = &pkt_ipv4_icmp_0,
 		.num_opt = 1,
-		.opt = { .mode = ODP_IPSEC_FRAG_DISABLED, },
+		.opt = { .frag_mode = ODP_IPSEC_FRAG_DISABLED, },
 		.out_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,
@@ -623,7 +623,7 @@ static void test_out_ipv4_esp_null_sha256_frag_check(void)
 	ipsec_test_part test2 = {
 		.pkt_in = &pkt_ipv4_icmp_0,
 		.num_opt = 1,
-		.opt = { .mode = ODP_IPSEC_FRAG_DISABLED, },
+		.opt = { .frag_mode = ODP_IPSEC_FRAG_DISABLED, },
 		.out_pkt = 1,
 		.out = {
 			{ .status.warn.all = 0,


### PR DESCRIPTION
Specify how application can recognize and create TFC padding and dummy packets, both in inbound and outbound directions.