### PR TITLE
[PATCH v1] travis: install codespell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
                         - gcc
                         - clang-3.8
                         - automake autoconf libtool libssl-dev graphviz mscgen
+                        - codespell
                         - libpcap-dev
                         - libnuma-dev
 #        coverity_scan:


### PR DESCRIPTION
Install codespell to let checkpatch find typical typos.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>