### PR TITLE
[PATCH v2] Packet function inlines 

### DIFF
--- a/include/odp/api/abi-default/buffer.h
+++ b/include/odp/api/abi-default/buffer.h
@@ -20,7 +20,7 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_buffer_t;
 
 typedef _odp_abi_buffer_t *odp_buffer_t;
 
-#define ODP_BUFFER_INVALID   ((odp_buffer_t)NULL)
+#define ODP_BUFFER_INVALID   ((odp_buffer_t)0)
 
 /**
  * @}

--- a/include/odp/api/abi-default/event.h
+++ b/include/odp/api/abi-default/event.h
@@ -22,7 +22,7 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_event_t;
 
 typedef _odp_abi_event_t *odp_event_t;
 
-#define ODP_EVENT_INVALID  ((odp_event_t)NULL)
+#define ODP_EVENT_INVALID  ((odp_event_t)0)
 
 typedef enum odp_event_type_t {
 	ODP_EVENT_BUFFER       = 1,

--- a/include/odp/api/abi-default/packet.h
+++ b/include/odp/api/abi-default/packet.h
@@ -26,7 +26,7 @@ typedef struct { char dummy; /**< *internal Dummy */ } _odp_abi_packet_seg_t;
 typedef _odp_abi_packet_t *odp_packet_t;
 typedef _odp_abi_packet_seg_t *odp_packet_seg_t;
 
-#define ODP_PACKET_INVALID        ((odp_packet_t)0xffffffff)
+#define ODP_PACKET_INVALID        ((odp_packet_t)0)
 #define ODP_PACKET_SEG_INVALID    ((odp_packet_seg_t)0xffffffff)
 #define ODP_PACKET_OFFSET_INVALID 0xffff
 

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -30,6 +30,8 @@ odpapiplatinclude_HEADERS = \
 		  include/odp/api/plat/packet_inline_types.h \
 		  include/odp/api/plat/packet_inlines.h \
 		  include/odp/api/plat/packet_inlines_api.h \
+		  include/odp/api/plat/pktio_inlines.h \
+		  include/odp/api/plat/pktio_inlines_api.h \
 		  include/odp/api/plat/pool_inline_types.h \
 		  include/odp/api/plat/std_clib_inlines.h \
 		  include/odp/api/plat/strong_types.h \
@@ -205,6 +207,7 @@ __LIB__libodp_linux_la_SOURCES += \
 			   odp_byteorder.c \
 			   odp_packet_api.c \
 			   odp_packet_flags_api.c \
+			   odp_pktio_api.c \
 			   odp_std_clib.c \
 			   odp_sync.c \
 			   odp_thread_api.c \

