### PR TITLE
[PATCH API-NEXT v2] api: init: global shm memory size

### DIFF
--- a/include/odp/api/spec/init.h
+++ b/include/odp/api/spec/init.h
@@ -107,23 +107,29 @@ typedef int (*odp_log_func_t)(odp_log_level_t level, const char *fmt, ...);
 typedef void (*odp_abort_func_t)(void) ODP_NORETURN;
 
 /**
- * ODP initialization data
+ * Global initialization parameters
  *
- * Data that is required to initialize the ODP API with the
- * application specific data such as specifying a logging callback, the log
- * level etc.
+ * These parameters may be used at global initialization time to configure and
+ * optimize ODP implementation to match the intended usage. Application
+ * specifies maximum resource usage. Implementation may round up resource
+ * reservations as needed. Initialization function returns a failure if resource
+ * requirements are too high. Init parameters may be used also to override
+ * logging and abort functions.
  *
- * @note It is expected that all unassigned members are zero
+ * Use odp_init_param_init() to initialize the parameters into their default
+ * values. Unused parameters are left to default values.
  */
 typedef struct odp_init_t {
 	/** Maximum number of worker threads the user will run concurrently.
 	    Valid range is from 0 to platform specific maximum. Set both
 	    num_worker and num_control to zero for default number of threads. */
 	int num_worker;
+
 	/** Maximum number of control threads the user will run concurrently.
 	    Valid range is from 0 to platform specific maximum. Set both
 	    num_worker and num_control to zero for default number of threads. */
 	int num_control;
+
 	/** Pointer to bit mask mapping CPUs available to this ODP instance
 	    for running worker threads.
 	    Initialize to a NULL pointer to use default CPU mapping.
@@ -139,6 +145,7 @@ typedef struct odp_init_t {
 		  worker masks
 	 */
 	const odp_cpumask_t *worker_cpus;
+
 	/** Pointer to bit mask mapping CPUs available to this ODP instance
 	    for running control threads.
 	    Initialize to a NULL pointer to use default CPU mapping.
@@ -150,10 +157,13 @@ typedef struct odp_init_t {
 	    worker and control masks do not overlap.
 	 */
 	const odp_cpumask_t *control_cpus;
+
 	/** Replacement for the default log fn */
 	odp_log_func_t log_fn;
+
 	/** Replacement for the default abort fn */
 	odp_abort_func_t abort_fn;
+
 	/** Unused features. These are hints to the ODP implementation that
 	 * the application will not use any APIs associated with these
 	 * features. Implementations may use this information to provide
@@ -161,6 +171,16 @@ typedef struct odp_init_t {
 	 * that a feature will not be used and it is used anyway.
 	 */
 	odp_feature_t not_used;
+
+	/** Shared memory parameters */
+	struct {
+		/** Maximum memory usage in bytes. This is the maximum
+		 *  amount of shared memory that application will reserve
+		 *  concurrently. Use 0 when not set. Default value is 0.
+		 */
+		uint64_t max_memory;
+	} shm;
+
 } odp_init_t;
 
 /**
@@ -189,7 +209,8 @@ void odp_init_param_init(odp_init_t *param);
  * system and outputs a handle for it. The handle is used in other calls
  * (e.g. odp_init_local()) as a reference to the instance. When user provides
  * configuration parameters, the platform may configure and optimize the
- * instance to match user requirements.
+ * instance to match user requirements. A failure is returned if requirements
+ * cannot be met.
  *
  * Configuration parameters are divided into standard and platform specific
  * parts. Standard parameters are supported by any ODP platform, where as

--- a/platform/linux-generic/_ishm.c
+++ b/platform/linux-generic/_ishm.c
@@ -258,7 +258,7 @@ static void *alloc_fragment(uintptr_t size, int block_index, intptr_t align,
 	ishm_fragment_t *rem_fragmnt;
 	uintptr_t border;/* possible start of new fragment (next alignement)  */
 	intptr_t left;	 /* room remaining after, if the segment is allocated */
