### PR TITLE
[PATCH API-NEXT v1] validation: crypto: properly use check_alg for GMAC/CMAC testing

### DIFF
--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -1243,31 +1243,22 @@ static int check_alg_aes_gmac(void)
 
 static void crypto_test_gen_alg_aes_gmac(void)
 {
-	unsigned int test_vec_num = (sizeof(aes_gmac_reference) /
-				     sizeof(aes_gmac_reference[0]));
-	unsigned int i;
-
-	for (i = 0; i < test_vec_num; i++)
-		check_alg(ODP_CRYPTO_OP_ENCODE,
-			  ODP_CIPHER_ALG_NULL,
-			  ODP_AUTH_ALG_AES_GMAC,
-			  aes_gmac_reference,
-			  ARRAY_SIZE(aes_gmac_reference),
-			  false);
+	check_alg(ODP_CRYPTO_OP_ENCODE,
+		  ODP_CIPHER_ALG_NULL,
+		  ODP_AUTH_ALG_AES_GMAC,
+		  aes_gmac_reference,
+		  ARRAY_SIZE(aes_gmac_reference),
+		  false);
 }
 
 static void crypto_test_gen_alg_aes_gmac_ovr_iv(void)
 {
-	unsigned int test_vec_num = (sizeof(aes_gmac_reference) /
-				     sizeof(aes_gmac_reference[0]));
-	unsigned int i;
-
-	for (i = 0; i < test_vec_num; i++)
-		alg_test(ODP_CRYPTO_OP_ENCODE,
-			 ODP_CIPHER_ALG_NULL,
-			 ODP_AUTH_ALG_AES_GMAC,
-			 &aes_gmac_reference[i],
-			 true);
+	check_alg(ODP_CRYPTO_OP_ENCODE,
+		  ODP_CIPHER_ALG_NULL,
+		  ODP_AUTH_ALG_AES_GMAC,
+		  aes_gmac_reference,
+		  ARRAY_SIZE(aes_gmac_reference),
+		  true);
 }
 
 static void crypto_test_check_alg_aes_gmac(void)
@@ -1282,16 +1273,12 @@ static void crypto_test_check_alg_aes_gmac(void)
 
 static void crypto_test_check_alg_aes_gmac_ovr_iv(void)
 {
-	unsigned int test_vec_num = (sizeof(aes_gmac_reference) /
-				     sizeof(aes_gmac_reference[0]));
-	unsigned int i;
-
-	for (i = 0; i < test_vec_num; i++)
-		alg_test(ODP_CRYPTO_OP_DECODE,
-			 ODP_CIPHER_ALG_NULL,
-			 ODP_AUTH_ALG_AES_GMAC,
-			 &aes_gmac_reference[i],
-			 true);
+	check_alg(ODP_CRYPTO_OP_DECODE,
+		  ODP_CIPHER_ALG_NULL,
+		  ODP_AUTH_ALG_AES_GMAC,
+		  aes_gmac_reference,
+		  ARRAY_SIZE(aes_gmac_reference),
+		  false);
 }
 
 static int check_alg_aes_cmac(void)
@@ -1301,17 +1288,12 @@ static int check_alg_aes_cmac(void)
 
 static void crypto_test_gen_alg_aes_cmac(void)
 {
-	unsigned int test_vec_num = (sizeof(aes_cmac_reference) /
-				     sizeof(aes_cmac_reference[0]));
-	unsigned int i;
-
-	for (i = 0; i < test_vec_num; i++)
-		check_alg(ODP_CRYPTO_OP_ENCODE,
-			  ODP_CIPHER_ALG_NULL,
-			  ODP_AUTH_ALG_AES_CMAC,
-			  aes_cmac_reference,
-			  ARRAY_SIZE(aes_cmac_reference),
-			  false);
+	check_alg(ODP_CRYPTO_OP_ENCODE,
+		  ODP_CIPHER_ALG_NULL,
+		  ODP_AUTH_ALG_AES_CMAC,
+		  aes_cmac_reference,
+		  ARRAY_SIZE(aes_cmac_reference),
+		  false);
 }
 
 static void crypto_test_check_alg_aes_cmac(void)


### PR DESCRIPTION
Use check_alg instead of alg_test for GMAC/CMAC testing.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>