### PR TITLE
[PATCH API-NEXT v1] linux-generic: atomic: avoid doxygen warnings on atomic types

### DIFF
--- a/platform/linux-generic/include/odp/api/plat/atomic_types.h
+++ b/platform/linux-generic/include/odp/api/plat/atomic_types.h
@@ -77,8 +77,10 @@ struct odp_atomic_u32_s {
 })
 #endif
 
+/** @internal */
 typedef struct odp_atomic_u64_s odp_atomic_u64_t;
 
+/** @internal */
 typedef struct odp_atomic_u32_s odp_atomic_u32_t;
 
 #ifdef __cplusplus


### PR DESCRIPTION
Flag internal atomic type definitions as @internal to suppress
extraneous doxygen warnings.

Signed-off-by: Bill Fischofer <bill.fischofer@linaro.org>