### PR TITLE
[PATCH v3] linux-gen: cls: fix: invalid queue handle check for hashing

### DIFF
--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -988,8 +988,10 @@ int cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 	if (cos == NULL)
 		return -EINVAL;
 
-	if (cos->s.queue == ODP_QUEUE_INVALID ||
-	    cos->s.pool == ODP_POOL_INVALID)
+	if (cos->s.queue == ODP_QUEUE_INVALID && cos->s.num_queue == 1)
+		return -EFAULT;
+
+	if (cos->s.pool == ODP_POOL_INVALID)
 		return -EFAULT;
 
 	*pool = cos->s.pool;


### PR DESCRIPTION
invalid queue handle check should not be done for hash queues
Fixes: https://bugs.linaro.org/show_bug.cgi?id=3577

Signed-off-by: Balasubramanian Manoharan <bala.manoharan@linaro.org>