### PR TITLE
[PATCH CATERPILLAR v4] Code instrumentation with PAPI library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -205,6 +205,16 @@ install:
             fi
             sudo insmod ./netmap/LINUX/netmap.ko
           fi
+#	PAPI library
+        - |
+          if [ -z "$CROSS_ARCH" -a ! -f "$HOME/papi-install/lib/libpapi.so" ]; then
+            git -c advice.detachedHead=false clone -q --depth=1 --single-branch --branch=papi-5-6-0-t https://bitbucket.org/icl/papi.git
+            pushd papi/src
+            ./configure --prefix=$HOME/papi-install
+            make
+            make install
+            popd
+          fi
 
 script:
         - if [ -z "$CROSS_ARCH" ] ; then
@@ -307,6 +317,17 @@ jobs:
                           - ./configure --with-platform=linux-dpdk --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example --with-sdk-install-path=`pwd`/dpdk-17.02/${TARGET} --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH $CONF
                           - make -j $(nproc)
                           - sudo LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" make check
+                - stage: test
+                  env: TEST=code_instrum
+                  compiler: gcc
+                  script:
+                          - ./bootstrap
+                          - ./configure --prefix=$HOME/odp-papi-install --enable-test-cpp --enable-test-vald --enable-test-helper --enable-test-perf --enable-user-guides --enable-test-perf-proc --enable-test-example --with-cunit-path=$HOME/cunit-install/$CROSS_ARCH --with-papi-path=$HOME/papi-install $CONF
+                          - make -j $(nproc)
+                          - make install
+                          - sudo $HOME/papi-install/bin/papi_avail
+                          - mkdir $HOME/store
+                          - sudo LD_LIBRARY_PATH="/usr/local/lib:$HOME/odp-papi-install/lib:$HOME/papi-install/lib:$LD_LIBRARY_PATH" ODP_INSTRUM_STORE_DIR=$HOME/store LD_PRELOAD=libinstrum.so.0.0.0 $HOME/odp-papi-install/bin/odp_generator -I lo --srcmac a0:36:9f:28:e2:57 --dstmac 00:0f:fe:c5:73:66 --srcip 192.168.150.1 --dstip 192.168.150.2 -m u -n 200
 after_failure:
   - cat config.log
   - find . -name "*.trs" | xargs grep -l '^.test-result. FAIL' | while read trs ; do echo FAILURE detected at $trs; cat ${trs%%.trs}.log ; done

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -202,6 +202,88 @@ Prerequisites for building the OpenDataPlane (ODP) API
    1024MB of memory:
    $ sudo ODP_PKTIO_DPDK_PARAMS="-m 1024" ./test/performance/odp_l2fwd -i 0 -c 1
 
+3.5 Code instrumentation with PAPI library (optional)
+
+   PAPI library is used to instrument ODP API.
+
+3.5.1 Building PAPI library
+
+   ODP example library 'instrum' is using PAPI library to retrieve performance
+   counters associated with execution of ODP API. PAPI library is currently at 5.6.0.
+   However, if possible one should try to use the latest PAPI master branch commit for
+   the best performance and the latest bug fixes.
+
+   # Checkout PAPI code
+   $ git clone https://bitbucket.org/icl/papi.git
+   $ cd papi
+   $ git checkout papi-5-6-0-t (optional)
+
+   # Build PAPI
+   $ cd ./src/
+   $ ./configure --prefix=<papi_install_dir>
+   $ make clean
+   $ make
+   $ make install
+
+   Alternatively, one may install PAPI from packages, if available.
+   # apt-get install libpapi-dev
+
+3.5.2 Building ODP with PAPI support
+
+   $ cd <odp_dir>
+   $ ./bootstrap
+   $ ./configure --enable-code-instrum --with-papi-path=<papi_install_dir>
+   $ make clean
+   $ make
+
+   Note 1: Specifying PAPI install path (with '--with-papi-path' option) is not required if
+   PAPI was installed from packages.
+   Note 2: Building ODP with PAPI support forces dynamic linkage of ODP example applications with
+   ODP library.
+
+3.5.3 Configuration of instrumented API set
+
+   Instrumentation profile option can be applied at configure time to select API set to
+   be instrumented. By default, all ODP APIs stated in 'instrum' example are instrumented.
+
+   $ ./configure --with-papi-path=<papi_install_dir> --with-code-instrum-profile=<all|scheduler|pktio_direct>
+
+3.5.4 Running ODP application with code instrumentation
+
+   ODP example library 'instrum' is preloaded before execution of ODP application. ODP application
+   must link dynamically with ODP library.
+
+   # LD_PRELOAD=libinstrum.so.0.0.0 ./odp_application
+
+   Note: ODP and PAPI shared libraries must be accessible at runtime. Use LD_LIBRARY_PATH for
+   non-standard locations.
+
+   # export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<odp_install_dir>/lib:<papi_install_dir>/lib
+
+3.5.5 Retrieving performance counters
+
+   Performance counters are acquired per ODP worker and dumped in fix size sample chunks to CSV files.
+
+   CSV file name is composed as follows: profile_<ODP thread ID>_<sample chunk count>.csv
+
+   Default CSV files storage folder is '/tmp'. Use ODP_INSTRUM_STORE_DIR environment variable to
+   select a different folder.
+
+   # export ODP_INSTRUM_STORE_DIR=<store_dir>
+
+   CSV row contains the counters for execution of one API call: timestamp (ns) for the start of API call,
+   duration (cycles), API name and the differences between end and start for the list of PAPI counters.
+
+3.5.6 Selecting performance counters
+
+   By default, PAPI_BR_CN and PAPI_L2_DCM are acquired. Use ODP_INSTRUM_PAPI_EVENTS environment variable
+   to configure the list of PAPI counters (events).
+
+   # export ODP_INSTRUM_PAPI_EVENTS=PAPI_BR_CN,PAPI_L2_DCM,PAPI_BR_UCN
+
+   Note: Some PAPI counters may not be available for some architectures. Use papi tools 'papi_avail' and
+   'papi_native_avail' to retrieve the list of available counters.
+
 4.0 Packages needed to build API tests
 
    CUnit test framework version 2.1-3 is required

