### PR TITLE
[PATCH CATERPILLAR v1] odp_crypto (dpdk): RAND_pseudo_bytes is deprecated

### DIFF
--- a/platform/linux-dpdk/odp_crypto.c
+++ b/platform/linux-dpdk/odp_crypto.c
@@ -1134,9 +1134,6 @@ int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
 
 	switch (kind) {
 	case ODP_RANDOM_BASIC:
-		RAND_pseudo_bytes(buf, len);
-		return len;
-
 	case ODP_RANDOM_CRYPTO:
 		rc = RAND_bytes(buf, len);
 		return (1 == rc) ? (int)len /*success*/: -1 /*failure*/;


### PR DESCRIPTION
Signed-off-by: Josep Puigdemont <josep.puigdemont@linaro.org>