### PR TITLE
[PATCH v5] linux-gen: move common macros to odp_internal.h

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -101,6 +101,7 @@ noinst_HEADERS = \
 		  include/odp_internal.h \
 		  include/odp_ipsec_internal.h \
 		  include/odp_llqueue.h \
+		  include/odp_macros_internal.h \
 		  include/odp_name_table_internal.h \
 		  include/odp_packet_internal.h \
 		  include/odp_packet_io_internal.h \

--- a/platform/linux-generic/include/odp_bitmap_internal.h
+++ b/platform/linux-generic/include/odp_bitmap_internal.h
@@ -21,13 +21,11 @@ extern "C" {
 #include <stdbool.h>
 #include <string.h>
 #include <odp/api/hints.h>
+#include <odp_macros_internal.h>
 
 /* Generate unique identifier for instantiated class */
 #define TOKENIZE(template, line) \
 	template ## _ ## line ## _ ## __COUNTER__
-
-/* Array size in general */
-#define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
 #define BITS_PER_BYTE	(8)
 #define BITS_PER_LONG	__WORDSIZE

--- a/platform/linux-generic/include/odp_macros_internal.h
+++ b/platform/linux-generic/include/odp_macros_internal.h
@@ -1,0 +1,54 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * ODP miscellaneous macros
+ */
+
+#ifndef ODP_MACROS_INTERNAL_H_
+#define ODP_MACROS_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <odp/api/debug.h>
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+#define MIN(a, b)				\
+	({					\
+		__typeof__(a) tmp_a = (a);	\
+		__typeof__(b) tmp_b = (b);	\
+		tmp_a < tmp_b ? tmp_a : tmp_b;	\
+	})
+
+#define MAX(a, b)				\
+	({					\
+		__typeof__(a) tmp_a = (a);	\
+		__typeof__(b) tmp_b = (b);	\
+		tmp_a > tmp_b ? tmp_a : tmp_b;	\
+	})
+
+#define odp_container_of(pointer, type, member) \
+	((type *)(void *)(((char *)pointer) - offsetof(type, member)))
+
+#define DIV_ROUND_UP(a, b)					\
+	({							\
+		__typeof__(a) tmp_a = (a);			\
+		__typeof__(b) tmp_b = (b);			\
+		ODP_STATIC_ASSERT(__builtin_constant_p(b), "");	\
+		ODP_STATIC_ASSERT((((b) - 1) & (b)) == 0, "");	\
+		(tmp_a + tmp_b - 1) >> __builtin_ctz(tmp_b);	\
+	})
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp_traffic_mngr_internal.h
+++ b/platform/linux-generic/include/odp_traffic_mngr_internal.h
@@ -34,9 +34,6 @@ extern "C" {
 
 typedef struct stat  file_stat_t;
 
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-
 #define INPUT_WORK_RING_SIZE  (16 * 1024)
 
 #define TM_QUEUE_MAGIC_NUM   0xBABEBABE

--- a/platform/linux-generic/odp_name_table.c
+++ b/platform/linux-generic/odp_name_table.c
@@ -14,9 +14,7 @@
 #include <stdlib.h>
 #include <odp_name_table_internal.h>
 #include <odp_debug_internal.h>
-
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#include <odp_macros_internal.h>
 
  /* The following constants define some tunable parameters of this module.
  * They are set to fairly reasonable values (perhaps somewhat biased toward
@@ -298,7 +296,7 @@ static int new_name_tbl_add(void)
 	name_tbls_idx = name_tbls.num_name_tbls;
 	num_entries   = INITIAL_NAME_TBL_SIZE << name_tbls_idx;
 	new_name_tbl  = name_tbl_alloc(name_tbls_idx, num_entries);
-	name_tbl_free_list_add(new_name_tbl, MIN(num_entries, 256));
+	name_tbl_free_list_add(new_name_tbl, MIN(num_entries, UINT32_C(256)));
 
 	name_tbls.tbls[name_tbls_idx]   = new_name_tbl;
 	name_tbls.avail_space_bit_mask |= 1 << name_tbls_idx;
@@ -387,7 +385,7 @@ static hash_tbl_entry_t make_hash_tbl_entry(name_tbl_entry_t *name_tbl_entry,
 	hash_tbl_entry_t hash_tbl_entry;
 	uint32_t         new_entry_cnt;
 
-	new_entry_cnt   = MIN(entry_cnt + 1, 0x3F);
+	new_entry_cnt   = MIN(entry_cnt + 1, UINT32_C(0x3F));
 	hash_tbl_entry  = (hash_tbl_entry_t)(uintptr_t)name_tbl_entry;
 	hash_tbl_entry &= ~0x3F;
 	hash_tbl_entry |= new_entry_cnt;
@@ -1006,7 +1004,7 @@ static uint32_t level2_hash_histo(secondary_hash_tbl_t *hash_tbl,
 			collisions     = linked_list_len(name_tbl_entry);
 		}
 
-		level2_histo[MIN(collisions, 256)]++;
+		level2_histo[MIN(collisions, UINT32_C(256))]++;
 		total_collisions += collisions;
 	}
 
@@ -1038,7 +1036,7 @@ static uint32_t level1_hash_histo(secondary_hash_tbl_t *hash_tbl,
 							   level2_histo);
 		}
 
-		level1_histo[MIN(collisions, 256)]++;
+		level1_histo[MIN(collisions, UINT32_C(256))]++;
 		total_collisions += collisions;
 	}
 
@@ -1147,7 +1145,8 @@ void _odp_int_name_tbl_stats_print(void)
 
 	memset(primary_hash_histo, 0, sizeof(primary_hash_histo));
 	for (idx = 0; idx < PRIMARY_HASH_TBL_SIZE; idx++) {
-		collisions = MIN(name_hash_tbl.hash_collisions[idx], 256);
+		collisions =
+		    MIN(name_hash_tbl.hash_collisions[idx], UINT32_C(256));
 		primary_hash_histo[collisions]++;
 	}
 

--- a/platform/linux-generic/odp_pkt_queue.c
+++ b/platform/linux-generic/odp_pkt_queue.c
@@ -16,9 +16,7 @@
 #include <odp_api.h>
 #include <odp_pkt_queue_internal.h>
 #include <odp_debug_internal.h>
-
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#include <odp_macros_internal.h>
 
 #define NUM_PKTS     7
 
@@ -230,7 +228,7 @@ _odp_int_queue_pool_t _odp_queue_pool_create(uint32_t max_num_queues,
        /* Initialize the queue_blk_tbl_sizes array based upon the
 	* max_queued_pkts.
 	*/
-	max_queued_pkts = MAX(max_queued_pkts, 64 * 1024);
+	max_queued_pkts = MAX(max_queued_pkts, 64 * UINT32_C(1024));
 	queue_region_desc_init(pool, 0, max_queued_pkts / 4);
 	queue_region_desc_init(pool, 1, max_queued_pkts / 64);
 	queue_region_desc_init(pool, 2, max_queued_pkts / 64);
@@ -242,7 +240,7 @@ _odp_int_queue_pool_t _odp_queue_pool_create(uint32_t max_num_queues,
        /* Now allocate the first queue_blk_tbl and add its blks to the free
 	* list.  Replenish the queue_blk_t free list.
 	*/
-	initial_free_list_size = MIN(64 * 1024, max_queued_pkts / 4);
+	initial_free_list_size = MIN(64 * UINT32_C(1024), max_queued_pkts / 4);
 	rc = pkt_queue_free_list_add(pool, initial_free_list_size);
 	if (rc < 0) {
 		free(pool->queue_num_tbl);

--- a/platform/linux-generic/odp_timer_wheel.c
+++ b/platform/linux-generic/odp_timer_wheel.c
@@ -16,6 +16,7 @@
 #include <odp_timer_wheel_internal.h>
 #include <odp_traffic_mngr_internal.h>
 #include <odp_debug_internal.h>
+#include <odp_macros_internal.h>
 
 /* The following constants can be changed either at compile time or run time
  * as long as the following constraints are met (by the way REV stands for
@@ -627,7 +628,7 @@ static int timer_current_wheel_update(timer_wheels_t *timer_wheels,
 	slot_idx      = wheel_desc->slot_idx;
 	num_slots     = wheel_desc->num_slots;
 	max_ticks     = wheel_desc->max_ticks;
-	max_cnt       = (uint32_t)MIN(elapsed_ticks, 32);
+	max_cnt       = MIN(elapsed_ticks, UINT32_C(32));
 	current_wheel = timer_wheels->current_wheel;
 	ret_code      = 0;
 	rc            = -1;

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -28,6 +28,7 @@
 #include <odp_traffic_mngr_internal.h>
 #include <odp/api/plat/packet_inlines.h>
 #include <odp/api/plat/byteorder_inlines.h>
+#include <odp_macros_internal.h>
 
 /* Local vars */
 static const
@@ -731,7 +732,8 @@ static uint64_t time_till_not_red(tm_shaper_params_t *shaper_params,
 		commit_delay = (-shaper_obj->commit_cnt)
 			/ shaper_params->commit_rate;
 
-	min_time_delay = MAX(shaper_obj->shaper_params->min_time_delta, 256);
+	min_time_delay =
+	    MAX(shaper_obj->shaper_params->min_time_delta, UINT64_C(256));
 	commit_delay = MAX(commit_delay, min_time_delay);
 	if (shaper_params->peak_rate == 0)
 		return commit_delay;
@@ -1670,7 +1672,7 @@ static odp_tm_percent_t tm_queue_fullness(tm_wred_params_t      *wred_params,
 		return 0;
 
 	fullness = (10000 * current_cnt) / max_cnt;
-	return (odp_tm_percent_t)MIN(fullness, 50000);
+	return (odp_tm_percent_t)MIN(fullness, UINT64_C(50000));
 }
 
 static odp_bool_t tm_local_random_drop(tm_system_t      *tm_system,
@@ -2501,7 +2503,7 @@ static void tm_system_capabilities_set(odp_tm_capabilities_t *cap_ptr,
 	memset(cap_ptr, 0, sizeof(odp_tm_capabilities_t));
 
 	max_queues       = MIN(req_ptr->max_tm_queues,
-			       ODP_TM_MAX_NUM_TM_NODES);
+			       (uint32_t)ODP_TM_MAX_NUM_TM_NODES);
 	shaper_supported = req_ptr->tm_queue_shaper_needed;
 	wred_supported   = req_ptr->tm_queue_wred_needed;
 	dual_slope       = req_ptr->tm_queue_dual_slope_needed;
@@ -2525,8 +2527,9 @@ static void tm_system_capabilities_set(odp_tm_capabilities_t *cap_ptr,
 		per_level_req = &req_ptr->per_level[level_idx];
 
 		max_nodes        = MIN(per_level_req->max_num_tm_nodes,
-				       ODP_TM_MAX_NUM_TM_NODES);
-		max_fanin        = MIN(per_level_req->max_fanin_per_node, 1024);
+				       (uint32_t)ODP_TM_MAX_NUM_TM_NODES);
+		max_fanin        = MIN(per_level_req->max_fanin_per_node,
+				       UINT32_C(1024));
 		max_priority     = MIN(per_level_req->max_priority,
 				       ODP_TM_MAX_PRIORITIES - 1);
 		min_weight       = MAX(per_level_req->min_weight,


### PR DESCRIPTION
Gather macros needed for upcoming mediated devices in one location.
Fix signed vs. unsigned comparisons caused by incorrect MIN / MAX usage.

Signed-off-by: Mykyta Iziumtsev <mykyta.iziumtsev@linaro.org>
Reviewed-by: Bill Fischofer <bill.fischofer@linaro.org>