### PR TITLE
[PATCH API-NEXT v6] Pktio dropwait

### DIFF
--- a/include/odp/api/abi-default/packet_io.h
+++ b/include/odp/api/abi-default/packet_io.h
@@ -46,7 +46,6 @@ typedef struct odp_pktout_queue_t {
 #define ODP_PKTIO_MACADDR_MAXSIZE 16
 
 #define ODP_PKTIN_NO_WAIT 0
-#define ODP_PKTIN_WAIT    UINT64_MAX
 
 /**
  * @}

--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -73,11 +73,6 @@ extern "C" {
  */
 
 /**
- * @def ODP_PKTIN_WAIT
- * Wait infinitely on packet input
- */
-
-/**
  * Packet input mode
  */
 typedef enum odp_pktin_mode_t {
@@ -884,7 +879,6 @@ int odp_pktin_recv(odp_pktin_queue_t queue, odp_packet_t packets[], int num);
  * @param      num        Maximum number of packets to receive
  * @param      wait       Wait time specified as as follows:
  *                        * ODP_PKTIN_NO_WAIT: Do not wait
- *                        * ODP_PKTIN_WAIT:    Wait infinitely
  *                        * Other values specify the minimum time to wait.
  *                          Use odp_pktin_wait_time() to convert nanoseconds
  *                          to a valid parameter value. Wait time may be
@@ -923,7 +917,6 @@ int odp_pktin_recv_tmo(odp_pktin_queue_t queue, odp_packet_t packets[],
  * @param      num        Maximum number of packets to receive
  * @param      wait       Wait time specified as as follows:
  *                        * ODP_PKTIN_NO_WAIT: Do not wait
- *                        * ODP_PKTIN_WAIT:    Wait infinitely
  *                        * Other values specify the minimum time to wait.
  *                          Use odp_pktin_wait_time() to convert nanoseconds
  *                          to a valid parameter value. Wait time may be

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -40,6 +40,9 @@
  * Must be power of two. */
 #define SLEEP_CHECK 32
 
+/* Max wait time supported to avoid potential overflow */
+#define MAX_WAIT_TIME (UINT64_MAX / 1024)
+
 static pktio_table_t *pktio_tbl;
 
 /* pktio pointer entries ( for inlines) */
@@ -1699,33 +1702,31 @@ int odp_pktin_recv_tmo(odp_pktin_queue_t queue, odp_packet_t packets[], int num,
 	while (1) {
 		ret = entry->s.ops->recv(entry, queue.index, packets, num);
 
-		if (ret != 0)
+		if (ret != 0 || wait == 0)
 			return ret;
 
-		if (wait == 0)
-			return 0;
+		/* Avoid unnecessary system calls. Record the start time
+		 * only when needed and after the first call to recv. */
+		if (odp_unlikely(!started)) {
+			odp_time_t t;
 
-		if (wait != ODP_PKTIN_WAIT) {
-			/* Avoid unnecessary system calls. Record the start time
-			 * only when needed and after the first call to recv. */
-			if (odp_unlikely(!started)) {
-				odp_time_t t;
-
-				t = odp_time_local_from_ns(wait * 1000);
-				started = 1;
-				t1 = odp_time_sum(odp_time_local(), t);
-			}
-
-			/* Check every SLEEP_CHECK rounds if total wait time
-			 * has been exceeded. */
-			if ((++sleep_round & (SLEEP_CHECK - 1)) == 0) {
-				t2 = odp_time_local();
-
-				if (odp_time_cmp(t2, t1) > 0)
-					return 0;
-			}
-			wait = wait > SLEEP_USEC ? wait - SLEEP_USEC : 0;
+			/* Avoid overflow issues for large wait times */
+			if (wait > MAX_WAIT_TIME)
+				wait = MAX_WAIT_TIME;
+			t = odp_time_local_from_ns(wait * 1000);
+			started = 1;
+			t1 = odp_time_sum(odp_time_local(), t);
 		}
+
+		/* Check every SLEEP_CHECK rounds if total wait time
+		 * has been exceeded. */
+		if ((++sleep_round & (SLEEP_CHECK - 1)) == 0) {
+			t2 = odp_time_local();
+
+			if (odp_time_cmp(t2, t1) > 0)
+				return 0;
+		}
+		wait = wait > SLEEP_USEC ? wait - SLEEP_USEC : 0;
 
 		nanosleep(&ts, NULL);
 	}
@@ -1779,25 +1780,26 @@ int odp_pktin_recv_mq_tmo(const odp_pktin_queue_t queues[], unsigned num_q,
 		if (wait == 0)
 			return 0;
 
-		if (wait != ODP_PKTIN_WAIT) {
-			if (odp_unlikely(!started)) {
-				odp_time_t t;
+		if (odp_unlikely(!started)) {
+			odp_time_t t;
 
-				t = odp_time_local_from_ns(wait * 1000);
-				started = 1;
-				t1 = odp_time_sum(odp_time_local(), t);
-			}
-
-			/* Check every SLEEP_CHECK rounds if total wait time
-			 * has been exceeded. */
-			if ((++sleep_round & (SLEEP_CHECK - 1)) == 0) {
-				t2 = odp_time_local();
-
-				if (odp_time_cmp(t2, t1) > 0)
-					return 0;
-			}
-			wait = wait > SLEEP_USEC ? wait - SLEEP_USEC : 0;
+			/* Avoid overflow issues for large wait times */
+			if (wait > MAX_WAIT_TIME)
+				wait = MAX_WAIT_TIME;
+			t = odp_time_local_from_ns(wait * 1000);
+			started = 1;
+			t1 = odp_time_sum(odp_time_local(), t);
 		}
+
+		/* Check every SLEEP_CHECK rounds if total wait time
+		 * has been exceeded. */
+		if ((++sleep_round & (SLEEP_CHECK - 1)) == 0) {
+			t2 = odp_time_local();
+
+			if (odp_time_cmp(t2, t1) > 0)
+				return 0;
+		}
+		wait = wait > SLEEP_USEC ? wait - SLEEP_USEC : 0;
 
 		nanosleep(&ts, NULL);
 	}

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -834,8 +834,7 @@ static int netmap_recv_tmo(pktio_entry_t *pktio_entry, int index,
 	FD_ZERO(&readfds);
 	maxfd = netmap_fd_set(pktio_entry, index, &readfds);
 
-	if (select(maxfd + 1, &readfds, NULL, NULL,
-		   usecs == ODP_PKTIN_WAIT ? NULL : &timeout) == 0)
+	if (select(maxfd + 1, &readfds, NULL, NULL, &timeout) == 0)
 		return 0;
 
 	return netmap_recv(pktio_entry, index, pkt_table, num);
@@ -872,8 +871,7 @@ static int netmap_recv_mq_tmo(pktio_entry_t *pktio_entry[], int index[],
 	timeout.tv_sec = usecs / (1000 * 1000);
 	timeout.tv_usec = usecs - timeout.tv_sec * (1000ULL * 1000ULL);
 
-	if (select(maxfd + 1, &readfds, NULL, NULL,
-		   usecs == ODP_PKTIN_WAIT ? NULL : &timeout) == 0)
+	if (select(maxfd + 1, &readfds, NULL, NULL, &timeout) == 0)
 		return 0;
 
 	for (i = 0; i < num_q; i++) {

--- a/platform/linux-generic/pktio/pktio_common.c
+++ b/platform/linux-generic/pktio/pktio_common.c
@@ -107,8 +107,7 @@ static int sock_recv_mq_tmo_select(pktio_entry_t * const *entry,
 	timeout.tv_sec = usecs / (1000 * 1000);
 	timeout.tv_usec = usecs - timeout.tv_sec * (1000ULL * 1000ULL);
 
-	if (select(maxfd + 1, readfds, NULL, NULL,
-		   usecs == ODP_PKTIN_WAIT ? NULL : &timeout) == 0)
+	if (select(maxfd + 1, readfds, NULL, NULL, &timeout) == 0)
 		return 0;
 
 	for (i = 0; i < num_q; i++) {

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -726,8 +726,7 @@ static int sock_recv_tmo(pktio_entry_t *pktio_entry, int index,
 	FD_ZERO(&readfds);
 	maxfd = sock_fd_set(pktio_entry, index, &readfds);
 
-	if (select(maxfd + 1, &readfds, NULL, NULL,
-		   usecs == ODP_PKTIN_WAIT ? NULL : &timeout) == 0)
+	if (select(maxfd + 1, &readfds, NULL, NULL, &timeout) == 0)
 		return 0;
 
 	return sock_mmsg_recv(pktio_entry, index, pkt_table, num);
@@ -764,8 +763,7 @@ static int sock_recv_mq_tmo(pktio_entry_t *pktio_entry[], int index[],
 			maxfd = maxfd2;
 	}
 
-	if (select(maxfd + 1, &readfds, NULL, NULL,
-		   usecs == ODP_PKTIN_WAIT ? NULL : &timeout) == 0)
+	if (select(maxfd + 1, &readfds, NULL, NULL, &timeout) == 0)
 		return 0;
 
 	for (i = 0; i < num_q; i++) {

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -692,8 +692,7 @@ static int sock_mmap_recv_tmo(pktio_entry_t *pktio_entry, int index,
 	FD_ZERO(&readfds);
 	maxfd = sock_mmap_fd_set(pktio_entry, index, &readfds);
 
-	if (select(maxfd + 1, &readfds, NULL, NULL,
-		   usecs == ODP_PKTIN_WAIT ? NULL : &timeout) == 0)
+	if (select(maxfd + 1, &readfds, NULL, NULL, &timeout) == 0)
 		return 0;
 
 	return sock_mmap_recv(pktio_entry, index, pkt_table, num);
@@ -730,8 +729,7 @@ static int sock_mmap_recv_mq_tmo(pktio_entry_t *pktio_entry[], int index[],
 	timeout.tv_sec = usecs / (1000 * 1000);
 	timeout.tv_usec = usecs - timeout.tv_sec * (1000ULL * 1000ULL);
 
-	if (select(maxfd + 1, &readfds, NULL, NULL,
-		   usecs == ODP_PKTIN_WAIT ? NULL : &timeout) == 0)
+	if (select(maxfd + 1, &readfds, NULL, NULL, &timeout) == 0)
 		return 0;
 
 	for (i = 0; i < num_q; i++) {

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -554,10 +554,8 @@ static int recv_packets_tmo(odp_pktio_t pktio, odp_packet_t pkt_tbl[],
 			CU_ASSERT(from_val < (unsigned)num_q);
 	} while (num_rx < num);
 
-	if (tmo == ODP_PKTIN_WAIT)
-		CU_ASSERT(num_rx == num);
 	if (num_rx < num)
-		CU_ASSERT(odp_time_to_ns(odp_time_diff(ts2, ts1)) >=  ns);
+		CU_ASSERT(odp_time_diff_ns(ts2, ts1) >= ns);
 
 	return num_rx;
 }
@@ -981,7 +979,7 @@ static void test_recv_tmo(recv_tmo_mode_e mode)
 	CU_ASSERT_FATAL(ret == test_pkt_count);
 
 	ret = recv_packets_tmo(pktio_rx, &pkt_tbl[0], &pkt_seq[0], 1, mode,
-			       ODP_PKTIN_WAIT, 0);
+			       odp_pktin_wait_time(UINT64_MAX), 0);
 	CU_ASSERT_FATAL(ret == 1);
 
 	ret = recv_packets_tmo(pktio_rx, &pkt_tbl[1], &pkt_seq[1], 1, mode,


### PR DESCRIPTION
Deprecate and remove the ODP_PKTIN_WAIT option from odp_pktin_recv_tmo() and odp_pktin_recv_mq_tmo().