### PR TITLE
[PATCH CATERPILLAR v1] [RFC] odp: pktio: added tcpdump like functionality

### DIFF
--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -97,6 +97,20 @@ struct pktio_entry {
 		odp_queue_t        queue;
 		odp_pktout_queue_t pktout;
 	} out_queue[PKTIO_MAX_QUEUES];
+
+	/**< inotify instance for pcapng fifos */
+	struct {
+		int inotify_pcapng_fd;
+		int inotify_watch_fd;
+		pthread_t inotify_thread;
+		enum {
+			PCAPNG_WR_INVALID = 0,
+			PCAPNG_WR_STOP,
+			PCAPNG_WR_HDR,
+			PCAPNG_WR_PKT,
+		} state[PKTIO_MAX_QUEUES];
+		int pcapng_fd[PKTIO_MAX_QUEUES];
+	} pcapng_info;
 };
 
 union pktio_entry_u {

--- a/platform/linux-generic/include/odp_pcapng.h
+++ b/platform/linux-generic/include/odp_pcapng.h
@@ -1,0 +1,56 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <protocols/eth.h>
+#include <protocols/ip.h>
+#include <odp/api/plat/packet_inlines.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/fcntl.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#define PCAPNG_BLOCK_TYPE_EPB 0x00000006UL
+#define PCAPNG_BLOCK_TYPE_SHB 0x0A0D0D0AUL
+#define PCAPNG_BLOCK_TYPE_IDB 0x00000001UL
+#define PCAPNG_ENDIAN_MAGIC 0x1A2B3C4DUL
+#define PCAP_DATA_ALIGN (4)
+
+/* inotify */
+#define INOTIFY_EVENT_SIZE  (sizeof(struct inotify_event))
+#define INOTIFY_BUF_LEN     (1024 * (INOTIFY_EVENT_SIZE + 16))
+#define PCAPNG_WATCH_DIR "/var/run/odp/"
+
+/* pcapng: enhanced packet block file encoding */
+typedef struct ODP_PACKED pcapng_section_hdr_block_s {
+	uint32_t block_type;
+	uint32_t block_total_length;
+	uint32_t magic;
+	uint16_t version_major;
+	uint16_t version_minor;
+	int64_t section_len;
+	uint32_t block_total_length2;
+} pcapng_section_hdr_block_t;
+
+typedef struct pcapng_interface_description_block {
+	uint32_t block_type;
+	uint32_t block_total_length;
+	uint16_t linktype;
+	uint16_t reserved;
+	uint32_t snaplen;
+	uint32_t block_total_length2;
+} pcapng_interface_description_block_s;
+
+typedef struct pcapng_enhanced_packet_block_s {
+	uint32_t block_type;
+	uint32_t block_total_length;
+	uint32_t interface_idx;
+	uint32_t timestamp_high;
+	uint32_t timestamp_low;
+	uint32_t captured_len;
+	uint32_t packet_len;
+} pcapng_enhanced_packet_block_t;
+


### PR DESCRIPTION
The code is not 100% ready to be merged, this is a proof of concept. 

Once an ODP application starts, there will be a number of fifos registered in /var/run/odp and a inotify watcher, as long as the directory exists. 
The current naming and number of fifos is "interface name"-flow-"queue number".
If the number of input and output queues are not equal the greater number is selected.
This can be further fine tuned if needed by registering 1 fifo per direction and per queue number, so we'll end up with fifos looking looking like "interface name"-rxflow-"queue number" and "interface name"-txflow-"queue number".
Tested on Chelsio 40Gbit the changes in pktio_entry_t seem to have zero impact on performance(if the trace is not running).

The moment a user opens the fifo, with dd or similar application, inotify will trigger and packets packets will be dumped in the fifo using pcapng format.

How to test:
sudo mkdir /var/run/odp/
sudo dd if=/var/run/odp/enp2s0-flow-0 of=~/test.pcap

If odp is stopped fifo's need to be removed manually
sudo rm /var/run/odp/*



Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>