--- a/platform/linux-generic/include-abi/odp/api/abi/buffer.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/buffer.h
@@ -26,7 +26,7 @@ extern "C" {
 
 typedef ODP_HANDLE_T(odp_buffer_t);
 
-#define ODP_BUFFER_INVALID _odp_cast_scalar(odp_buffer_t, NULL)
+#define ODP_BUFFER_INVALID _odp_cast_scalar(odp_buffer_t, 0)
 
 /**
  * @}

--- a/platform/linux-generic/include-abi/odp/api/abi/event.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/event.h
@@ -26,7 +26,7 @@ extern "C" {
 
 typedef ODP_HANDLE_T(odp_event_t);
 
-#define ODP_EVENT_INVALID _odp_cast_scalar(odp_event_t, NULL)
+#define ODP_EVENT_INVALID _odp_cast_scalar(odp_event_t, 0)
 
 typedef enum odp_event_type_t {
 	ODP_EVENT_BUFFER       = 1,

--- a/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet_io.h
@@ -51,6 +51,10 @@ typedef struct odp_pktout_queue_t {
  * @}
  */
 
+#define _ODP_INLINE static inline
+#include <odp/api/plat/pktio_inlines.h>
+#include <odp/api/plat/pktio_inlines_api.h>
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -23,63 +23,52 @@
 #include <odp/api/plat/packet_inline_types.h>
 #include <odp/api/plat/pool_inline_types.h>
 
-/** @internal Inline function @param pkt_ptr @param offset @param seg_len
- *  @param seg_idx @return */
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
 void *_odp_packet_map(void *pkt_ptr, uint32_t offset, uint32_t *seg_len,
 		      int *seg_idx);
 
-/** @internal Inline function offsets */
 extern const _odp_packet_inline_offset_t _odp_packet_inline;
-
-/** @internal Pool inline function offsets */
-extern const _odp_pool_inline_offset_t _odp_pool_inline;
+extern const _odp_pool_inline_offset_t   _odp_pool_inline;
 
 #ifndef _ODP_HAVE_PACKET_SEG_NDX
 #include <odp/api/plat/strong_types.h>
-/** @internal Inline function @param seg @return */
 static inline uint32_t _odp_packet_seg_to_ndx(odp_packet_seg_t seg)
 {
 	return _odp_typeval(seg);
 }
 
-/** @internal Inline function @param ndx @return */
 static inline odp_packet_seg_t _odp_packet_seg_from_ndx(uint32_t ndx)
 {
 	return _odp_cast_scalar(odp_packet_seg_t, ndx);
 }
 #endif
 
-/** @internal Inline function @param pkt @return */
 static inline void *_odp_packet_data(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, void *, data);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_seg_len(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint32_t, seg_len);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_len(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint32_t, frame_len);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_headroom(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint16_t, headroom);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_tailroom(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint16_t, tailroom);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline odp_pool_t _odp_packet_pool(odp_packet_t pkt)
 {
 	void *pool = _odp_pkt_get(pkt, void *, pool);
@@ -87,31 +76,26 @@ static inline odp_pool_t _odp_packet_pool(odp_packet_t pkt)
 	return _odp_pool_get(pool, odp_pool_t, pool_hdl);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline odp_pktio_t _odp_packet_input(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, odp_pktio_t, input);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline int _odp_packet_num_segs(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint8_t, segcount);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline void *_odp_packet_user_ptr(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, void *, user_ptr);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline void *_odp_packet_user_area(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, void *, user_area);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_user_area_size(odp_packet_t pkt)
 {
 	void *pool = _odp_pkt_get(pkt, void *, pool);
@@ -119,25 +103,21 @@ static inline uint32_t _odp_packet_user_area_size(odp_packet_t pkt)
 	return _odp_pool_get(pool, uint32_t, uarea_size);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_l2_offset(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint16_t, l2_offset);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_l3_offset(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint16_t, l3_offset);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_l4_offset(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint16_t, l4_offset);
 }
 
-/** @internal Inline function @param pkt @param len @return */
 static inline void *_odp_packet_l2_ptr(odp_packet_t pkt, uint32_t *len)
 {
 	uint32_t offset  = _odp_packet_l2_offset(pkt);
@@ -156,7 +136,6 @@ static inline void *_odp_packet_l2_ptr(odp_packet_t pkt, uint32_t *len)
 	return data + offset;
 }
 
-/** @internal Inline function @param pkt @param len @return */
 static inline void *_odp_packet_l3_ptr(odp_packet_t pkt, uint32_t *len)
 {
 	uint32_t offset  = _odp_packet_l3_offset(pkt);
@@ -175,7 +154,6 @@ static inline void *_odp_packet_l3_ptr(odp_packet_t pkt, uint32_t *len)
 	return data + offset;
 }
 
-/** @internal Inline function @param pkt @param len @return */
 static inline void *_odp_packet_l4_ptr(odp_packet_t pkt, uint32_t *len)
 {
 	uint32_t offset  = _odp_packet_l4_offset(pkt);
@@ -194,31 +172,26 @@ static inline void *_odp_packet_l4_ptr(odp_packet_t pkt, uint32_t *len)
 	return data + offset;
 }
 
-/** @internal Inline function @param pkt @return */
 static inline uint32_t _odp_packet_flow_hash(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint32_t, flow_hash);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline odp_time_t _odp_packet_ts(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, odp_time_t, timestamp);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline void *_odp_packet_head(odp_packet_t pkt)
 {
 	return (uint8_t *)_odp_packet_data(pkt) - _odp_packet_headroom(pkt);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline int _odp_packet_is_segmented(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, uint8_t, segcount) > 1;
 }
 
-/** @internal Inline function @param pkt @return */
 static inline odp_packet_seg_t _odp_packet_first_seg(odp_packet_t pkt)
 {
 	(void)pkt;
@@ -226,13 +199,11 @@ static inline odp_packet_seg_t _odp_packet_first_seg(odp_packet_t pkt)
 	return _odp_packet_seg_from_ndx(0);
 }
 
-/** @internal Inline function @param pkt @return */
 static inline odp_packet_seg_t _odp_packet_last_seg(odp_packet_t pkt)
 {
 	return _odp_packet_seg_from_ndx(_odp_packet_num_segs(pkt) - 1);
 }
 
-/** @internal Inline function @param pkt @param seg @return */
 static inline odp_packet_seg_t _odp_packet_next_seg(odp_packet_t pkt,
 						    odp_packet_seg_t seg)
 {
@@ -243,17 +214,17 @@ static inline odp_packet_seg_t _odp_packet_next_seg(odp_packet_t pkt,
 	return seg + 1;
 }
 
-/** @internal Inline function @param pkt @param offset @param len */
 static inline void _odp_packet_prefetch(odp_packet_t pkt, uint32_t offset,
 					uint32_t len)
 {
 	(void)pkt; (void)offset; (void)len;
 }
 
-/** @internal Inline function @param pkt @return */
 static inline odp_buffer_t packet_to_buffer(odp_packet_t pkt)
 {
 	return (odp_buffer_t)pkt;
 }
+
+/** @endcond */
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -22,6 +22,7 @@
 
 #include <odp/api/plat/packet_inline_types.h>
 #include <odp/api/plat/pool_inline_types.h>
+#include <odp/api/plat/pktio_inlines.h>
 
 #include <string.h>
 
@@ -87,6 +88,13 @@ static inline odp_pool_t _odp_packet_pool(odp_packet_t pkt)
 static inline odp_pktio_t _odp_packet_input(odp_packet_t pkt)
 {
 	return _odp_pkt_get(pkt, odp_pktio_t, input);
+}
+
+static inline int _odp_packet_input_index(odp_packet_t pkt)
+{
+	odp_pktio_t pktio = _odp_packet_input(pkt);
+
+	return _odp_pktio_index(pktio);
 }
 
 static inline int _odp_packet_num_segs(odp_packet_t pkt)

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -225,7 +225,14 @@ static inline odp_packet_seg_t _odp_packet_next_seg(odp_packet_t pkt,
 static inline void _odp_packet_prefetch(odp_packet_t pkt, uint32_t offset,
 					uint32_t len)
 {
-	(void)pkt; (void)offset; (void)len;
+	uint32_t seg_len = _odp_packet_seg_len(pkt);
+	uint8_t *data    = (uint8_t *)_odp_packet_data(pkt);
+	(void)len;
+
+	if (odp_unlikely(offset >= seg_len))
+		return;
+
+	odp_prefetch(data + offset);
 }
 
 static inline int _odp_packet_copy_from_mem(odp_packet_t pkt, uint32_t offset,

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -228,11 +228,6 @@ static inline void _odp_packet_prefetch(odp_packet_t pkt, uint32_t offset,
 	(void)pkt; (void)offset; (void)len;
 }
 
-static inline odp_buffer_t packet_to_buffer(odp_packet_t pkt)
-{
-	return (odp_buffer_t)pkt;
-}
-
 static inline int _odp_packet_copy_from_mem(odp_packet_t pkt, uint32_t offset,
 					    uint32_t len, const void *src)
 {

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -23,10 +23,18 @@
 #include <odp/api/plat/packet_inline_types.h>
 #include <odp/api/plat/pool_inline_types.h>
 
+#include <string.h>
+
 /** @cond _ODP_HIDE_FROM_DOXYGEN_ */
 
 void *_odp_packet_map(void *pkt_ptr, uint32_t offset, uint32_t *seg_len,
 		      int *seg_idx);
+
+int _odp_packet_copy_from_mem_seg(odp_packet_t pkt, uint32_t offset,
+				  uint32_t len, const void *src);
+
+int _odp_packet_copy_to_mem_seg(odp_packet_t pkt, uint32_t offset,
+				uint32_t len, void *dst);
 
 extern const _odp_packet_inline_offset_t _odp_packet_inline;
 extern const _odp_pool_inline_offset_t   _odp_pool_inline;
@@ -223,6 +231,34 @@ static inline void _odp_packet_prefetch(odp_packet_t pkt, uint32_t offset,
 static inline odp_buffer_t packet_to_buffer(odp_packet_t pkt)
 {
 	return (odp_buffer_t)pkt;
+}
+
+static inline int _odp_packet_copy_from_mem(odp_packet_t pkt, uint32_t offset,
+					    uint32_t len, const void *src)
+{
+	uint32_t seg_len = _odp_packet_seg_len(pkt);
+	uint8_t *data    = (uint8_t *)_odp_packet_data(pkt);
+
+	if (odp_unlikely(offset + len > seg_len))
+		return _odp_packet_copy_from_mem_seg(pkt, offset, len, src);
+
+	memcpy(data + offset, src, len);
+
+	return 0;
+}
+
+static inline int _odp_packet_copy_to_mem(odp_packet_t pkt, uint32_t offset,
+					  uint32_t len, void *dst)
+{
+	uint32_t seg_len = _odp_packet_seg_len(pkt);
+	uint8_t *data    = (uint8_t *)_odp_packet_data(pkt);
+
+	if (odp_unlikely(offset + len > seg_len))
+		return _odp_packet_copy_to_mem_seg(pkt, offset, len, dst);
+
+	memcpy(dst, data + offset, len);
+
+	return 0;
 }
 
 /** @endcond */

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -263,6 +263,35 @@ static inline int _odp_packet_copy_to_mem(odp_packet_t pkt, uint32_t offset,
 	return 0;
 }
 
+static inline odp_packet_t _odp_packet_from_event(odp_event_t ev)
+{
+	return (odp_packet_t)ev;
+}
+
+static inline odp_event_t _odp_packet_to_event(odp_packet_t pkt)
+{
+	return (odp_event_t)pkt;
+}
+
+static inline void _odp_packet_from_event_multi(odp_packet_t pkt[],
+						const odp_event_t ev[],
+						int num)
+{
+	int i;
+
+	for (i = 0; i < num; i++)
+		pkt[i] = _odp_packet_from_event(ev[i]);
+}
+
+static inline void _odp_packet_to_event_multi(const odp_packet_t pkt[],
+					      odp_event_t ev[], int num)
+{
+	int i;
+
+	for (i = 0; i < num; i++)
+		ev[i] = _odp_packet_to_event(pkt[i]);
+}
+
 /** @endcond */
 
 #endif

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
@@ -152,4 +152,25 @@ _ODP_INLINE int odp_packet_copy_to_mem(odp_packet_t pkt, uint32_t offset,
 	return _odp_packet_copy_to_mem(pkt, offset, len, dst);
 }
 
+_ODP_INLINE odp_packet_t odp_packet_from_event(odp_event_t ev)
+{
+	return _odp_packet_from_event(ev);
+}
+
+_ODP_INLINE odp_event_t odp_packet_to_event(odp_packet_t pkt)
+{
+	return _odp_packet_to_event(pkt);
+}
+
+_ODP_INLINE void odp_packet_from_event_multi(odp_packet_t pkt[],
+					     const odp_event_t ev[], int num)
+{
+	return _odp_packet_from_event_multi(pkt, ev, num);
+}
+
+_ODP_INLINE void odp_packet_to_event_multi(const odp_packet_t pkt[],
+					   odp_event_t ev[], int num)
+{
+	return _odp_packet_to_event_multi(pkt, ev, num);
+}
 #endif

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
@@ -48,6 +48,11 @@ _ODP_INLINE odp_pktio_t odp_packet_input(odp_packet_t pkt)
 	return _odp_packet_input(pkt);
 }
 
+_ODP_INLINE int odp_packet_input_index(odp_packet_t pkt)
+{
+	return _odp_packet_input_index(pkt);
+}
+
 _ODP_INLINE int odp_packet_num_segs(odp_packet_t pkt)
 {
 	return _odp_packet_num_segs(pkt);

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines_api.h
@@ -140,4 +140,16 @@ _ODP_INLINE void odp_packet_prefetch(odp_packet_t pkt, uint32_t offset,
 	return _odp_packet_prefetch(pkt, offset, len);
 }
 
+_ODP_INLINE int odp_packet_copy_from_mem(odp_packet_t pkt, uint32_t offset,
+					 uint32_t len, const void *src)
+{
+	return _odp_packet_copy_from_mem(pkt, offset, len, src);
+}
+
+_ODP_INLINE int odp_packet_copy_to_mem(odp_packet_t pkt, uint32_t offset,
+				       uint32_t len, void *dst)
+{
+	return _odp_packet_copy_to_mem(pkt, offset, len, dst);
+}
+
 #endif

--- a/platform/linux-generic/include/odp/api/plat/pktio_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/pktio_inlines.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_PLAT_PKTIO_INLINES_H_
+#define ODP_PLAT_PKTIO_INLINES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+static inline int _odp_pktio_index(odp_pktio_t pktio)
+{
+	return (int)(uintptr_t)pktio - 1;
+}
+
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp/api/plat/pktio_inlines_api.h
+++ b/platform/linux-generic/include/odp/api/plat/pktio_inlines_api.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ */
+
+#ifndef ODP_PLAT_PKTIO_INLINES_API_H_
+#define ODP_PLAT_PKTIO_INLINES_API_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+_ODP_INLINE int odp_pktio_index(odp_pktio_t pktio)
+{
+	return _odp_pktio_index(pktio);
+}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -169,7 +169,7 @@ typedef struct {
 /**
  * Return the packet header
  */
-static inline odp_packet_hdr_t *odp_packet_hdr(odp_packet_t pkt)
+static inline odp_packet_hdr_t *packet_hdr(odp_packet_t pkt)
 {
 	return (odp_packet_hdr_t *)(uintptr_t)pkt;
 }
@@ -181,7 +181,7 @@ static inline odp_packet_t packet_handle(odp_packet_hdr_t *pkt_hdr)
 
 static inline odp_buffer_hdr_t *packet_to_buf_hdr(odp_packet_t pkt)
 {
-	return &odp_packet_hdr(pkt)->buf_hdr;
+	return &packet_hdr(pkt)->buf_hdr;
 }
 
 static inline odp_packet_t packet_from_buf_hdr(odp_buffer_hdr_t *buf_hdr)
@@ -201,12 +201,12 @@ static inline seg_entry_t *seg_entry_last(odp_packet_hdr_t *hdr)
 
 static inline odp_event_subtype_t packet_subtype(odp_packet_t pkt)
 {
-	return odp_packet_hdr(pkt)->subtype;
+	return packet_hdr(pkt)->subtype;
 }
 
 static inline void packet_subtype_set(odp_packet_t pkt, int ev)
 {
-	odp_packet_hdr(pkt)->subtype = ev;
+	packet_hdr(pkt)->subtype = ev;
 }
 
 /**

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -331,6 +331,13 @@ static inline int packet_hdr_has_ipv6(odp_packet_hdr_t *pkt_hdr)
 	return pkt_hdr->p.input_flags.ipv6;
 }
 
+static inline void packet_set_flow_hash(odp_packet_hdr_t *pkt_hdr,
+					uint32_t flow_hash)
+{
+	pkt_hdr->flow_hash = flow_hash;
+	pkt_hdr->p.input_flags.flow_hash = 1;
+}
+
 static inline void packet_set_ts(odp_packet_hdr_t *pkt_hdr, odp_time_t *ts)
 {
 	if (ts != NULL) {

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -18,6 +18,8 @@
 extern "C" {
 #endif
 
+#include <odp/api/packet_io.h>
+#include <odp/api/plat/pktio_inlines.h>
 #include <odp/api/spinlock.h>
 #include <odp/api/ticketlock.h>
 #include <odp_classification_datamodel.h>
@@ -235,13 +237,10 @@ typedef struct pktio_if_ops {
 
 extern void *pktio_entry_ptr[];
 
-static inline int pktio_to_id(odp_pktio_t pktio)
-{
-	return _odp_typeval(pktio) - 1;
-}
-
 static inline pktio_entry_t *get_pktio_entry(odp_pktio_t pktio)
 {
+	int idx;
+
 	if (odp_unlikely(pktio == ODP_PKTIO_INVALID))
 		return NULL;
 
@@ -251,7 +250,9 @@ static inline pktio_entry_t *get_pktio_entry(odp_pktio_t pktio)
 		return NULL;
 	}
 
-	return pktio_entry_ptr[pktio_to_id(pktio)];
+	idx = _odp_pktio_index(pktio);
+
+	return pktio_entry_ptr[idx];
 }
 
 static inline int pktio_cls_enabled(pktio_entry_t *entry)

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -1434,7 +1434,7 @@ odp_event_t odp_crypto_packet_to_event(odp_packet_t pkt)
 static
 odp_crypto_packet_result_t *get_op_result_from_packet(odp_packet_t pkt)
 {
-	odp_packet_hdr_t *hdr = odp_packet_hdr(pkt);
+	odp_packet_hdr_t *hdr = packet_hdr(pkt);
 
 	return &hdr->crypto_op_result;
 }
@@ -1520,7 +1520,7 @@ int odp_crypto_int(odp_packet_t pkt_in,
 		(rc_cipher == ODP_CRYPTO_ALG_ERR_NONE) &&
 		(rc_auth == ODP_CRYPTO_ALG_ERR_NONE);
 
-	pkt_hdr = odp_packet_hdr(out_pkt);
+	pkt_hdr = packet_hdr(out_pkt);
 	pkt_hdr->p.error_flags.crypto_err = !op_result->ok;
 
 	/* Synchronous, simply return results */

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -158,7 +158,7 @@ static odp_ipsec_packet_result_t *ipsec_pkt_result(odp_packet_t packet)
 	ODP_ASSERT(ODP_EVENT_PACKET_IPSEC ==
 		   odp_event_subtype(odp_packet_to_event(packet)));
 
-	return &odp_packet_hdr(packet)->ipsec_ctx;
+	return &packet_hdr(packet)->ipsec_ctx;
 }
 
 static inline int _odp_ipv4_csum(odp_packet_t pkt,
@@ -829,7 +829,7 @@ static ipsec_sa_t *ipsec_in_single(odp_packet_t pkt,
 	return ipsec_sa;
 
 err:
-	pkt_hdr = odp_packet_hdr(pkt);
+	pkt_hdr = packet_hdr(pkt);
 	pkt_hdr->p.error_flags.ipsec_err = 1;
 
 	*pkt_out = pkt;
@@ -1404,7 +1404,7 @@ static ipsec_sa_t *ipsec_out_single(odp_packet_t pkt,
 	return ipsec_sa;
 
 err:
-	pkt_hdr = odp_packet_hdr(pkt);
+	pkt_hdr = packet_hdr(pkt);
 
 	pkt_hdr->p.error_flags.ipsec_err = 1;
 
@@ -1652,7 +1652,7 @@ int _odp_ipsec_try_inline(odp_packet_t pkt)
 	result->sa = ipsec_sa->ipsec_sa_hdl;
 	result->flag.inline_mode = 1;
 
-	pkt_hdr = odp_packet_hdr(pkt);
+	pkt_hdr = packet_hdr(pkt);
 	pkt_hdr->p.input_flags.dst_queue = 1;
 	pkt_hdr->dst_queue = queue_fn->from_ext(ipsec_sa->queue);
 

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -49,11 +49,6 @@ const _odp_packet_inline_offset_t ODP_ALIGNED_CACHE _odp_packet_inline = {
 
 #include <odp/visibility_end.h>
 
-static inline odp_packet_hdr_t *packet_hdr(odp_packet_t pkt)
-{
-	return (odp_packet_hdr_t *)(uintptr_t)pkt;
-}
-
 static inline odp_buffer_t buffer_handle(odp_packet_hdr_t *pkt_hdr)
 {
 	return (odp_buffer_t)pkt_hdr;
@@ -67,6 +62,11 @@ static inline odp_packet_hdr_t *buf_to_packet_hdr(odp_buffer_t buf)
 odp_packet_t _odp_packet_from_buf_hdr(odp_buffer_hdr_t *buf_hdr)
 {
 	return (odp_packet_t)buf_hdr;
+}
+
+static inline odp_buffer_t packet_to_buffer(odp_packet_t pkt)
+{
+	return (odp_buffer_t)pkt;
 }
 
 static inline seg_entry_t *seg_entry(odp_packet_hdr_t *hdr,

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1269,11 +1269,6 @@ void *odp_packet_offset(odp_packet_t pkt, uint32_t offset, uint32_t *len,
  *
  */
 
-int odp_packet_input_index(odp_packet_t pkt)
-{
-	return _odp_pktio_index(packet_hdr(pkt)->input);
-}
-
 void odp_packet_user_ptr_set(odp_packet_t pkt, const void *ctx)
 {
 	packet_hdr(pkt)->buf_hdr.buf_cctx = ctx;

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -49,15 +49,14 @@ const _odp_packet_inline_offset_t ODP_ALIGNED_CACHE _odp_packet_inline = {
 
 #include <odp/visibility_end.h>
 
-static inline odp_buffer_t buffer_handle(odp_packet_hdr_t *pkt_hdr)
-{
-	return (odp_buffer_t)pkt_hdr;
-}
-
-static inline odp_packet_hdr_t *buf_to_packet_hdr(odp_buffer_t buf)
-{
-	return (odp_packet_hdr_t *)buf_hdl_to_hdr(buf);
-}
+/* Check that invalid values are the same. Some versions of Clang have trouble
+ * with the strong type casting, and complain that these invalid values are not
+ * integral constants. */
+#ifndef __clang__
+ODP_STATIC_ASSERT(ODP_PACKET_INVALID == 0, "Packet invalid not 0");
+ODP_STATIC_ASSERT(ODP_BUFFER_INVALID == 0, "Buffer invalid not 0");
+ODP_STATIC_ASSERT(ODP_EVENT_INVALID  == 0, "Event invalid not 0");
+#endif
 
 odp_packet_t _odp_packet_from_buf_hdr(odp_buffer_hdr_t *buf_hdr)
 {
@@ -996,40 +995,6 @@ int odp_packet_reset(odp_packet_t pkt, uint32_t len)
 	packet_init(pkt_hdr, len);
 
 	return 0;
-}
-
-odp_packet_t odp_packet_from_event(odp_event_t ev)
-{
-	if (odp_unlikely(ev == ODP_EVENT_INVALID))
-		return ODP_PACKET_INVALID;
-
-	return (odp_packet_t)buf_to_packet_hdr((odp_buffer_t)ev);
-}
-
-odp_event_t odp_packet_to_event(odp_packet_t pkt)
-{
-	if (odp_unlikely(pkt == ODP_PACKET_INVALID))
-		return ODP_EVENT_INVALID;
-
-	return (odp_event_t)buffer_handle(packet_hdr(pkt));
-}
-
-void odp_packet_from_event_multi(odp_packet_t pkt[], const odp_event_t ev[],
-				 int num)
-{
-	int i;
-
-	for (i = 0; i < num; i++)
-		pkt[i] = odp_packet_from_event(ev[i]);
-}
-
-void odp_packet_to_event_multi(const odp_packet_t pkt[], odp_event_t ev[],
-			       int num)
-{
-	int i;
-
-	for (i = 0; i < num; i++)
-		ev[i] = odp_packet_to_event(pkt[i]);
 }
 
 int odp_event_filter_packet(const odp_event_t event[],

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -13,6 +13,8 @@
 #include <odp/api/hints.h>
 #include <odp/api/byteorder.h>
 #include <odp/api/plat/byteorder_inlines.h>
+#include <odp/api/packet_io.h>
+#include <odp/api/plat/pktio_inlines.h>
 
 #include <protocols/eth.h>
 #include <protocols/ip.h>
@@ -1269,7 +1271,7 @@ void *odp_packet_offset(odp_packet_t pkt, uint32_t offset, uint32_t *len,
 
 int odp_packet_input_index(odp_packet_t pkt)
 {
-	return odp_pktio_index(packet_hdr(pkt)->input);
+	return _odp_pktio_index(packet_hdr(pkt)->input);
 }
 
 void odp_packet_user_ptr_set(odp_packet_t pkt, const void *ctx)

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -1352,16 +1352,14 @@ void odp_packet_flow_hash_set(odp_packet_t pkt, uint32_t flow_hash)
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
-	pkt_hdr->flow_hash = flow_hash;
-	pkt_hdr->p.input_flags.flow_hash = 1;
+	packet_set_flow_hash(pkt_hdr, flow_hash);
 }
 
 void odp_packet_ts_set(odp_packet_t pkt, odp_time_t timestamp)
 {
 	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
-	pkt_hdr->timestamp = timestamp;
-	pkt_hdr->p.input_flags.timestamp = 1;
+	packet_set_ts(pkt_hdr, &timestamp);
 }
 
 /*

--- a/platform/linux-generic/odp_packet_flags.c
+++ b/platform/linux-generic/odp_packet_flags.c
@@ -11,18 +11,18 @@
 #include <odp_packet_internal.h>
 
 #define retflag(pkt, x) do {                             \
-	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt); \
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt); \
 	return pkt_hdr->p.x;                             \
 	} while (0)
 
 #define setflag(pkt, x, v) do {                          \
-	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt); \
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt); \
 	pkt_hdr->p.x = (v) & 1;				 \
 	} while (0)
 
 int odp_packet_has_error(odp_packet_t pkt)
 {
-	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
 	return pkt_hdr->p.error_flags.all != 0;
 }
@@ -31,7 +31,7 @@ int odp_packet_has_error(odp_packet_t pkt)
 
 int odp_packet_has_l2_error(odp_packet_t pkt)
 {
-	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 	/* L2 parsing is always done by default and hence
 	no additional check is required */
 	return pkt_hdr->p.error_flags.frame_len
@@ -46,7 +46,7 @@ int odp_packet_has_l3(odp_packet_t pkt)
 
 int odp_packet_has_l3_error(odp_packet_t pkt)
 {
-	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
 	return pkt_hdr->p.error_flags.ip_err;
 }
@@ -58,7 +58,7 @@ int odp_packet_has_l4(odp_packet_t pkt)
 
 int odp_packet_has_l4_error(odp_packet_t pkt)
 {
-	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
 	return pkt_hdr->p.error_flags.tcp_err | pkt_hdr->p.error_flags.udp_err;
 }
@@ -150,14 +150,14 @@ odp_packet_color_t odp_packet_color(odp_packet_t pkt)
 
 void odp_packet_color_set(odp_packet_t pkt, odp_packet_color_t color)
 {
-	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
 	pkt_hdr->p.input_flags.color = color;
 }
 
 odp_bool_t odp_packet_drop_eligible(odp_packet_t pkt)
 {
-	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
 	return !pkt_hdr->p.input_flags.nodrop;
 }
@@ -174,7 +174,7 @@ int8_t odp_packet_shaper_len_adjust(odp_packet_t pkt)
 
 void odp_packet_shaper_len_adjust_set(odp_packet_t pkt, int8_t adj)
 {
-	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
 	pkt_hdr->p.output_flags.shaper_len_adj = adj;
 }
@@ -288,14 +288,14 @@ void odp_packet_has_icmp_set(odp_packet_t pkt, int val)
 
 void odp_packet_has_flow_hash_clr(odp_packet_t pkt)
 {
-	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
 	pkt_hdr->p.input_flags.flow_hash = 0;
 }
 
 void odp_packet_has_ts_clr(odp_packet_t pkt)
 {
-	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+	odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
 	pkt_hdr->p.input_flags.timestamp = 0;
 }

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -570,7 +570,7 @@ static inline int pktin_recv_buf(odp_pktin_queue_t queue,
 
 	for (i = 0; i < pkts; i++) {
 		pkt = packets[i];
-		pkt_hdr = odp_packet_hdr(pkt);
+		pkt_hdr = packet_hdr(pkt);
 		buf_hdr = packet_to_buf_hdr(pkt);
 
 		if (pkt_hdr->p.input_flags.dst_queue) {
@@ -698,7 +698,7 @@ int sched_cb_pktin_poll_one(int pktio_index,
 	num_rx = 0;
 	for (i = 0; i < num_pkts; i++) {
 		pkt = packets[i];
-		pkt_hdr = odp_packet_hdr(pkt);
+		pkt_hdr = packet_hdr(pkt);
 		if (odp_unlikely(pkt_hdr->p.input_flags.dst_queue)) {
 			queue = pkt_hdr->dst_queue;
 			buf_hdr = packet_to_buf_hdr(pkt);

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -9,6 +9,7 @@
 #include <odp_posix_extensions.h>
 
 #include <odp/api/packet_io.h>
+#include <odp/api/plat/pktio_inlines.h>
 #include <odp_packet_io_internal.h>
 #include <odp/api/packet.h>
 #include <odp_packet_internal.h>
@@ -481,7 +482,7 @@ int odp_pktio_start(odp_pktio_t hdl)
 			}
 		}
 
-		sched_fn->pktio_start(pktio_to_id(hdl), num, index, odpq);
+		sched_fn->pktio_start(_odp_pktio_index(hdl), num, index, odpq);
 	}
 
 	return res;
@@ -1022,16 +1023,6 @@ int odp_pktio_info(odp_pktio_t hdl, odp_pktio_info_t *info)
 	return 0;
 }
 
-int odp_pktio_index(odp_pktio_t pktio)
-{
-	pktio_entry_t *entry = get_pktio_entry(pktio);
-
-	if (!entry || is_free(entry))
-		return -1;
-
-	return pktio_to_id(pktio);
-}
-
 uint64_t odp_pktin_ts_res(odp_pktio_t hdl)
 {
 	pktio_entry_t *entry;
@@ -1361,7 +1352,7 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 		    mode == ODP_PKTIN_MODE_SCHED) {
 			odp_queue_param_t queue_param;
 			char name[ODP_QUEUE_NAME_LEN];
-			int pktio_id = pktio_to_id(pktio);
+			int pktio_id = _odp_pktio_index(pktio);
 
 			snprintf(name, sizeof(name), "odp-pktin-%i-%i",
 				 pktio_id, i);
@@ -1496,7 +1487,7 @@ int odp_pktout_queue_config(odp_pktio_t pktio,
 			odp_queue_param_t queue_param;
 			queue_t q_int;
 			char name[ODP_QUEUE_NAME_LEN];
-			int pktio_id = pktio_to_id(pktio);
+			int pktio_id = _odp_pktio_index(pktio);
 
 			snprintf(name, sizeof(name), "odp-pktout-%i-%i",
 				 pktio_id, i);

--- a/platform/linux-generic/odp_pktio_api.c
+++ b/platform/linux-generic/odp_pktio_api.c
@@ -1,0 +1,14 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include <odp/api/packet_io.h>
+#include <odp/api/plat/pktio_inlines.h>
+
+/* Include non-inlined versions of API functions */
+#define _ODP_INLINE
+#include <odp/api/plat/pktio_inlines_api.h>

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -1941,8 +1941,8 @@ static void egress_vlan_marking(tm_vlan_marking_t *vlan_marking,
 	 * correctness rather then performance. */
 	split_hdr = hdr_len < (_ODP_ETHHDR_LEN + _ODP_VLANHDR_LEN);
 	if (split_hdr) {
-		odp_packet_copy_to_mem(odp_pkt, _ODP_ETHHDR_LEN,
-				       _ODP_VLANHDR_LEN, &vlan_hdr);
+		_odp_packet_copy_to_mem(odp_pkt, _ODP_ETHHDR_LEN,
+					_ODP_VLANHDR_LEN, &vlan_hdr);
 		vlan_hdr_ptr = &vlan_hdr;
 	}
 
@@ -1956,8 +1956,8 @@ static void egress_vlan_marking(tm_vlan_marking_t *vlan_marking,
 
 	vlan_hdr_ptr->tci = _odp_cpu_to_be_16(new_tci);
 	if (split_hdr)
-		odp_packet_copy_from_mem(odp_pkt, _ODP_ETHHDR_LEN,
-					 _ODP_VLANHDR_LEN, &vlan_hdr);
+		_odp_packet_copy_from_mem(odp_pkt, _ODP_ETHHDR_LEN,
+					  _ODP_VLANHDR_LEN, &vlan_hdr);
 }
 
 static void egress_ipv4_tos_marking(tm_tos_marking_t *tos_marking,
@@ -1980,8 +1980,8 @@ static void egress_ipv4_tos_marking(tm_tos_marking_t *tos_marking,
 	 * correctness rather then performance. */
 	split_hdr = hdr_len < 12;
 	if (split_hdr) {
-		odp_packet_copy_to_mem(odp_pkt, l3_offset,
-				       _ODP_IPV4HDR_LEN, &ipv4_hdr);
+		_odp_packet_copy_to_mem(odp_pkt, l3_offset,
+					_ODP_IPV4HDR_LEN, &ipv4_hdr);
 		ipv4_hdr_ptr = &ipv4_hdr;
 	}
 
@@ -2022,8 +2022,8 @@ static void egress_ipv4_tos_marking(tm_tos_marking_t *tos_marking,
 	ipv4_hdr_ptr->tos    = new_tos;
 	ipv4_hdr_ptr->chksum = _odp_cpu_to_be_16((~ones_compl_sum) & 0xFFFF);
 	if (split_hdr)
-		odp_packet_copy_from_mem(odp_pkt, l3_offset,
-					 _ODP_IPV4HDR_LEN, &ipv4_hdr);
+		_odp_packet_copy_from_mem(odp_pkt, l3_offset,
+					  _ODP_IPV4HDR_LEN, &ipv4_hdr);
 }
 
 static void egress_ipv6_tc_marking(tm_tos_marking_t *tos_marking,
@@ -2046,8 +2046,8 @@ static void egress_ipv6_tc_marking(tm_tos_marking_t *tos_marking,
 	 * correctness rather then performance. */
 	split_hdr = hdr_len < 4;
 	if (split_hdr) {
-		odp_packet_copy_to_mem(odp_pkt, l3_offset,
-				       _ODP_IPV6HDR_LEN, &ipv6_hdr);
+		_odp_packet_copy_to_mem(odp_pkt, l3_offset,
+					_ODP_IPV6HDR_LEN, &ipv6_hdr);
 		ipv6_hdr_ptr = &ipv6_hdr;
 	}
 
@@ -2075,8 +2075,8 @@ static void egress_ipv6_tc_marking(tm_tos_marking_t *tos_marking,
 	ipv6_hdr_ptr->ver_tc_flow = _odp_cpu_to_be_32(new_ver_tc_flow);
 
 	if (split_hdr)
-		odp_packet_copy_from_mem(odp_pkt, l3_offset,
-					 _ODP_IPV6HDR_LEN, &ipv6_hdr);
+		_odp_packet_copy_from_mem(odp_pkt, l3_offset,
+					  _ODP_IPV6HDR_LEN, &ipv6_hdr);
 }
 
 static void tm_egress_marking(tm_system_t *tm_system, odp_packet_t odp_pkt)

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -483,7 +483,7 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 					   pktio_entry->s.config.parser.layer);
 
 		if (mbuf->ol_flags & PKT_RX_RSS_HASH)
-			odp_packet_flow_hash_set(pkt, mbuf->hash.rss);
+			packet_set_flow_hash(pkt_hdr, mbuf->hash.rss);
 
 		packet_set_ts(pkt_hdr, ts);
 
@@ -723,7 +723,7 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 					   pktio_entry->s.config.parser.layer);
 
 		if (mbuf->ol_flags & PKT_RX_RSS_HASH)
-			odp_packet_flow_hash_set(pkt, mbuf->hash.rss);
+			packet_set_flow_hash(pkt_hdr, mbuf->hash.rss);
 
 		packet_set_ts(pkt_hdr, ts);
 

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -471,7 +471,7 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 		pkt_hdr = odp_packet_hdr(pkt);
 		pull_tail(pkt_hdr, alloc_len - pkt_len);
 
-		if (odp_packet_copy_from_mem(pkt, 0, pkt_len, data) != 0)
+		if (_odp_packet_copy_from_mem(pkt, 0, pkt_len, data) != 0)
 			goto fail;
 
 		pkt_hdr->input = pktio_entry->s.handle;
@@ -649,7 +649,7 @@ static inline int pkt_to_mbuf(pktio_entry_t *pktio_entry,
 		/* Packet always fits in mbuf */
 		data = rte_pktmbuf_append(mbuf_table[i], pkt_len);
 
-		odp_packet_copy_to_mem(pkt_table[i], 0, pkt_len, data);
+		_odp_packet_copy_to_mem(pkt_table[i], 0, pkt_len, data);
 
 		if (odp_unlikely(pktio_entry->s.chksum_insert_ena)) {
 			odp_pktout_config_opt_t *pktout_capa =

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -262,7 +262,7 @@ static int pool_dequeue_bulk(struct rte_mempool *mp, void **obj_table,
 
 	for (i = 0; i < pkts; i++) {
 		odp_packet_t pkt = packet_tbl[i];
-		odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+		odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 		struct rte_mbuf *mbuf = (struct rte_mbuf *)
 					(uintptr_t)pkt_hdr->extra;
 		if (pkt_hdr->extra_type != PKT_EXTRA_TYPE_DPDK)
@@ -468,7 +468,7 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 		}
 
 		pkt     = pkt_table[i];
-		pkt_hdr = odp_packet_hdr(pkt);
+		pkt_hdr = packet_hdr(pkt);
 		pull_tail(pkt_hdr, alloc_len - pkt_len);
 
 		if (_odp_packet_copy_from_mem(pkt, 0, pkt_len, data) != 0)
@@ -636,7 +636,7 @@ static inline int pkt_to_mbuf(pktio_entry_t *pktio_entry,
 		return 0;
 	}
 	for (i = 0; i < num; i++) {
-		odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt_table[i]);
+		odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt_table[i]);
 
 		pkt_len = packet_len(pkt_hdr);
 
@@ -697,7 +697,7 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 		pkt_len = rte_pktmbuf_pkt_len(mbuf);
 
 		pkt = (odp_packet_t)mbuf->userdata;
-		pkt_hdr = odp_packet_hdr(pkt);
+		pkt_hdr = packet_hdr(pkt);
 
 		if (pktio_cls_enabled(pktio_entry)) {
 			if (cls_classify_packet(pktio_entry,
@@ -754,7 +754,7 @@ static inline int pkt_to_mbuf_zero(pktio_entry_t *pktio_entry,
 
 	for (i = 0; i < num; i++) {
 		odp_packet_t pkt = pkt_table[i];
-		odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+		odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 		struct rte_mbuf *mbuf = (struct rte_mbuf *)
 					(uintptr_t)pkt_hdr->extra;
 		uint16_t pkt_len = odp_packet_len(pkt);
@@ -1606,7 +1606,7 @@ static int dpdk_send(pktio_entry_t *pktio_entry, int index,
 
 			for (i = 0; i < mbufs && freed != copy_count; i++) {
 				odp_packet_t pkt = pkt_table[i];
-				odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+				odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 
 				if (pkt_hdr->buf_hdr.segcount > 1) {
 					if (odp_likely(i < tx_pkts))

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -507,14 +507,14 @@ static int ipc_pktio_recv_lockless(pktio_entry_t *pktio_entry,
 		memcpy(pkt_data, rmt_data_ptr, phdr->frame_len);
 
 		/* Copy packets L2, L3 parsed offsets and size */
-		copy_packet_cls_metadata(phdr, odp_packet_hdr(pkt));
+		copy_packet_cls_metadata(phdr, packet_hdr(pkt));
 
-		odp_packet_hdr(pkt)->frame_len = phdr->frame_len;
-		odp_packet_hdr(pkt)->headroom = phdr->headroom;
-		odp_packet_hdr(pkt)->tailroom = phdr->tailroom;
+		packet_hdr(pkt)->frame_len = phdr->frame_len;
+		packet_hdr(pkt)->headroom = phdr->headroom;
+		packet_hdr(pkt)->tailroom = phdr->tailroom;
 
 		/* Take classification fields */
-		odp_packet_hdr(pkt)->p = phdr->p;
+		packet_hdr(pkt)->p = phdr->p;
 
 		pkt_table[i] = pkt;
 	}
@@ -604,7 +604,7 @@ static int ipc_pktio_send_lockless(pktio_entry_t *pktio_entry,
 		odp_packet_hdr_t *pkt_hdr;
 		pool_t *pool;
 
-		pkt_hdr = odp_packet_hdr(pkt);
+		pkt_hdr = packet_hdr(pkt);
 		pool = pkt_hdr->buf_hdr.pool_ptr;
 
 		if (pool->pool_idx != ipc_pool->pool_idx ||
@@ -626,7 +626,7 @@ static int ipc_pktio_send_lockless(pktio_entry_t *pktio_entry,
 	for (i = 0; i < num; i++) {
 		uint64_t data_pool_off;
 		odp_packet_t pkt = pkt_table_mapped[i];
-		odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+		odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 		odp_pool_t pool_hdl = odp_packet_pool(pkt);
 		pool_t *pool = pool_entry_from_hdl(pool_hdl);
 

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -101,7 +101,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 		pkt = packet_from_buf_hdr(hdr_tbl[i]);
 		pkt_len = odp_packet_len(pkt);
-		pkt_hdr = odp_packet_hdr(pkt);
+		pkt_hdr = packet_hdr(pkt);
 
 		packet_parse_reset(pkt_hdr);
 		if (pktio_cls_enabled(pktio_entry)) {

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -647,7 +647,7 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 		}
 
 		pkt = pkt_tbl[i];
-		pkt_hdr = odp_packet_hdr(pkt);
+		pkt_hdr = packet_hdr(pkt);
 		pull_tail(pkt_hdr, alloc_len - len);
 
 		/* For now copy the data in the mbuf,

--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -652,7 +652,7 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 
 		/* For now copy the data in the mbuf,
 		   worry about zero-copy later */
-		if (odp_packet_copy_from_mem(pkt, 0, len, slot.buf) != 0)
+		if (_odp_packet_copy_from_mem(pkt, 0, len, slot.buf) != 0)
 			goto fail;
 
 		pkt_hdr->input = pktio_entry->s.handle;
@@ -938,7 +938,7 @@ static int netmap_send(pktio_entry_t *pktio_entry, int index,
 
 			buf = NETMAP_BUF(ring, ring->slot[slot_id].buf_idx);
 
-			if (odp_packet_copy_to_mem(pkt, 0, pkt_len, buf)) {
+			if (_odp_packet_copy_to_mem(pkt, 0, pkt_len, buf)) {
 				i = NM_INJECT_RETRIES;
 				break;
 			}

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -39,6 +39,7 @@
 #include <odp_posix_extensions.h>
 
 #include <odp_api.h>
+#include <odp/api/plat/packet_inlines.h>
 #include <odp_packet_internal.h>
 #include <odp_packet_io_internal.h>
 
@@ -249,7 +250,7 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 
 		pkt_hdr = odp_packet_hdr(pkt);
 
-		if (odp_packet_copy_from_mem(pkt, 0, hdr->caplen, data) != 0) {
+		if (_odp_packet_copy_from_mem(pkt, 0, hdr->caplen, data) != 0) {
 			ODP_ERR("failed to copy packet data\n");
 			break;
 		}
@@ -283,7 +284,7 @@ static int _pcapif_dump_pkt(pkt_pcap_t *pcap, odp_packet_t pkt)
 	hdr.len = hdr.caplen;
 	(void)gettimeofday(&hdr.ts, NULL);
 
-	if (odp_packet_copy_to_mem(pkt, 0, hdr.len, pcap->buf) != 0)
+	if (_odp_packet_copy_to_mem(pkt, 0, hdr.len, pcap->buf) != 0)
 		return -1;
 
 	pcap_dump(pcap->tx_dump, &hdr, pcap->buf);

--- a/platform/linux-generic/pktio/pcap.c
+++ b/platform/linux-generic/pktio/pcap.c
@@ -248,7 +248,7 @@ static int pcapif_recv_pkt(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 		if (ts != NULL)
 			ts_val = odp_time_global();
 
-		pkt_hdr = odp_packet_hdr(pkt);
+		pkt_hdr = packet_hdr(pkt);
 
 		if (_odp_packet_copy_from_mem(pkt, 0, hdr->caplen, data) != 0) {
 			ODP_ERR("failed to copy packet data\n");

--- a/platform/linux-generic/pktio/socket.c
+++ b/platform/linux-generic/pktio/socket.c
@@ -639,7 +639,7 @@ static int sock_mmsg_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 		void *base = msgvec[i].msg_hdr.msg_iov->iov_base;
 		struct ethhdr *eth_hdr = base;
 		odp_packet_t pkt = pkt_table[i];
-		odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+		odp_packet_hdr_t *pkt_hdr = packet_hdr(pkt);
 		uint16_t pkt_len = msgvec[i].msg_len;
 		int ret;
 

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -243,7 +243,7 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 			frame_num = next_frame_num;
 			continue;
 		}
-		hdr = odp_packet_hdr(pkt_table[nb_rx]);
+		hdr = packet_hdr(pkt_table[nb_rx]);
 		ret = _odp_packet_copy_from_mem(pkt_table[nb_rx], 0,
 						pkt_len, pkt_buf);
 		if (ret != 0) {

--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -26,6 +26,7 @@
 #include <time.h>
 
 #include <odp_api.h>
+#include <odp/api/plat/packet_inlines.h>
 #include <odp_packet_socket.h>
 #include <odp_packet_internal.h>
 #include <odp_packet_io_internal.h>
@@ -243,8 +244,8 @@ static inline unsigned pkt_mmap_v2_rx(pktio_entry_t *pktio_entry,
 			continue;
 		}
 		hdr = odp_packet_hdr(pkt_table[nb_rx]);
-		ret = odp_packet_copy_from_mem(pkt_table[nb_rx], 0,
-					       pkt_len, pkt_buf);
+		ret = _odp_packet_copy_from_mem(pkt_table[nb_rx], 0,
+						pkt_len, pkt_buf);
 		if (ret != 0) {
 			odp_packet_free(pkt_table[nb_rx]);
 			mmap_rx_user_ready(ppd.raw); /* drop */
@@ -345,7 +346,7 @@ static inline unsigned pkt_mmap_v2_tx(int sock, struct ring *ring,
 
 		buf = (uint8_t *)ppd.raw + TPACKET2_HDRLEN -
 		       sizeof(struct sockaddr_ll);
-		odp_packet_copy_to_mem(pkt_table[i], 0, pkt_len, buf);
+		_odp_packet_copy_to_mem(pkt_table[i], 0, pkt_len, buf);
 
 		mmap_tx_user_ready(ppd.raw);
 

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -280,7 +280,7 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 		return ODP_PACKET_INVALID;
 	}
 
-	pkt_hdr = odp_packet_hdr(pkt);
+	pkt_hdr = packet_hdr(pkt);
 
 	if (pktio_cls_enabled(pktio_entry))
 		copy_packet_cls_metadata(&parsed_hdr, pkt_hdr);

--- a/platform/linux-generic/pktio/tap.c
+++ b/platform/linux-generic/pktio/tap.c
@@ -42,6 +42,7 @@
 #include <linux/if_tun.h>
 
 #include <odp_api.h>
+#include <odp/api/plat/packet_inlines.h>
 #include <odp_packet_socket.h>
 #include <odp_packet_internal.h>
 #include <odp_packet_io_internal.h>
@@ -273,7 +274,7 @@ static odp_packet_t pack_odp_pkt(pktio_entry_t *pktio_entry, const void *data,
 	if (num != 1)
 		return ODP_PACKET_INVALID;
 
-	if (odp_packet_copy_from_mem(pkt, 0, len, data) < 0) {
+	if (_odp_packet_copy_from_mem(pkt, 0, len, data) < 0) {
 		ODP_ERR("failed to copy packet data\n");
 		odp_packet_free(pkt);
 		return ODP_PACKET_INVALID;
@@ -352,7 +353,7 @@ static int tap_pktio_send_lockless(pktio_entry_t *pktio_entry,
 			break;
 		}
 
-		if (odp_packet_copy_to_mem(pkts[i], 0, pkt_len, buf) < 0) {
+		if (_odp_packet_copy_to_mem(pkts[i], 0, pkt_len, buf) < 0) {
 			ODP_ERR("failed to copy packet data\n");
 			break;
 		}

--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -270,12 +270,10 @@ static inline int event_queue_send(odp_queue_t queue, odp_packet_t *pkt_tbl,
 				   unsigned pkts)
 {
 	int ret;
-	unsigned i;
 	unsigned sent = 0;
 	odp_event_t ev_tbl[pkts];
 
-	for (i = 0; i < pkts; i++)
-		ev_tbl[i] = odp_packet_to_event(pkt_tbl[i]);
+	odp_packet_to_event_multi(pkt_tbl, ev_tbl, pkts);
 
 	while (sent < pkts) {
 		ret = odp_queue_enq_multi(queue, &ev_tbl[sent], pkts - sent);
@@ -373,8 +371,7 @@ static int run_worker_sched_mode(void *arg)
 		if (pkts <= 0)
 			continue;
 
-		for (i = 0; i < pkts; i++)
-			pkt_tbl[i] = odp_packet_from_event(ev_tbl[i]);
+		odp_packet_from_event_multi(pkt_tbl, ev_tbl, pkts);
 
 		if (odp_unlikely(gbl_args->appl.extra_check)) {
 			if (gbl_args->appl.chksum)
@@ -499,8 +496,7 @@ static int run_worker_plain_queue_mode(void *arg)
 		if (odp_unlikely(pkts <= 0))
 			continue;
 
-		for (i = 0; i < pkts; i++)
-			pkt_tbl[i] = odp_packet_from_event(event[i]);
+		odp_packet_from_event_multi(pkt_tbl, event, pkts);
 
 		if (odp_unlikely(gbl_args->appl.extra_check)) {
 			if (gbl_args->appl.chksum)

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -1183,7 +1183,7 @@ void pktio_test_lookup(void)
 
 void pktio_test_index(void)
 {
-	odp_pktio_t pktio, pktio_inval = ODP_PKTIO_INVALID;
+	odp_pktio_t pktio;
 	odp_pktio_param_t pktio_param;
 	int ndx;
 
@@ -1195,10 +1195,8 @@ void pktio_test_index(void)
 
 	ndx = odp_pktio_index(pktio);
 	CU_ASSERT(ndx >= 0);
-	CU_ASSERT(odp_pktio_index(pktio_inval) < 0);
 
 	CU_ASSERT(odp_pktio_close(pktio) == 0);
-	CU_ASSERT(odp_pktio_index(pktio) < 0);
 }
 
 static void pktio_test_print(void)


### PR DESCRIPTION
Continue inlining of commonly used small packet and pktio API functions. These improve few percents  packet rate of L2fwd (both direct/scheduled mode) and OFP burst test. Especially, in non-ABI compat mode and with copying pktios (test with DPDK). 