--- a/configure.ac
+++ b/configure.ac
@@ -411,4 +411,5 @@ AC_MSG_RESULT([
 	test_example:		${test_example}
 	user_guides:		${user_guides}
 	mdev:			${mdev_support}
+	code instrumentation:	${code_instrumentation}
 ])

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -13,4 +13,8 @@ SUBDIRS = classifier \
 	  ddf_ifs \
 	  ddf_app
 
+if CODE_INSTRUM
+SUBDIRS += instrum
+endif
+
 noinst_HEADERS = example_debug.h

--- a/example/Makefile.inc
+++ b/example/Makefile.inc
@@ -13,4 +13,8 @@ AM_CFLAGS = \
 	-I$(top_srcdir)/platform/@with_platform@/arch/@ARCH_DIR@ \
 	-I$(top_builddir)/include
 
+if CODE_INSTRUM
+AM_LDFLAGS = -L$(LIB) -lssl -lcrypto -latomic
+else
 AM_LDFLAGS = -L$(LIB) -static
+endif

--- a/example/instrum/Makefile.am
+++ b/example/instrum/Makefile.am
@@ -16,13 +16,11 @@ AM_LDFLAGS = -L$(PAPI_PATH)/lib -lpapi
 
 lib_LTLIBRARIES = $(LIB)/libinstrum.la
 
-__LIB__libinstrum_la_SOURCES = \
+INSTRUM_SRC = \
 		instrum.c \
 		store.c \
 		papi_cnt.c \
 		init.c \
-		pktio_direct.c\
-		sched.c \
 		instrum_common.h \
 		sample.h \
 		store.h \
@@ -30,3 +28,15 @@ __LIB__libinstrum_la_SOURCES = \
 		init.h \
 		pktio_direct.h \
 		sched.h
+
+if CODE_INSTRUM_SCHED
+AM_CFLAGS += -DCODE_INSTRUM_SCHED
+INSTRUM_SRC += sched.c
+endif
+
+if CODE_INSTRUM_PKTIO_DIRECT
+AM_CFLAGS += -DCODE_INSTRUM_PKTIO_DIRECT
+INSTRUM_SRC += pktio_direct.c
+endif
+
+__LIB__libinstrum_la_SOURCES = $(INSTRUM_SRC)

--- a/example/instrum/Makefile.am
+++ b/example/instrum/Makefile.am
@@ -1,0 +1,20 @@
+LIB   = $(top_builddir)/lib
+
+AM_CFLAGS = \
+        -I$(srcdir) \
+        -I$(top_srcdir)/example \
+        -I$(top_srcdir)/platform/@with_platform@/include \
+        -I$(top_srcdir)/include/ \
+        -I$(top_srcdir)/include/odp/arch/@ARCH_ABI@ \
+        -I$(top_srcdir)/helper/include \
+        -I$(top_builddir)/platform/@with_platform@/include \
+        -I$(top_srcdir)/platform/@with_platform@/arch/@ARCH_DIR@ \
+        -I$(top_builddir)/include \
+        -I$(PAPI_PATH)/include
+
+AM_LDFLAGS = -L$(PAPI_PATH)/lib -lpapi
+
+lib_LTLIBRARIES = $(LIB)/libinstrum.la
+
+__LIB__libinstrum_la_SOURCES = \
+		instrum.c

--- a/example/instrum/Makefile.am
+++ b/example/instrum/Makefile.am
@@ -17,4 +17,16 @@ AM_LDFLAGS = -L$(PAPI_PATH)/lib -lpapi
 lib_LTLIBRARIES = $(LIB)/libinstrum.la
 
 __LIB__libinstrum_la_SOURCES = \
