### PR TITLE
[PATCH API-NEXT v1] api: init: shm memory size

### DIFF
--- a/platform/linux-generic/_ishm.c
+++ b/platform/linux-generic/_ishm.c
@@ -258,7 +258,7 @@ static void *alloc_fragment(uintptr_t size, int block_index, intptr_t align,
 	ishm_fragment_t *rem_fragmnt;
 	uintptr_t border;/* possible start of new fragment (next alignement)  */
 	intptr_t left;	 /* room remaining after, if the segment is allocated */
-	uintptr_t remainder = ODP_CONFIG_ISHM_VA_PREALLOC_SZ;
+	uintptr_t remainder = odp_global_data.shm_max_memory;
 
 	/*
 	 * search for the best bit, i.e. search for the unallocated fragment
@@ -1436,7 +1436,7 @@ int _odp_ishm_cleanup_files(const char *dirpath)
 	return 0;
 }
 
-int _odp_ishm_init_global(void)
+int _odp_ishm_init_global(const odp_init_t *init)
 {
 	void *addr;
 	void *spce_addr;
@@ -1444,7 +1444,15 @@ int _odp_ishm_init_global(void)
 	uid_t uid;
 	char *hp_dir = odp_global_data.hugepage_info.default_huge_page_dir;
 	uint64_t align;
+	uint64_t max_memory = ODP_CONFIG_ISHM_VA_PREALLOC_SZ;
+	uint64_t internal   = ODP_CONFIG_ISHM_VA_PREALLOC_SZ / 8;
 
+	/* user requested memory size + some extra for internal use */
+	if (init && init->shm.max_memory)
+		max_memory = init->shm.max_memory + internal;
+
+	odp_global_data.shm_max_memory = max_memory;
+	odp_global_data.shm_max_size   = max_memory - internal;
 	odp_global_data.main_pid = getpid();
 	odp_global_data.shm_dir = getenv("ODP_SHM_DIR");
 	if (odp_global_data.shm_dir) {
@@ -1507,7 +1515,7 @@ int _odp_ishm_init_global(void)
 	 *reserve the address space for _ODP_ISHM_SINGLE_VA reserved blocks,
 	 * only address space!
 	 */
-	spce_addr = _odp_ishmphy_book_va(ODP_CONFIG_ISHM_VA_PREALLOC_SZ, align);
+	spce_addr = _odp_ishmphy_book_va(max_memory, align);
 	if (!spce_addr) {
 		ODP_ERR("unable to reserve virtual space\n.");
 		goto init_glob_err3;
@@ -1516,7 +1524,7 @@ int _odp_ishm_init_global(void)
 	/* use the first fragment descriptor to describe to whole VA space: */
 	ishm_ftbl->fragment[0].block_index   = -1;
 	ishm_ftbl->fragment[0].start = spce_addr;
-	ishm_ftbl->fragment[0].len   = ODP_CONFIG_ISHM_VA_PREALLOC_SZ;
+	ishm_ftbl->fragment[0].len   = max_memory;
 	ishm_ftbl->fragment[0].prev  = NULL;
 	ishm_ftbl->fragment[0].next  = NULL;
 	ishm_ftbl->used_fragmnts   = &ishm_ftbl->fragment[0];

--- a/platform/linux-generic/include/odp_internal.h
+++ b/platform/linux-generic/include/odp_internal.h
@@ -44,6 +44,8 @@ typedef struct {
 struct odp_global_data_s {
 	char *shm_dir; /*< directory for odp mmaped files */
 	int   shm_dir_from_env; /*< overload default with env */
+	uint64_t shm_max_memory;
+	uint64_t shm_max_size;
 	pid_t main_pid;
 	char uid[UID_MAXLEN];
 	odp_log_func_t log_fn;
@@ -129,7 +131,7 @@ int _odp_int_name_tbl_term_global(void);
 int _odp_fdserver_init_global(void);
 int _odp_fdserver_term_global(void);
 
-int _odp_ishm_init_global(void);
+int _odp_ishm_init_global(const odp_init_t *init);
 int _odp_ishm_init_local(void);
 int _odp_ishm_term_global(void);
 int _odp_ishm_term_local(void);

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -122,6 +122,7 @@ struct ipsec_sa_s {
 
 	uint8_t		salt[IPSEC_MAX_SALT_LEN];
 	uint32_t	salt_length;
+	odp_ipsec_lookup_mode_t lookup_mode;
 
 	union {
 		unsigned flags;
@@ -144,7 +145,6 @@ struct ipsec_sa_s {
 
 	union {
 		struct {
-			odp_ipsec_lookup_mode_t lookup_mode;
 			odp_ipsec_ip_version_t lookup_ver;
 			union {
 				odp_u32be_t	lookup_dst_ipv4;

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -221,7 +221,7 @@ static inline void _cls_queue_unwind(uint32_t tbl_index, uint32_t j)
 
 odp_cos_t odp_cls_cos_create(const char *name, odp_cls_cos_param_t *param)
 {
-	int i, j;
+	uint32_t i, j;
 	odp_queue_t queue;
 	odp_cls_drop_t drop_policy;
 	cos_t *cos;
@@ -258,7 +258,7 @@ odp_cos_t odp_cls_cos_create(const char *name, odp_cls_cos_param_t *param)
 				_odp_cls_update_hash_proto(cos,
 							   param->hash_proto);
 				tbl_index = i * CLS_COS_QUEUE_MAX;
-				for (j = 0; j < CLS_COS_QUEUE_MAX; j++) {
+				for (j = 0; j < param->num_queue; j++) {
 					queue = odp_queue_create(NULL, &cos->s.
 								 queue_param);
 					if (queue == ODP_QUEUE_INVALID) {
@@ -988,8 +988,10 @@ int cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 	if (cos == NULL)
 		return -EINVAL;
 
-	if (cos->s.queue == ODP_QUEUE_INVALID ||
-	    cos->s.pool == ODP_POOL_INVALID)
+	if (cos->s.queue == ODP_QUEUE_INVALID && cos->s.num_queue == 1)
+		return -EFAULT;
+
+	if (cos->s.pool == ODP_POOL_INVALID)
 		return -EFAULT;
 
 	*pool = cos->s.pool;
@@ -1003,7 +1005,8 @@ int cls_classify_packet(pktio_entry_t *entry, const uint8_t *base,
 	hash = packet_rss_hash(pkt_hdr, cos->s.hash_proto, base);
 	/* CLS_COS_QUEUE_MAX is a power of 2 */
 	hash = hash & (CLS_COS_QUEUE_MAX - 1);
-	tbl_index = (cos->s.index * CLS_COS_QUEUE_MAX) + hash;
+	tbl_index = (cos->s.index * CLS_COS_QUEUE_MAX) + (hash %
+							  cos->s.num_queue);
 	pkt_hdr->dst_queue = queue_fn->from_ext(queue_grp_tbl->
 						s.queue[tbl_index]);
 	return 0;

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -66,7 +66,7 @@ int odp_init_global(odp_instance_t *instance,
 	}
 	stage = SYSINFO_INIT;
 
-	if (_odp_ishm_init_global()) {
+	if (_odp_ishm_init_global(params)) {
 		ODP_ERR("ODP ishm init failed.\n");
 		goto init_failed;
 	}

--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -12,6 +12,7 @@
 #include <odp/api/shared_memory.h>
 #include <odp/api/plat/strong_types.h>
 #include <_ishm_internal.h>
+#include <odp_internal.h>
 #include <string.h>
 
 ODP_STATIC_ASSERT(ODP_CONFIG_SHM_BLOCKS >= ODP_CONFIG_POOLS,
@@ -47,7 +48,7 @@ int odp_shm_capability(odp_shm_capability_t *capa)
 	memset(capa, 0, sizeof(odp_shm_capability_t));
 
 	capa->max_blocks = ODP_CONFIG_SHM_BLOCKS;
-	capa->max_size = 0;
+	capa->max_size = odp_global_data.shm_max_size;
 	capa->max_align = 0;
 
 	return 0;

--- a/test/validation/api/shmem/shmem.c
+++ b/test/validation/api/shmem/shmem.c
@@ -22,6 +22,8 @@
 #define STRESS_SIZE 32		/* power of 2 and <=256 */
 #define STRESS_RANDOM_SZ 5
 #define STRESS_ITERATION 5000
+#define MEGA            1000000UL
+#define MAX_MEMORY_USED (100 * MEGA)
 
 typedef enum {
 	STRESS_FREE, /* entry is free and can be allocated */
@@ -210,6 +212,55 @@ void shmem_test_basic(void)
 	odp_shm_print(shm);
 
 	CU_ASSERT(0 == odp_shm_free(shm));
+}
+
+/*
+ * maximum size reservation
+ */
+static void shmem_test_max_reserve(void)
+{
+	odp_shm_capability_t capa;
+	odp_shm_t shm;
+	uint64_t size, align;
+	uint8_t *data;
+	uint64_t i;
+
+	memset(&capa, 0, sizeof(odp_shm_capability_t));
+	CU_ASSERT_FATAL(odp_shm_capability(&capa) == 0);
+
+	CU_ASSERT(capa.max_blocks > 0);
+
+	size  = capa.max_size;
+	align = capa.max_align;
+
+	/* Assuming that system has at least MAX_MEMORY_USED bytes available */
+	if (capa.max_size == 0 || capa.max_size > MAX_MEMORY_USED)
+		size = MAX_MEMORY_USED;
+
+	if (capa.max_align == 0 || capa.max_align > MEGA)
+		align = MEGA;
+
+	printf("\n    size:  %" PRIu64 "\n", size);
+	printf("    align: %" PRIu64 "\n", align);
+
+	shm = odp_shm_reserve("test_max_reserve", size, align, 0);
+	CU_ASSERT(shm != ODP_SHM_INVALID);
+
+	data = odp_shm_addr(shm);
+	CU_ASSERT(data != NULL);
+
+	if (data) {
+		memset(data, 0xde, size);
+		for (i = 0; i < size; i++) {
+			if (data[i] != 0xde) {
+				CU_FAIL("Data error");
+				break;
+			}
+		}
+	}
+
+	if (shm != ODP_SHM_INVALID)
+		CU_ASSERT(odp_shm_free(shm) == 0);
 }
 
 /*
@@ -769,6 +820,7 @@ void shmem_test_stress(void)
 
 odp_testinfo_t shmem_suite[] = {
 	ODP_TEST_INFO(shmem_test_basic),
+	ODP_TEST_INFO(shmem_test_max_reserve),
 	ODP_TEST_INFO(shmem_test_reserve_after_fork),
 	ODP_TEST_INFO(shmem_test_singleva_after_fork),
 	ODP_TEST_INFO(shmem_test_stress),


### PR DESCRIPTION
Application memory usage vary a lot. E.g. OFP cannot scale to high number of route table entries due to SHM having a fixed limit of 512 MB.