-	uintptr_t remainder = ODP_CONFIG_ISHM_VA_PREALLOC_SZ;
+	uintptr_t remainder = odp_global_data.shm_max_memory;
 
 	/*
 	 * search for the best bit, i.e. search for the unallocated fragment
@@ -1436,7 +1436,7 @@ int _odp_ishm_cleanup_files(const char *dirpath)
 	return 0;
 }
 
-int _odp_ishm_init_global(void)
+int _odp_ishm_init_global(const odp_init_t *init)
 {
 	void *addr;
 	void *spce_addr;
@@ -1444,7 +1444,15 @@ int _odp_ishm_init_global(void)
 	uid_t uid;
 	char *hp_dir = odp_global_data.hugepage_info.default_huge_page_dir;
 	uint64_t align;
+	uint64_t max_memory = ODP_CONFIG_ISHM_VA_PREALLOC_SZ;
+	uint64_t internal   = ODP_CONFIG_ISHM_VA_PREALLOC_SZ / 8;
 
+	/* user requested memory size + some extra for internal use */
+	if (init && init->shm.max_memory)
+		max_memory = init->shm.max_memory + internal;
+
+	odp_global_data.shm_max_memory = max_memory;
+	odp_global_data.shm_max_size   = max_memory - internal;
 	odp_global_data.main_pid = getpid();
 	odp_global_data.shm_dir = getenv("ODP_SHM_DIR");
 	if (odp_global_data.shm_dir) {
@@ -1507,7 +1515,7 @@ int _odp_ishm_init_global(void)
 	 *reserve the address space for _ODP_ISHM_SINGLE_VA reserved blocks,
 	 * only address space!
 	 */
-	spce_addr = _odp_ishmphy_book_va(ODP_CONFIG_ISHM_VA_PREALLOC_SZ, align);
+	spce_addr = _odp_ishmphy_book_va(max_memory, align);
 	if (!spce_addr) {
 		ODP_ERR("unable to reserve virtual space\n.");
 		goto init_glob_err3;
@@ -1516,7 +1524,7 @@ int _odp_ishm_init_global(void)
 	/* use the first fragment descriptor to describe to whole VA space: */
 	ishm_ftbl->fragment[0].block_index   = -1;
 	ishm_ftbl->fragment[0].start = spce_addr;
-	ishm_ftbl->fragment[0].len   = ODP_CONFIG_ISHM_VA_PREALLOC_SZ;
+	ishm_ftbl->fragment[0].len   = max_memory;
 	ishm_ftbl->fragment[0].prev  = NULL;
 	ishm_ftbl->fragment[0].next  = NULL;
 	ishm_ftbl->used_fragmnts   = &ishm_ftbl->fragment[0];

--- a/platform/linux-generic/include/odp_internal.h
+++ b/platform/linux-generic/include/odp_internal.h
@@ -44,6 +44,8 @@ typedef struct {
 struct odp_global_data_s {
 	char *shm_dir; /*< directory for odp mmaped files */
 	int   shm_dir_from_env; /*< overload default with env */
+	uint64_t shm_max_memory;
+	uint64_t shm_max_size;
 	pid_t main_pid;
 	char uid[UID_MAXLEN];
 	odp_log_func_t log_fn;
@@ -129,7 +131,7 @@ int _odp_int_name_tbl_term_global(void);
 int _odp_fdserver_init_global(void);
 int _odp_fdserver_term_global(void);
 
-int _odp_ishm_init_global(void);
+int _odp_ishm_init_global(const odp_init_t *init);
 int _odp_ishm_init_local(void);
 int _odp_ishm_term_global(void);
 int _odp_ishm_term_local(void);

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -66,7 +66,7 @@ int odp_init_global(odp_instance_t *instance,
 	}
 	stage = SYSINFO_INIT;
 
-	if (_odp_ishm_init_global()) {
+	if (_odp_ishm_init_global(params)) {
 		ODP_ERR("ODP ishm init failed.\n");
 		goto init_failed;
 	}

--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -12,6 +12,7 @@
 #include <odp/api/shared_memory.h>
 #include <odp/api/plat/strong_types.h>
 #include <_ishm_internal.h>
+#include <odp_internal.h>
 #include <string.h>
 
 ODP_STATIC_ASSERT(ODP_CONFIG_SHM_BLOCKS >= ODP_CONFIG_POOLS,
@@ -47,7 +48,7 @@ int odp_shm_capability(odp_shm_capability_t *capa)
 	memset(capa, 0, sizeof(odp_shm_capability_t));
 
 	capa->max_blocks = ODP_CONFIG_SHM_BLOCKS;
-	capa->max_size = 0;
+	capa->max_size = odp_global_data.shm_max_size;
 	capa->max_align = 0;
 
 	return 0;

--- a/test/validation/api/shmem/shmem.c
+++ b/test/validation/api/shmem/shmem.c
@@ -22,6 +22,8 @@
 #define STRESS_SIZE 32		/* power of 2 and <=256 */
 #define STRESS_RANDOM_SZ 5
 #define STRESS_ITERATION 5000
+#define MAX_SIZE_TESTED  (100 * 1000000UL)
+#define MAX_ALIGN_TESTED (1024 * 1024)
 
 typedef enum {
 	STRESS_FREE, /* entry is free and can be allocated */
@@ -210,6 +212,57 @@ void shmem_test_basic(void)
 	odp_shm_print(shm);
 
 	CU_ASSERT(0 == odp_shm_free(shm));
+}
+
+/*
+ * maximum size reservation
+ */
+static void shmem_test_max_reserve(void)
+{
+	odp_shm_capability_t capa;
+	odp_shm_t shm;
+	uint64_t size, align;
+	uint8_t *data;
+	uint64_t i;
+
+	memset(&capa, 0, sizeof(odp_shm_capability_t));
+	CU_ASSERT_FATAL(odp_shm_capability(&capa) == 0);
+
+	CU_ASSERT(capa.max_blocks > 0);
+
+	size  = capa.max_size;
+	align = capa.max_align;
+
+	/* Assuming that system has at least MAX_SIZE_TESTED bytes available */
+	if (capa.max_size == 0 || capa.max_size > MAX_SIZE_TESTED)
+		size = MAX_SIZE_TESTED;
+
+	if (capa.max_align == 0 || capa.max_align > MAX_ALIGN_TESTED)
+		align = MAX_ALIGN_TESTED;
+
+	printf("\n    size:  %" PRIu64 "\n", size);
+	printf("    align: %" PRIu64 "\n", align);
+
+	shm = odp_shm_reserve("test_max_reserve", size, align, 0);
+	CU_ASSERT(shm != ODP_SHM_INVALID);
+
+	data = odp_shm_addr(shm);
+	CU_ASSERT(data != NULL);
+
+	if (data) {
+		memset(data, 0xde, size);
+		for (i = 0; i < size; i++) {
+			if (data[i] != 0xde) {
+				printf("    data error i:%" PRIu64 ", data %x"
+				       "\n", i, data[i]);
+				CU_FAIL("Data error");
+				break;
+			}
+		}
+	}
+
+	if (shm != ODP_SHM_INVALID)
+		CU_ASSERT(odp_shm_free(shm) == 0);
 }
 
 /*
@@ -769,6 +822,7 @@ void shmem_test_stress(void)
 
 odp_testinfo_t shmem_suite[] = {
 	ODP_TEST_INFO(shmem_test_basic),
+	ODP_TEST_INFO(shmem_test_max_reserve),
 	ODP_TEST_INFO(shmem_test_reserve_after_fork),
 	ODP_TEST_INFO(shmem_test_singleva_after_fork),
 	ODP_TEST_INFO(shmem_test_stress),


### PR DESCRIPTION
Memory usage vary a lot between applications. If implementation has to decide a hard limit at init time (as odp-linux does), it's hard to pick a value that is large enough for every application but don't reserve too much memory in average. E.g. OFP already suffers from current fixed limit of 512MB in odp-linux.