-		instrum.c
+		instrum.c \
+		store.c \
+		papi_cnt.c \
+		init.c \
+		pktio_direct.c\
+		sched.c \
+		instrum_common.h \
+		sample.h \
+		store.h \
+		papi_cnt.h \
+		init.h \
+		pktio_direct.h \
+		sched.h

--- a/example/instrum/init.c
+++ b/example/instrum/init.c
@@ -1,0 +1,54 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <odp_api.h>
+#include <instrum_common.h>
+#include <init.h>
+#include <store.h>
+
+static int (*instr_odp_init_local)(odp_instance_t instance,
+				   odp_thread_type_t thr_type);
+
+static int (*instr_odp_term_local)(void);
+
+int instr_odpinit_init(void)
+{
+	INSTR_FUNCTION(odp_init_local);
+
+	if (!instr_odp_init_local) {
+		printf("odp_init_local: Not Found\n");
+		return -1;
+	}
+
+	INSTR_FUNCTION(odp_term_local);
+
+	if (!instr_odp_term_local) {
+		printf("odp_term_local: Not Found\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+int odp_init_local(odp_instance_t instance, odp_thread_type_t thr_type)
+{
+	int ret;
+
+	ret = (*instr_odp_init_local)(instance, thr_type);
+
+	instr_store_init_local();
+
+	return ret;
+}
+
+int odp_term_local(void)
+{
+	instr_store_term_local();
+
+	return (*instr_odp_term_local)();
+}

--- a/example/instrum/init.h
+++ b/example/instrum/init.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef __INSTRUM_INIT_H__
+#define __INSTRUM_INIT_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int instr_odpinit_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /*__INSTRUM_INIT_H__*/

--- a/example/instrum/instrum.c
+++ b/example/instrum/instrum.c
@@ -1,0 +1,18 @@
+/* Copyright (c) 2017, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static __attribute__((constructor)) void setup_wrappers(void)
+{
+	printf("Setup Wrappers\n");
+}
+
+static __attribute__((destructor)) void teardown_wrappers(void)
+{
+	printf("Teardown Wrappers\n");
+}

--- a/example/instrum/instrum.c
+++ b/example/instrum/instrum.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017, Linaro Limited
+/* Copyright (c) 2018, Linaro Limited
  * All rights reserved.
  *
  * SPDX-License-Identifier:     BSD-3-Clause
@@ -6,13 +6,30 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <store.h>
+#include <init.h>
+#include <sched.h>
+#include <pktio_direct.h>
 
 static __attribute__((constructor)) void setup_wrappers(void)
 {
 	printf("Setup Wrappers\n");
+
+	if (instr_store_init())
+		return;
+
+	if (instr_odpinit_init())
+		return;
+
+	if (instr_odpsched_init())
+		return;
+
+	if (instr_odppktio_direct_init())
+		return;
 }
 
 static __attribute__((destructor)) void teardown_wrappers(void)
 {
 	printf("Teardown Wrappers\n");
+	instr_store_term();
 }

--- a/example/instrum/instrum.c
+++ b/example/instrum/instrum.c
@@ -21,11 +21,15 @@ static __attribute__((constructor)) void setup_wrappers(void)
 	if (instr_odpinit_init())
 		return;
 
+#ifdef CODE_INSTRUM_SCHED
 	if (instr_odpsched_init())
 		return;
+#endif /* CODE_INSTRUM_SCHED */
 
+#ifdef CODE_INSTRUM_PKTIO_DIRECT
 	if (instr_odppktio_direct_init())
 		return;
+#endif /* CODE_INSTRUM_PKTIO_DIRECT */
 }
 
 static __attribute__((destructor)) void teardown_wrappers(void)

--- a/example/instrum/instrum_common.h
+++ b/example/instrum/instrum_common.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef __INSTRUM_COMMON_H__
+#define __INSTRUM_COMMON_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef RTLD_NEXT
+/*#define __GNU_SOURCE*/
+#define __USE_GNU
+#endif
+
+#include <dlfcn.h>
+#include <errno.h>
+
+#define INSTR_FUNCTION(func) do {			\
+		instr_##func = dlsym(RTLD_NEXT, #func);	\
+		if (dlerror()) {			\
+			errno = EACCES;			\
+			instr_##func = NULL;	\
+		}					\
+	} while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INSTRUM_COMMON_H__ */

--- a/example/instrum/papi_cnt.c
+++ b/example/instrum/papi_cnt.c
@@ -6,17 +6,25 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <pthread.h>
 #include <papi.h>
 #include <papi_cnt.h>
 
-static int papi_event_tab[SAMPLE_COUNTER_TAB_SIZE] = {PAPI_BR_CN, PAPI_L2_DCM};
+#define PAPI_EVENTS_ENV "ODP_INSTRUM_PAPI_EVENTS"
+
+#define PAPI_EVENT_TAB_SIZE_DFLT 2
+int papi_event_tab_dflt[PAPI_EVENT_TAB_SIZE_DFLT] = {PAPI_BR_CN, PAPI_L2_DCM};
+
+static int papi_event_tab[SAMPLE_COUNTER_TAB_SIZE];
+static int papi_event_tab_size;
 
 static __thread int event_set = PAPI_NULL;
 
 int papi_init(void)
 {
 	int retval, i;
+	char *papi_events_env = NULL;
 
 	retval = PAPI_library_init(PAPI_VER_CURRENT);
 	if (retval != PAPI_VER_CURRENT) {
@@ -35,7 +43,28 @@ int papi_init(void)
 		goto err_shutdown;
 	}
 
-	for (i = 0; i < SAMPLE_COUNTER_TAB_SIZE; i++) {
+	papi_events_env = getenv(PAPI_EVENTS_ENV);
+	if (papi_events_env) {
+		char *tk = strtok(papi_events_env, ",");
+		int papi_event;
+
+		while (tk != NULL &&
+		       papi_event_tab_size < SAMPLE_COUNTER_TAB_SIZE) {
+			if (PAPI_event_name_to_code(tk, &papi_event) == PAPI_OK)
+				papi_event_tab[papi_event_tab_size++] =
+					papi_event;
+
+			tk = strtok(NULL, ",");
+		}
+	}
+
+	if (!papi_event_tab_size) {
+		for (i = 0; i < PAPI_EVENT_TAB_SIZE_DFLT; i++)
+			papi_event_tab[i] = papi_event_tab_dflt[i];
+		papi_event_tab_size = PAPI_EVENT_TAB_SIZE_DFLT;
+	}
+
+	for (i = 0; i < papi_event_tab_size; i++) {
 		retval = PAPI_query_event(papi_event_tab[i]);
 		if (retval != PAPI_OK) {
 			printf("PAPI_query_event %d - error\n", i);
@@ -75,7 +104,7 @@ int papi_init_local(void)
 	}
 
 	retval = PAPI_add_events(event_set, papi_event_tab,
-				 SAMPLE_COUNTER_TAB_SIZE);
+				 papi_event_tab_size);
 	if (retval != PAPI_OK) {
 		printf("PAPI_add_events error: %d\n", retval);
 		goto err_clean_evset;
@@ -103,7 +132,7 @@ int papi_term_local(void)
 	if (PAPI_stop(event_set, last_counters) == PAPI_OK) {
 		int i;
 
-		for (i = 0; i < SAMPLE_COUNTER_TAB_SIZE; i++)
+		for (i = 0; i < papi_event_tab_size; i++)
 			printf("Counter[%d] = %lld\n", i, last_counters[i]);
 	}
 
@@ -111,6 +140,11 @@ int papi_term_local(void)
 	PAPI_destroy_eventset(&event_set);
 
 	return 0;
+}
+
+int papi_counters_cnt(void)
+{
+	return papi_event_tab_size;
 }
 
 int papi_sample_start(profiling_sample_t *spl)
@@ -134,7 +168,7 @@ int papi_sample_end(profiling_sample_t *spl)
 		return -1;
 	}
 
-	for (i = 0; i < SAMPLE_COUNTER_TAB_SIZE; i++)
+	for (i = 0; i < papi_event_tab_size; i++)
 		spl->counters[i] = end_counters[i] - spl->counters[i];
 
 	spl->diff_cyc = end_cyc - spl->diff_cyc;

--- a/example/instrum/papi_cnt.c
+++ b/example/instrum/papi_cnt.c
@@ -1,0 +1,143 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <papi.h>
+#include <papi_cnt.h>
+
+static int papi_event_tab[SAMPLE_COUNTER_TAB_SIZE] = {PAPI_BR_CN, PAPI_L2_DCM};
+
+static __thread int event_set = PAPI_NULL;
+
+int papi_init(void)
+{
+	int retval, i;
+
+	retval = PAPI_library_init(PAPI_VER_CURRENT);
+	if (retval != PAPI_VER_CURRENT) {
+		printf("PAPI Library initialization error!\n");
+		return -1;
+	}
+
+	retval = PAPI_thread_init((unsigned long(*)(void))(pthread_self));
+	if (retval != PAPI_OK) {
+		printf("PAPI_thread_init error!\n");
+		goto err_shutdown;
+	}
+
+	if (PAPI_set_granularity(PAPI_GRN_THR) != PAPI_OK) {
+		printf("PAPI_set_granularity error!\n");
+		goto err_shutdown;
+	}
+
+	for (i = 0; i < SAMPLE_COUNTER_TAB_SIZE; i++) {
+		retval = PAPI_query_event(papi_event_tab[i]);
+		if (retval != PAPI_OK) {
+			printf("PAPI_query_event %d - error\n", i);
+			goto err_shutdown;
+		}
+	}
+
+	return 0;
+
+err_shutdown:
+	PAPI_shutdown();
+
+	return -1;
+}
+
+void papi_term(void)
+{
+	PAPI_shutdown();
+}
+
+int papi_init_local(void)
+{
+	int retval;
+
+	retval = PAPI_register_thread();
+	if (retval != PAPI_OK) {
+		printf("PAPI_register_thread failed - %d\n", retval);
+		return -1;
+	}
+
+	/* Create LL event set */
+	event_set = PAPI_NULL;
+	retval = PAPI_create_eventset(&event_set);
+	if (retval != PAPI_OK) {
+		printf("PAPI_create_eventset error: %d\n", retval);
+		return -1;
+	}
+
+	retval = PAPI_add_events(event_set, papi_event_tab,
+				 SAMPLE_COUNTER_TAB_SIZE);
+	if (retval != PAPI_OK) {
+		printf("PAPI_add_events error: %d\n", retval);
+		goto err_clean_evset;
+	}
+
+	retval = PAPI_start(event_set);
+	if (retval != PAPI_OK) {
+		printf("PAPI_start error: %d\n", retval);
+		goto err_clean_evset;
+	}
+
+	return 0;
+
+err_clean_evset:
+	PAPI_cleanup_eventset(event_set);
+	PAPI_destroy_eventset(&event_set);
+
+	return -1;
+}
+
+int papi_term_local(void)
+{
+	long long last_counters[SAMPLE_COUNTER_TAB_SIZE];
+
+	if (PAPI_stop(event_set, last_counters) == PAPI_OK) {
+		int i;
+
+		for (i = 0; i < SAMPLE_COUNTER_TAB_SIZE; i++)
+			printf("Counter[%d] = %lld\n", i, last_counters[i]);
+	}
+
+	PAPI_cleanup_eventset(event_set);
+	PAPI_destroy_eventset(&event_set);
+
+	return 0;
+}
+
+int papi_sample_start(profiling_sample_t *spl)
+{
+	spl->timestamp_ns = PAPI_get_real_nsec();
+	if (PAPI_read_ts(event_set, spl->counters, &spl->diff_cyc) != PAPI_OK) {
+		fprintf(stderr, "PAPI_read_counters - FAILED\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+int papi_sample_end(profiling_sample_t *spl)
+{
+	long long end_counters[SAMPLE_COUNTER_TAB_SIZE], end_cyc;
+	int i;
+
+	if (PAPI_read_ts(event_set, end_counters, &end_cyc) != PAPI_OK) {
+		fprintf(stderr, "PAPI_read_counters - FAILED\n");
+		return -1;
+	}
+
+	for (i = 0; i < SAMPLE_COUNTER_TAB_SIZE; i++)
+		spl->counters[i] = end_counters[i] - spl->counters[i];
+
+	spl->diff_cyc = end_cyc - spl->diff_cyc;
+
+	return 0;
+}

--- a/example/instrum/papi_cnt.h
+++ b/example/instrum/papi_cnt.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef __INSTRUM_PAPI_COUNTERS_H__
+#define __INSTRUM_PAPI_COUNTERS_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sample.h>
+
+int papi_init(void);
+void papi_term(void);
+int papi_init_local(void);
+int papi_term_local(void);
+
+int papi_sample_start(profiling_sample_t *spl);
+int papi_sample_end(profiling_sample_t *spl);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __INSTRUM_PAPI_COUNTERS_H__ */

--- a/example/instrum/papi_cnt.h
+++ b/example/instrum/papi_cnt.h
@@ -18,6 +18,8 @@ void papi_term(void);
 int papi_init_local(void);
 int papi_term_local(void);
 
+int papi_counters_cnt(void);
+
 int papi_sample_start(profiling_sample_t *spl);
 int papi_sample_end(profiling_sample_t *spl);
 

--- a/example/instrum/pktio_direct.c
+++ b/example/instrum/pktio_direct.c
@@ -1,0 +1,68 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <odp_api.h>
+#include <instrum_common.h>
+#include <pktio_direct.h>
+#include <store.h>
+
+static int (*instr_odp_pktout_send)(odp_pktout_queue_t queue,
+				    const odp_packet_t packets[],
+				    int num);
+
+static int (*instr_odp_pktin_recv_tmo)(odp_pktin_queue_t queue,
+				       odp_packet_t packets[],
+				       int num, uint64_t wait);
+
+int instr_odppktio_direct_init(void)
+{
+	INSTR_FUNCTION(odp_pktout_send);
+
+	if (!instr_odp_pktout_send) {
+		printf("odp_pktout_send: Not Found\n");
+		return -1;
+	}
+
+	INSTR_FUNCTION(odp_pktin_recv_tmo);
+
+	if (!instr_odp_pktin_recv_tmo) {
+		printf("odp_pktin_recv_tmo: Not Found\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+int odp_pktout_send(odp_pktout_queue_t queue, const odp_packet_t packets[],
+		    int num)
+{
+	int ret;
+
+	STORE_SAMPLE_INIT;
+
+	STORE_SAMPLE_START;
+	ret = (*instr_odp_pktout_send)(queue, packets, num);
+	STORE_SAMPLE_END;
+
+	return ret;
+}
+
+int odp_pktin_recv_tmo(odp_pktin_queue_t queue, odp_packet_t packets[],
+		       int num, uint64_t wait)
+{
+	int ret;
+
+	STORE_SAMPLE_INIT;
+
+	STORE_SAMPLE_START;
+	ret = (*instr_odp_pktin_recv_tmo)(queue, packets, num, wait);
+	STORE_SAMPLE_END;
+
+	return ret;
+}
+

--- a/example/instrum/pktio_direct.h
+++ b/example/instrum/pktio_direct.h
@@ -7,6 +7,8 @@
 #ifndef __INSTRUM_PKTIO_DIRECT_H__
 #define __INSTRUM_PKTIO_DIRECT_H__
 
+#ifdef CODE_INSTRUM_PKTIO_DIRECT
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -16,5 +18,6 @@ int instr_odppktio_direct_init(void);
 #ifdef __cplusplus
 }
 #endif
+#endif /* CODE_INSTRUM_PKTIO_DIRECT */
 #endif /* __INSTRUM_PKTIO_DIRECT_H__ */
 

--- a/example/instrum/pktio_direct.h
+++ b/example/instrum/pktio_direct.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef __INSTRUM_PKTIO_DIRECT_H__
+#define __INSTRUM_PKTIO_DIRECT_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int instr_odppktio_direct_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __INSTRUM_PKTIO_DIRECT_H__ */
+

--- a/example/instrum/sample.h
+++ b/example/instrum/sample.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 #define SAMPLE_NAME_SIZE_MAX 20
-#define SAMPLE_COUNTER_TAB_SIZE 2
+#define SAMPLE_COUNTER_TAB_SIZE 10
 
 typedef struct {
 	char name[SAMPLE_NAME_SIZE_MAX];

--- a/example/instrum/sample.h
+++ b/example/instrum/sample.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef __INSTRUM_SAMPLE_H__
+#define __INSTRUM_SAMPLE_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SAMPLE_NAME_SIZE_MAX 20
+#define SAMPLE_COUNTER_TAB_SIZE 2
+
+typedef struct {
+	char name[SAMPLE_NAME_SIZE_MAX];
+	long long timestamp_ns;
+	long long diff_cyc;
+
+	long long counters[SAMPLE_COUNTER_TAB_SIZE];
+} profiling_sample_t;
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __INSTRUM_SAMPLE_H__ */

--- a/example/instrum/sched.c
+++ b/example/instrum/sched.c
@@ -1,0 +1,43 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <odp_api.h>
+#include <instrum_common.h>
+#include <sched.h>
+#include <store.h>
+
+static int (*instr_odp_schedule_multi)(odp_queue_t *from,
+				       uint64_t wait,
+				       odp_event_t events[],
+				       int num);
+
+int instr_odpsched_init(void)
+{
+	INSTR_FUNCTION(odp_schedule_multi);
+
+	if (!instr_odp_schedule_multi) {
+		printf("odp_schedule_multi: Not Found\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+int odp_schedule_multi(odp_queue_t *from, uint64_t wait, odp_event_t events[],
+		       int num)
+{
+	int ret;
+
+	STORE_SAMPLE_INIT;
+
+	STORE_SAMPLE_START;
+	ret = (*instr_odp_schedule_multi)(from, wait, events, num);
+	STORE_SAMPLE_END;
+
+	return ret;
+}

--- a/example/instrum/sched.h
+++ b/example/instrum/sched.h
@@ -7,6 +7,8 @@
 #ifndef __INSTRUM_SCHED_H__
 #define __INSTRUM_SCHED_H__
 
+#ifdef CODE_INSTRUM_SCHED
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -16,4 +18,5 @@ int instr_odpsched_init(void);
 #ifdef __cplusplus
 }
 #endif
+#endif /* CODE_INSTRUM_SCHED */
 #endif /* __INSTRUM_SCHED_H__ */

--- a/example/instrum/sched.h
+++ b/example/instrum/sched.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef __INSTRUM_SCHED_H__
+#define __INSTRUM_SCHED_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int instr_odpsched_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __INSTRUM_SCHED_H__ */

--- a/example/instrum/store.c
+++ b/example/instrum/store.c
@@ -23,6 +23,7 @@ static __thread uint64_t profile_sample_ovf;
 #define STORE_FILE_NAME_SIZE_MAX 250
 
 static char store_dir[STORE_DIR_NAME_SIZE_MAX];
+static int counters_cnt;
 
 static void store_dump(int last)
 {
@@ -49,7 +50,7 @@ static void store_dump(int last)
 			profile_sample_tab[i].timestamp_ns,
 			profile_sample_tab[i].diff_cyc,
 			profile_sample_tab[i].name);
-		for (j = 0; j < SAMPLE_COUNTER_TAB_SIZE; j++) {
+		for (j = 0; j < counters_cnt; j++) {
 			sprintf(smpl_tmp, ",%lld",
 				profile_sample_tab[i].counters[j]);
 			strcat(smpl, smpl_tmp);
@@ -74,6 +75,7 @@ int instr_store_init(void)
 	if (papi_init())
 		return -1;
 
+	counters_cnt = papi_counters_cnt();
 	return 0;
 }
 

--- a/example/instrum/store.c
+++ b/example/instrum/store.c
@@ -1,0 +1,133 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <odp_api.h>
+#include <store.h>
+#include <sample.h>
+#include <papi_cnt.h>
+
+#define SAMPLE_TAB_SIZE 50000
+
+static __thread profiling_sample_t profile_sample_tab[SAMPLE_TAB_SIZE];
+static __thread uint64_t profile_sample_idx;
+static __thread uint64_t profile_sample_ovf;
+
+#define STORE_DIR_ENV "ODP_INSTRUM_STORE_DIR"
+#define STORE_DIR_NAME_DFLT "/tmp"
+#define STORE_DIR_NAME_SIZE_MAX 250
+#define STORE_FILE_NAME_SIZE_MAX 250
+
+static char store_dir[STORE_DIR_NAME_SIZE_MAX];
+
+static void store_dump(int last)
+{
+	FILE *f = NULL;
+	char file_name[STORE_DIR_NAME_SIZE_MAX + STORE_FILE_NAME_SIZE_MAX];
+	char smpl[250], smpl_tmp[250];
+	int i, j, dump_size = SAMPLE_TAB_SIZE;
+
+	if (last)
+		dump_size = profile_sample_idx;
+
+	sprintf(file_name, "%s/profile_%d_%ju.csv",
+		store_dir, odp_thread_id(),
+		profile_sample_ovf);
+
+	f = fopen(file_name, "w");
+	if (f == NULL) {
+		printf("Failed to create profiling file %s\n", file_name);
+		return;
+	}
+
+	for (i = 0; i < dump_size; i++) {
+		sprintf(smpl, "%lld,%lld,%s",
+			profile_sample_tab[i].timestamp_ns,
+			profile_sample_tab[i].diff_cyc,
+			profile_sample_tab[i].name);
+		for (j = 0; j < SAMPLE_COUNTER_TAB_SIZE; j++) {
+			sprintf(smpl_tmp, ",%lld",
+				profile_sample_tab[i].counters[j]);
+			strcat(smpl, smpl_tmp);
+		}
+		fprintf(f, "%s\n", smpl);
+	}
+
+	fclose(f);
+}
+
+int instr_store_init(void)
+{
+	const char *store_dir_env = NULL;
+
+	store_dir_env = getenv(STORE_DIR_ENV);
+	if (!store_dir_env)
+		store_dir_env = STORE_DIR_NAME_DFLT;
+
+	strncpy(store_dir, store_dir_env, STORE_DIR_NAME_SIZE_MAX);
+	store_dir[STORE_DIR_NAME_SIZE_MAX - 1] = '\0';
+
+	if (papi_init())
+		return -1;
+
+	return 0;
+}
+
+void instr_store_term(void)
+{
+	papi_term();
+}
+
+int instr_store_init_local(void)
+{
+	return papi_init_local();
+}
+
+int instr_store_term_local(void)
+{
+	int ret = papi_term_local();
+
+	store_dump(1);
+
+	return ret;
+}
+
+instr_profiling_sample_t store_sample_start(const char *func)
+{
+	profiling_sample_t *spl = NULL;
+
+	if (profile_sample_idx == SAMPLE_TAB_SIZE)
+		return NULL;
+
+	spl = &profile_sample_tab[profile_sample_idx];
+
+	strncpy(spl->name, func, SAMPLE_NAME_SIZE_MAX);
+	spl->name[SAMPLE_NAME_SIZE_MAX - 1] = '\0';
+
+	if (papi_sample_start(spl))
+		return NULL;
+
+	profile_sample_idx++;
+	return spl;
+}
+
+void store_sample_end(instr_profiling_sample_t _spl)
+{
+	profiling_sample_t *spl = _spl;
+
+	if (!spl) /* failed sample - on start */
+		return;
+
+	if (papi_sample_end(spl))
+		spl->name[0] = 0; /* failed sample - on end*/
+
+	if (profile_sample_idx == SAMPLE_TAB_SIZE) {
+		store_dump(0);
+		profile_sample_idx = 0;
+		profile_sample_ovf++;
+	}
+}

--- a/example/instrum/store.h
+++ b/example/instrum/store.h
@@ -1,0 +1,36 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef __INSTRUM_STORE_H__
+#define __INSTRUM_STORE_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void *instr_profiling_sample_t;
+
+#define STORE_SAMPLE_INIT \
+	instr_profiling_sample_t _spl
+
+#define STORE_SAMPLE_START \
+	(_spl = store_sample_start(__func__))
+
+#define STORE_SAMPLE_END \
+	store_sample_end(_spl)
+
+int instr_store_init(void);
+void instr_store_term(void);
+int instr_store_init_local(void);
+int instr_store_term_local(void);
+
+instr_profiling_sample_t store_sample_start(const char *);
+void store_sample_end(instr_profiling_sample_t);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __INSTRUM_STORE_H__ */

--- a/example/m4/configure.m4
+++ b/example/m4/configure.m4
@@ -37,4 +37,5 @@ AC_CONFIG_FILES([example/classifier/Makefile
 		 example/traffic_mgmt/Makefile
 		 example/ddf_ifs/Makefile
 		 example/ddf_app/Makefile
+		 example/instrum/Makefile
 		 example/Makefile])

--- a/example/m4/configure.m4
+++ b/example/m4/configure.m4
@@ -7,6 +7,22 @@ AC_ARG_ENABLE([test-example],
     [test_example=yes])
 AM_CONDITIONAL([test_example], [test x$test_example = xyes ])
 
+code_instrumentation=no
+AC_ARG_ENABLE([code-instrum],
+    [  --enable-code-instrum   enable code instrumentation support],
+    [if test x$enableval = xyes; then
+        code_instrumentation=yes
+    fi])
+
+PAPI_PATH=""
+AC_ARG_WITH([papi-path],
+AS_HELP_STRING([--with-papi-path=DIR   path to papi install directory]),
+    [PAPI_PATH="$withval"
+    code_instrumentation=yes],[])
+
+AC_SUBST([PAPI_PATH])
+AM_CONDITIONAL([CODE_INSTRUM], [test x$code_instrumentation = xyes ])
+
 AC_CONFIG_FILES([example/classifier/Makefile
 		 example/generator/Makefile
 		 example/hello/Makefile

--- a/example/m4/configure.m4
+++ b/example/m4/configure.m4
@@ -23,6 +23,14 @@ AS_HELP_STRING([--with-papi-path=DIR   path to papi install directory]),
 AC_SUBST([PAPI_PATH])
 AM_CONDITIONAL([CODE_INSTRUM], [test x$code_instrumentation = xyes ])
 
+AC_ARG_WITH([code-instrum-profile],
+AS_HELP_STRING([--with-code-instrum-profile=all|scheduler|pktio_direct   set code instrumentation profile]),
+    [code_instrum_profile="$withval"],
+    [code_instrum_profile="all"])
+
+AM_CONDITIONAL([CODE_INSTRUM_SCHED],[test $code_instrum_profile = "all" || test $code_instrum_profile = "scheduler"])
+AM_CONDITIONAL([CODE_INSTRUM_PKTIO_DIRECT],[test $code_instrum_profile = "all" || test $code_instrum_profile = "pktio_direct"])
+
 AC_CONFIG_FILES([example/classifier/Makefile
 		 example/generator/Makefile
 		 example/hello/Makefile


### PR DESCRIPTION
ODP API instrumentation with PAPI (Performance API) library (http://icl.cs.utk.edu/papi)

"instrum" example is using library preload, symbols overloading and PAPI to obtain performance counters (like data cache miss or conditional branch count) for execution of ODP API calls. Performance counters are saved in CSV file format and can be presented in a graphical form (with Excel or similar).

Build:
./bootstrap
./configure --with-papi-path=< path to papi install> --with-code-instrum-profile=<ddf|scheduler|all>
make clean
make

Configure path to papi install:
--with-papi-path= < path to papi install>

Configure instrumented ODP API:
--with-code-instrum-profile=<ddf|scheduler|all>
Default: all

Storage directory:
export ODP_INSTRUM_STORE_DIR= < folder to store csv files >
Default directory: /tmp
e.g.
export ODP_INSTRUM_STORE_DIR=/home/bopi/Work/linaro/store

Configure PAPI events set:
export ODP_INSTRUM_PAPI_EVENTS=<coma separated list of PAPI events >
Default: PAPI_BR_CN,PAPI_L2_DCM
e.g:
export ODP_INSTRUM_PAPI_EVENTS=PAPI_BR_CN,PAPI_L2_DCM,PAPI_BR_UCN

Set load library path:
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<path to ODP libs>:<path to PAPI libs>
e.g.
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/bopi/Work/linaro/odp/lib/.libs:/home/bopi/Work/linaro/papi_inst/lib

Run:
LD_PRELOAD=libinstrum.so.0.0.0 ./example/generator/.libs/odp_generator -I eth1 -m r -c 0x8