### PR TITLE
[PATCH API-NEXT v1] Fix recv timeout issue with socket mmap

### DIFF
--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -692,10 +692,19 @@ static int sock_mmap_recv_tmo(pktio_entry_t *pktio_entry, int index,
 	FD_ZERO(&readfds);
 	maxfd = sock_mmap_fd_set(pktio_entry, index, &readfds);
 
-	if (select(maxfd + 1, &readfds, NULL, NULL, &timeout) == 0)
-		return 0;
+	while (1) {
+		ret = select(maxfd + 1, &readfds, NULL, NULL, &timeout);
 
-	return sock_mmap_recv(pktio_entry, index, pkt_table, num);
+		if (ret <= 0)
+			return ret;
+
+		ret = sock_mmap_recv(pktio_entry, index, pkt_table, num);
+
+		if (ret)
+			return ret;
+
+		/* If no packets, continue wait until timeout expires */
+	}
 }
 
 static int sock_mmap_recv_mq_tmo(pktio_entry_t *pktio_entry[], int index[],
@@ -729,20 +738,25 @@ static int sock_mmap_recv_mq_tmo(pktio_entry_t *pktio_entry[], int index[],
 	timeout.tv_sec = usecs / (1000 * 1000);
 	timeout.tv_usec = usecs - timeout.tv_sec * (1000ULL * 1000ULL);
 
-	if (select(maxfd + 1, &readfds, NULL, NULL, &timeout) == 0)
-		return 0;
+	while (1) {
+		ret = select(maxfd + 1, &readfds, NULL, NULL, &timeout);
 
-	for (i = 0; i < num_q; i++) {
-		ret = sock_mmap_recv(pktio_entry[i], index[i], pkt_table, num);
-
-		if (ret > 0 && from)
-			*from = i;
-
-		if (ret != 0)
+		if (ret <= 0)
 			return ret;
-	}
 
-	return 0;
+		for (i = 0; i < num_q; i++) {
+			ret = sock_mmap_recv(pktio_entry[i], index[i],
+					     pkt_table, num);
+
+			if (ret > 0 && from)
+				*from = i;
+
+			if (ret)
+				return ret;
+		}
+
+		/* If no packets, continue wait until timeout expires */
+	}
 }
 
 static int sock_mmap_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,

--- a/test/validation/api/pktio/pktio.c
+++ b/test/validation/api/pktio/pktio.c
@@ -511,7 +511,7 @@ static int wait_for_packets(pktio_info_t *pktio_rx, odp_packet_t pkt_tbl[],
 
 static int recv_packets_tmo(odp_pktio_t pktio, odp_packet_t pkt_tbl[],
 			    uint32_t seq_tbl[], int num, recv_tmo_mode_e mode,
-			    uint64_t tmo, uint64_t ns)
+			    uint64_t tmo, uint64_t ns, int no_pkt)
 {
 	odp_packet_t pkt_tmp[num];
 	odp_pktin_queue_t pktin[MAX_QUEUES];
@@ -542,8 +542,19 @@ static int recv_packets_tmo(odp_pktio_t pktio, odp_packet_t pkt_tbl[],
 						  num - num_rx, tmo);
 		ts2 = odp_time_global();
 
+		CU_ASSERT(n >= 0);
+
 		if (n <= 0)
 			break;
+
+		/* When we don't expect any packets, drop all packets and
+		 * retry timeout test. */
+		if (no_pkt) {
+			printf("    drop %i dummy packets\n", n);
+			odp_packet_free_multi(pkt_tmp, n);
+			continue;
+		}
+
 		for (i = 0; i < n; i++) {
 			if (pktio_pkt_seq(pkt_tmp[i]) == seq_tbl[num_rx])
 				pkt_tbl[num_rx++] = pkt_tmp[i];
@@ -554,8 +565,15 @@ static int recv_packets_tmo(odp_pktio_t pktio, odp_packet_t pkt_tbl[],
 			CU_ASSERT(from_val < (unsigned)num_q);
 	} while (num_rx < num);
 
-	if (num_rx < num)
-		CU_ASSERT(odp_time_diff_ns(ts2, ts1) >= ns);
+	if (num_rx < num) {
+		uint64_t diff = odp_time_diff_ns(ts2, ts1);
+
+		if (diff < ns)
+			printf("    diff %" PRIu64 ", ns %" PRIu64 "\n",
+			       diff, ns);
+
+		CU_ASSERT(diff >= ns);
+	}
 
 	return num_rx;
 }
@@ -967,8 +985,9 @@ static void test_recv_tmo(recv_tmo_mode_e mode)
 
 	/* No packets sent yet, so should wait */
 	ns = 100 * ODP_TIME_MSEC_IN_NS;
+
 	ret = recv_packets_tmo(pktio_rx, &pkt_tbl[0], &pkt_seq[0], 1, mode,
-			       odp_pktin_wait_time(ns), ns);
+			       odp_pktin_wait_time(ns), ns, 1);
 	CU_ASSERT(ret == 0);
 
 	ret = create_packets(pkt_tbl, pkt_seq, test_pkt_count, pktio_tx,
@@ -979,19 +998,19 @@ static void test_recv_tmo(recv_tmo_mode_e mode)
 	CU_ASSERT_FATAL(ret == test_pkt_count);
 
 	ret = recv_packets_tmo(pktio_rx, &pkt_tbl[0], &pkt_seq[0], 1, mode,
-			       odp_pktin_wait_time(UINT64_MAX), 0);
+			       odp_pktin_wait_time(UINT64_MAX), 0, 0);
 	CU_ASSERT_FATAL(ret == 1);
 
 	ret = recv_packets_tmo(pktio_rx, &pkt_tbl[1], &pkt_seq[1], 1, mode,
-			       ODP_PKTIN_NO_WAIT, 0);
+			       ODP_PKTIN_NO_WAIT, 0, 0);
 	CU_ASSERT_FATAL(ret == 1);
 
 	ret = recv_packets_tmo(pktio_rx, &pkt_tbl[2], &pkt_seq[2], 1, mode,
-			       odp_pktin_wait_time(0), 0);
+			       odp_pktin_wait_time(0), 0, 0);
 	CU_ASSERT_FATAL(ret == 1);
 
 	ret = recv_packets_tmo(pktio_rx, &pkt_tbl[3], &pkt_seq[3], 3, mode,
-			       odp_pktin_wait_time(ns), ns);
+			       odp_pktin_wait_time(ns), ns, 0);
 	CU_ASSERT_FATAL(ret == 3);
 
 	for (i = 0; i < test_pkt_count; i++)


### PR DESCRIPTION
The issue is on both master and api-next branches. Fixed on api-next branch to avoid merge conflicts as the same lines have been modified on api-next previously.