### PR TITLE
[PATCH v1] build: limit symbol visibility for libodp-linux

### DIFF
--- a/platform/Makefile.inc
+++ b/platform/Makefile.inc
@@ -8,6 +8,12 @@ lib_LTLIBRARIES = $(LIB)/libodp-linux.la
 
 AM_LDFLAGS = -version-number '$(ODP_LIBSO_VERSION)'
 
+if ODP_ABI_COMPAT
+AM_LDFLAGS += -export-symbols-regex '^(_deprecated)?odp_'
+else
+AM_LDFLAGS += -export-symbols-regex '^(_deprecated)?_?odp_'
+endif
+
 AM_CFLAGS = "-DGIT_HASH=$(VERSION)"
 AM_CFLAGS += $(VISIBILITY_CFLAGS)
 


### PR DESCRIPTION
If libodp-linux is linked with static DPDK libraries, it will re-export
all DPDK symbols. Use libtool's -export-symbols-regex to limit symbol
visibility.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>