### PR TITLE
[PATCH API-NEXT v3] Packet L3/L4 type implementation and API extension

### DIFF
--- a/example/generator/odp_generator.c
+++ b/example/generator/odp_generator.c
@@ -338,7 +338,7 @@ static odp_packet_t setup_udp_pkt_ref(odp_pool_t pool,
 
 	/* udp */
 	odp_packet_l4_offset_set(pkt, ODPH_ETHHDR_LEN + ODPH_IPV4HDR_LEN);
-	odp_packet_has_udp_set(pkt, 1);
+	odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_UDP);
 	udp = (odph_udphdr_t *)(buf + ODPH_ETHHDR_LEN + ODPH_IPV4HDR_LEN);
 	udp->src_port = odp_cpu_to_be_16(args->appl.srcport);
 	udp->dst_port = odp_cpu_to_be_16(args->appl.dstport);

--- a/example/generator/odp_generator.c
+++ b/example/generator/odp_generator.c
@@ -324,7 +324,7 @@ static odp_packet_t setup_udp_pkt_ref(odp_pool_t pool,
 
 	/* ip */
 	odp_packet_l3_offset_set(pkt, ODPH_ETHHDR_LEN);
-	odp_packet_has_ipv4_set(pkt, 1);
+	odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_IPV4);
 	ip = (odph_ipv4hdr_t *)(buf + ODPH_ETHHDR_LEN);
 	ip->dst_addr = odp_cpu_to_be_32(args->appl.dstip);
 	ip->src_addr = odp_cpu_to_be_32(args->appl.srcip);

--- a/example/ipfragreass/odp_ipfragreass_helpers.c
+++ b/example/ipfragreass/odp_ipfragreass_helpers.c
@@ -58,7 +58,7 @@ odp_packet_t pack_udp_ipv4_packet(odp_pool_t pool, odp_u16be_t ip_id,
 	header_len = WORDS_TO_BYTES(header_len_words);
 	assert(header_len >= IP_HDR_LEN_MIN && header_len <= IP_HDR_LEN_MAX);
 	odp_packet_l3_offset_set(result, 0);
-	odp_packet_has_ipv4_set(result, 1);
+	odp_packet_l3_type_set(result, ODP_PROTO_L3_TYPE_IPV4);
 	buffer = odp_packet_data(result);
 	header = (odph_ipv4hdr_t *)buffer;
 	ipv4hdr_init(header);

--- a/example/ipsec/odp_ipsec_stream.c
+++ b/example/ipsec/odp_ipsec_stream.c
@@ -202,7 +202,7 @@ odp_packet_t create_ipv4_packet(stream_db_entry_t *stream,
 	eth->type = odp_cpu_to_be_16(ODPH_ETHTYPE_IPV4);
 
 	/* IPv4 */
-	odp_packet_has_ipv4_set(pkt, 1);
+	odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_IPV4);
 	ip = (odph_ipv4hdr_t *)data;
 	data += sizeof(*ip);
 

--- a/helper/test/chksum.c
+++ b/helper/test/chksum.c
@@ -110,7 +110,7 @@ int main(int argc ODPH_UNUSED, char *argv[] ODPH_UNUSED)
 				       ODPH_IPV4HDR_LEN);
 	ip->proto = ODPH_IPPROTO_UDP;
 	ip->id = odp_cpu_to_be_16(1);
-	odp_packet_has_ipv4_set(test_packet, 1);
+	odp_packet_l3_type_set(test_packet, ODP_PROTO_L3_TYPE_IPV4);
 	if (odph_ipv4_csum_update(test_packet) < 0)
 		status = -1;
 

--- a/helper/test/chksum.c
+++ b/helper/test/chksum.c
@@ -131,7 +131,7 @@ int main(int argc ODPH_UNUSED, char *argv[] ODPH_UNUSED)
 	udp->dst_port = 0;
 	udp->length = odp_cpu_to_be_16(udat_size + ODPH_UDPHDR_LEN);
 	udp->chksum = 0;
-	odp_packet_has_udp_set(test_packet, 1);
+	odp_packet_l4_type_set(test_packet, ODP_PROTO_L4_TYPE_UDP);
 	udp->chksum = odph_ipv4_udp_chksum(test_packet);
 
 	if (udp->chksum == 0)

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1627,6 +1627,16 @@ int odp_packet_l4_offset_set(odp_packet_t pkt, uint32_t offset);
 odp_proto_l3_type_t odp_packet_l3_type(odp_packet_t pkt);
 
 /**
+ * Set Layer 3 protocol type
+ *
+ * Set layer 3 protocol type. Initial type value is ODP_PROTO_L3_TYPE_NONE.
+ *
+ * @param      pkt      Packet handle
+ * @param      val      Layer 3 protocol type
+ */
+void odp_packet_l3_type_set(odp_packet_t pkt, odp_proto_l3_type_t val);
+
+/**
  * Layer 4 protocol type
  *
  * Returns layer 4 protocol type. Initial type value is ODP_PROTO_L4_TYPE_NONE.
@@ -1636,6 +1646,16 @@ odp_proto_l3_type_t odp_packet_l3_type(odp_packet_t pkt);
  * @return Layer 4 protocol type
  */
 odp_proto_l4_type_t odp_packet_l4_type(odp_packet_t pkt);
+
+/**
+ * Set Layer 4 protocol type
+ *
+ * Set layer 4 protocol type. Initial type value is ODP_PROTO_L4_TYPE_NONE.
+ *
+ * @param      pkt      Packet handle
+ * @param      val      Layer 4 protocol type
+ */
+void odp_packet_l4_type_set(odp_packet_t pkt, odp_proto_l4_type_t val);
 
 /**
  * Layer 3 checksum check status

--- a/include/odp/api/spec/packet_flags.h
+++ b/include/odp/api/spec/packet_flags.h
@@ -21,6 +21,7 @@ extern "C" {
 
 #include <odp/api/std_types.h>
 #include <odp/api/packet.h>
+#include <odp/api/deprecated.h>
 
 /** @addtogroup odp_packet
  *  Operations on packet metadata flags.
@@ -412,28 +413,28 @@ void odp_packet_has_vlan_set(odp_packet_t pkt, int val);
 void odp_packet_has_vlan_qinq_set(odp_packet_t pkt, int val);
 
 /**
- * Set flag for ARP
+ * @deprecated Use odp_packet_l3_type_set instead */
  *
  * @param pkt Packet handle
  * @param val Value
  */
-void odp_packet_has_arp_set(odp_packet_t pkt, int val);
+void ODP_DEPRECATE(odp_packet_has_arp_set)(odp_packet_t pkt, int val);
 
 /**
- * Set flag for IPv4
+ * @deprecated Use odp_packet_l3_type_set instead */
  *
  * @param pkt Packet handle
  * @param val Value
  */
-void odp_packet_has_ipv4_set(odp_packet_t pkt, int val);
+void ODP_DEPRECATE(odp_packet_has_ipv4_set)(odp_packet_t pkt, int val);
 
 /**
- * Set flag for IPv6
+ * @deprecated Use odp_packet_l3_type_set instead */
  *
  * @param pkt Packet handle
  * @param val Value
  */
-void odp_packet_has_ipv6_set(odp_packet_t pkt, int val);
+void ODP_DEPRECATE(odp_packet_has_ipv6_set)(odp_packet_t pkt, int val);
 
 /**
  * Set flag for IP broadcast address
@@ -476,36 +477,36 @@ void odp_packet_has_ipopt_set(odp_packet_t pkt, int val);
 void odp_packet_has_ipsec_set(odp_packet_t pkt, int val);
 
 /**
- * Set flag for UDP
+ * @deprecated Use odp_packet_l3_type_set instead */
  *
  * @param pkt Packet handle
  * @param val Value
  */
-void odp_packet_has_udp_set(odp_packet_t pkt, int val);
+void ODP_DEPRECATE(odp_packet_has_udp_set)(odp_packet_t pkt, int val);
 
 /**
- * Set flag for TCP
+ * @deprecated Use odp_packet_l3_type_set instead */
  *
  * @param pkt Packet handle
  * @param val Value
  */
-void odp_packet_has_tcp_set(odp_packet_t pkt, int val);
+void ODP_DEPRECATE(odp_packet_has_tcp_set)(odp_packet_t pkt, int val);
 
 /**
- * Set flag for SCTP
+ * @deprecated Use odp_packet_l3_type_set instead */
  *
  * @param pkt Packet handle
  * @param val Value
  */
-void odp_packet_has_sctp_set(odp_packet_t pkt, int val);
+void ODP_DEPRECATE(odp_packet_has_sctp_set)(odp_packet_t pkt, int val);
 
 /**
- * Set flag for ICMP
+ * @deprecated Use odp_packet_l3_type_set instead */
  *
  * @param pkt Packet handle
  * @param val Value
  */
-void odp_packet_has_icmp_set(odp_packet_t pkt, int val);
+void ODP_DEPRECATE(odp_packet_has_icmp_set)(odp_packet_t pkt, int val);
 
 /**
  * Clear flag for packet flow hash

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -80,14 +80,7 @@ typedef union {
 
 		uint64_t ipsec:1;     /* IPSec packet. Required by the
 					   odp_packet_has_ipsec_set() func. */
-		uint64_t ipsec_ah:1;  /* IPSec authentication header */
-		uint64_t ipsec_esp:1; /* IPSec encapsulating security
-					   payload */
-		uint64_t udp:1;       /* UDP */
-		uint64_t tcp:1;       /* TCP */
 		uint64_t tcpopt:1;    /* TCP options present */
-		uint64_t sctp:1;      /* SCTP */
-		uint64_t icmp:1;      /* ICMP */
 
 		uint64_t color:2;     /* Packet color for traffic mgmt */
 		uint64_t nodrop:1;    /* Drop eligibility status */

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -98,6 +98,9 @@ typedef union {
 		uint64_t l3_chksum_done:1; /* L3 checksum validation done */
 		uint64_t l4_chksum_done:1; /* L4 checksum validation done */
 		uint64_t ipsec_udp:1; /* UDP-encapsulated IPsec packet */
+
+		uint64_t l3_type : 8; /* L3 packet type */
+		uint64_t l4_type : 8; /* L4 packet type */
 	};
 
 } _odp_packet_input_flags_t;

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -72,10 +72,7 @@ typedef union {
 		uint64_t vlan_qinq:1; /* Stacked VLAN found, QinQ */
 
 		uint64_t snap:1;      /* SNAP */
-		uint64_t arp:1;       /* ARP */
 
-		uint64_t ipv4:1;      /* IPv4 */
-		uint64_t ipv6:1;      /* IPv6 */
 		uint64_t ip_bcast:1;  /* IP broadcast */
 		uint64_t ip_mcast:1;  /* IP multicast */
 		uint64_t ipfrag:1;    /* IP fragment */

--- a/platform/linux-generic/include/odp_classification_inlines.h
+++ b/platform/linux-generic/include/odp_classification_inlines.h
@@ -51,7 +51,8 @@ static inline int verify_pmr_ip_proto(const uint8_t *pkt_addr,
 {
 	const _odp_ipv4hdr_t *ip;
 	uint8_t proto;
-	if (!pkt_hdr->p.input_flags.ipv4)
+
+	if (!packet_hdr_has_ipv4(pkt_hdr))
 		return 0;
 	ip = (const _odp_ipv4hdr_t *)(pkt_addr + pkt_hdr->p.l3_offset);
 	proto = ip->proto;
@@ -67,7 +68,8 @@ static inline int verify_pmr_ipv4_saddr(const uint8_t *pkt_addr,
 {
 	const _odp_ipv4hdr_t *ip;
 	uint32_t ipaddr;
-	if (!pkt_hdr->p.input_flags.ipv4)
+
+	if (!packet_hdr_has_ipv4(pkt_hdr))
 		return 0;
 	ip = (const _odp_ipv4hdr_t *)(pkt_addr + pkt_hdr->p.l3_offset);
 	ipaddr = _odp_be_to_cpu_32(ip->src_addr);
@@ -83,7 +85,8 @@ static inline int verify_pmr_ipv4_daddr(const uint8_t *pkt_addr,
 {
 	const _odp_ipv4hdr_t *ip;
 	uint32_t ipaddr;
-	if (!pkt_hdr->p.input_flags.ipv4)
+
+	if (!packet_hdr_has_ipv4(pkt_hdr))
 		return 0;
 	ip = (const _odp_ipv4hdr_t *)(pkt_addr + pkt_hdr->p.l3_offset);
 	ipaddr = _odp_be_to_cpu_32(ip->dst_addr);

--- a/platform/linux-generic/include/odp_classification_inlines.h
+++ b/platform/linux-generic/include/odp_classification_inlines.h
@@ -102,7 +102,8 @@ static inline int verify_pmr_tcp_sport(const uint8_t *pkt_addr,
 {
 	uint16_t sport;
 	const _odp_tcphdr_t *tcp;
-	if (!pkt_hdr->p.input_flags.tcp)
+
+	if (!packet_hdr_has_tcp(pkt_hdr))
 		return 0;
 	tcp = (const _odp_tcphdr_t *)(pkt_addr + pkt_hdr->p.l4_offset);
 	sport = _odp_be_to_cpu_16(tcp->src_port);
@@ -118,7 +119,8 @@ static inline int verify_pmr_tcp_dport(const uint8_t *pkt_addr,
 {
 	uint16_t dport;
 	const _odp_tcphdr_t *tcp;
-	if (!pkt_hdr->p.input_flags.tcp)
+
+	if (!packet_hdr_has_tcp(pkt_hdr))
 		return 0;
 	tcp = (const _odp_tcphdr_t *)(pkt_addr + pkt_hdr->p.l4_offset);
 	dport = _odp_be_to_cpu_16(tcp->dst_port);
@@ -134,7 +136,8 @@ static inline int verify_pmr_udp_dport(const uint8_t *pkt_addr,
 {
 	uint16_t dport;
 	const _odp_udphdr_t *udp;
-	if (!pkt_hdr->p.input_flags.udp)
+
+	if (!packet_hdr_has_udp(pkt_hdr))
 		return 0;
 	udp = (const _odp_udphdr_t *)(pkt_addr + pkt_hdr->p.l4_offset);
 	dport = _odp_be_to_cpu_16(udp->dst_port);
@@ -151,7 +154,7 @@ static inline int verify_pmr_udp_sport(const uint8_t *pkt_addr,
 	uint16_t sport;
 	const _odp_udphdr_t *udp;
 
-	if (!pkt_hdr->p.input_flags.udp)
+	if (!packet_hdr_has_udp(pkt_hdr))
 		return 0;
 	udp = (const _odp_udphdr_t *)(pkt_addr + pkt_hdr->p.l4_offset);
 	sport = _odp_be_to_cpu_16(udp->src_port);
@@ -291,11 +294,11 @@ static inline int verify_pmr_ipsec_spi(const uint8_t *pkt_addr,
 
 	pkt_addr += pkt_hdr->p.l4_offset;
 
-	if (pkt_hdr->p.input_flags.ipsec_ah) {
+	if (pkt_hdr->p.input_flags.l4_type == ODP_PROTO_L4_TYPE_AH) {
 		const _odp_ahhdr_t *ahhdr = (const _odp_ahhdr_t *)pkt_addr;
 
 		spi = _odp_be_to_cpu_32(ahhdr->spi);
-	} else if (pkt_hdr->p.input_flags.ipsec_esp) {
+	} else if (pkt_hdr->p.input_flags.l4_type == ODP_PROTO_L4_TYPE_ESP) {
 		const _odp_esphdr_t *esphdr = (const _odp_esphdr_t *)pkt_addr;
 
 		spi = _odp_be_to_cpu_32(esphdr->spi);

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -291,6 +291,16 @@ static inline int packet_hdr_has_ipv6(odp_packet_hdr_t *pkt_hdr)
 	return pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L3_TYPE_IPV6;
 }
 
+static inline int packet_hdr_has_tcp(odp_packet_hdr_t *pkt_hdr)
+{
+	return pkt_hdr->p.input_flags.l4_type == ODP_PROTO_L4_TYPE_TCP;
+}
+
+static inline int packet_hdr_has_udp(odp_packet_hdr_t *pkt_hdr)
+{
+	return pkt_hdr->p.input_flags.l4_type == ODP_PROTO_L4_TYPE_UDP;
+}
+
 static inline void packet_set_ts(odp_packet_hdr_t *pkt_hdr, odp_time_t *ts)
 {
 	if (ts != NULL) {

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -281,9 +281,14 @@ static inline int packet_hdr_has_eth(odp_packet_hdr_t *pkt_hdr)
 	return pkt_hdr->p.input_flags.eth;
 }
 
+static inline int packet_hdr_has_ipv4(odp_packet_hdr_t *pkt_hdr)
+{
+	return pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L3_TYPE_IPV4;
+}
+
 static inline int packet_hdr_has_ipv6(odp_packet_hdr_t *pkt_hdr)
 {
-	return pkt_hdr->p.input_flags.ipv6;
+	return pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L3_TYPE_IPV6;
 }
 
 static inline void packet_set_ts(odp_packet_hdr_t *pkt_hdr, odp_time_t *ts)

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -1036,14 +1036,14 @@ static uint32_t packet_rss_hash(odp_packet_hdr_t *pkt_hdr,
 			tuple_len += 2;
 		}
 
-		if (pkt_hdr->p.input_flags.tcp && hash_proto.tcp) {
+		if (packet_hdr_has_tcp(pkt_hdr) && hash_proto.tcp) {
 			/* add tcp */
 			tcp = (const _odp_tcphdr_t *)(base +
 			       pkt_hdr->p.l4_offset);
 			tuple.v4.sport = tcp->src_port;
 			tuple.v4.dport = tcp->dst_port;
 			tuple_len += 1;
-		} else if (pkt_hdr->p.input_flags.udp && hash_proto.udp) {
+		} else if (packet_hdr_has_udp(pkt_hdr) && hash_proto.udp) {
 			/* add udp */
 			udp = (const _odp_udphdr_t *)(base +
 			       pkt_hdr->p.l4_offset);
@@ -1059,13 +1059,13 @@ static uint32_t packet_rss_hash(odp_packet_hdr_t *pkt_hdr,
 			thash_load_ipv6_addr(ipv6, &tuple);
 			tuple_len += 8;
 		}
-		if (pkt_hdr->p.input_flags.tcp && hash_proto.tcp) {
+		if (packet_hdr_has_tcp(pkt_hdr) && hash_proto.tcp) {
 			tcp = (const _odp_tcphdr_t *)(base +
 			       pkt_hdr->p.l4_offset);
 			tuple.v6.sport = tcp->src_port;
 			tuple.v6.dport = tcp->dst_port;
 			tuple_len += 1;
-		} else if (pkt_hdr->p.input_flags.udp && hash_proto.udp) {
+		} else if (packet_hdr_has_udp(pkt_hdr) && hash_proto.udp) {
 			/* add udp */
 			udp = (const _odp_udphdr_t *)(base +
 			       pkt_hdr->p.l4_offset);

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -1026,7 +1026,7 @@ static uint32_t packet_rss_hash(odp_packet_hdr_t *pkt_hdr,
 
 	tuple_len = 0;
 	hash = 0;
-	if (pkt_hdr->p.input_flags.ipv4) {
+	if (packet_hdr_has_ipv4(pkt_hdr)) {
 		if (hash_proto.ipv4) {
 			/* add ipv4 */
 			ipv4 = (const _odp_ipv4hdr_t *)(base +
@@ -1051,7 +1051,7 @@ static uint32_t packet_rss_hash(odp_packet_hdr_t *pkt_hdr,
 			tuple.v4.dport = udp->dst_port;
 			tuple_len += 1;
 		}
-	} else if (pkt_hdr->p.input_flags.ipv6) {
+	} else if (packet_hdr_has_ipv6(pkt_hdr)) {
 		if (hash_proto.ipv6) {
 			/* add ipv6 */
 			ipv6 = (const _odp_ipv6hdr_t *)(base +
@@ -1089,11 +1089,11 @@ cos_t *match_qos_l3_cos(pmr_l3_cos_t *l3_cos, const uint8_t *pkt_addr,
 	const _odp_ipv4hdr_t *ipv4;
 	const _odp_ipv6hdr_t *ipv6;
 
-	if (hdr->p.input_flags.l3 && hdr->p.input_flags.ipv4) {
+	if (hdr->p.input_flags.l3 && packet_hdr_has_ipv4(hdr)) {
 		ipv4 = (const _odp_ipv4hdr_t *)(pkt_addr + hdr->p.l3_offset);
 		dscp = _ODP_IPV4HDR_DSCP(ipv4->tos);
 		cos = l3_cos->cos[dscp];
-	} else if (hdr->p.input_flags.l3 && hdr->p.input_flags.ipv6) {
+	} else if (hdr->p.input_flags.l3 && packet_hdr_has_ipv6(hdr)) {
 		ipv6 = (const _odp_ipv6hdr_t *)(pkt_addr + hdr->p.l3_offset);
 		dscp = _ODP_IPV6HDR_DSCP(ipv6->ver_tc_flow);
 		cos = l3_cos->cos[dscp];

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2196,14 +2196,12 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 	/* Parse Layer 3 headers */
 	switch (ethtype) {
 	case _ODP_ETHTYPE_IPV4:
-		prs->input_flags.ipv4 = 1;
 		prs->input_flags.l3_type = ODP_PROTO_L3_TYPE_IPV4;
 		ip_proto = parse_ipv4(prs, &parseptr, &offset, frame_len);
 		prs->l4_offset = offset;
 		break;
 
 	case _ODP_ETHTYPE_IPV6:
-		prs->input_flags.ipv6 = 1;
 		prs->input_flags.l3_type = ODP_PROTO_L3_TYPE_IPV6;
 		ip_proto = parse_ipv6(prs, &parseptr, &offset, frame_len,
 				      seg_len);
@@ -2211,7 +2209,6 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 		break;
 
 	case _ODP_ETHTYPE_ARP:
-		prs->input_flags.arp = 1;
 		prs->input_flags.l3_type = ODP_PROTO_L3_TYPE_ARP;
 		ip_proto = 255;  /* Reserved invalid by IANA */
 		break;
@@ -2562,9 +2559,6 @@ void odp_packet_l3_type_set(odp_packet_t pkt, odp_proto_l3_type_t val)
 	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
 
 	pkt_hdr->p.input_flags.l3_type = val;
-	pkt_hdr->p.input_flags.arp = (val == ODP_PROTO_L3_TYPE_ARP);
-	pkt_hdr->p.input_flags.ipv4 = (val == ODP_PROTO_L3_TYPE_IPV4);
-	pkt_hdr->p.input_flags.ipv6 = (val == ODP_PROTO_L3_TYPE_IPV6);
 }
 
 odp_proto_l4_type_t odp_packet_l4_type(odp_packet_t pkt)

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2197,12 +2197,14 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 	switch (ethtype) {
 	case _ODP_ETHTYPE_IPV4:
 		prs->input_flags.ipv4 = 1;
+		prs->input_flags.l3_type = ODP_PROTO_L3_TYPE_IPV4;
 		ip_proto = parse_ipv4(prs, &parseptr, &offset, frame_len);
 		prs->l4_offset = offset;
 		break;
 
 	case _ODP_ETHTYPE_IPV6:
 		prs->input_flags.ipv6 = 1;
+		prs->input_flags.l3_type = ODP_PROTO_L3_TYPE_IPV6;
 		ip_proto = parse_ipv6(prs, &parseptr, &offset, frame_len,
 				      seg_len);
 		prs->l4_offset = offset;
@@ -2210,6 +2212,7 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 
 	case _ODP_ETHTYPE_ARP:
 		prs->input_flags.arp = 1;
+		prs->input_flags.l3_type = ODP_PROTO_L3_TYPE_ARP;
 		ip_proto = 255;  /* Reserved invalid by IANA */
 		break;
 
@@ -2223,6 +2226,7 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 
 	/* Set l4 flag only for known ip_proto */
 	prs->input_flags.l4 = 1;
+	prs->input_flags.l4_type = ip_proto;
 
 	/* Parse Layer 4 headers */
 	switch (ip_proto) {
@@ -2267,6 +2271,7 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 
 	default:
 		prs->input_flags.l4 = 0;
+		prs->input_flags.l4_type = ODP_PROTO_L4_TYPE_NONE;
 		break;
 	}
 
@@ -2543,4 +2548,18 @@ int odp_packet_has_ref(odp_packet_t pkt)
 	}
 
 	return 0;
+}
+
+odp_proto_l3_type_t odp_packet_l3_type(odp_packet_t pkt)
+{
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	return pkt_hdr->p.input_flags.l3_type;
+}
+
+odp_proto_l4_type_t odp_packet_l4_type(odp_packet_t pkt)
+{
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	return pkt_hdr->p.input_flags.l4_type;
 }

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2557,9 +2557,31 @@ odp_proto_l3_type_t odp_packet_l3_type(odp_packet_t pkt)
 	return pkt_hdr->p.input_flags.l3_type;
 }
 
+void odp_packet_l3_type_set(odp_packet_t pkt, odp_proto_l3_type_t val)
+{
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	pkt_hdr->p.input_flags.l3_type = val;
+	pkt_hdr->p.input_flags.arp = (val == ODP_PROTO_L3_TYPE_ARP);
+	pkt_hdr->p.input_flags.ipv4 = (val == ODP_PROTO_L3_TYPE_IPV4);
+	pkt_hdr->p.input_flags.ipv6 = (val == ODP_PROTO_L3_TYPE_IPV6);
+}
+
 odp_proto_l4_type_t odp_packet_l4_type(odp_packet_t pkt)
 {
 	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
 
 	return pkt_hdr->p.input_flags.l4_type;
+}
+
+void odp_packet_l4_type_set(odp_packet_t pkt, odp_proto_l4_type_t val)
+{
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	pkt_hdr->p.input_flags.l4_type = val;
+	pkt_hdr->p.input_flags.tcp = (val == ODP_PROTO_L4_TYPE_TCP);
+	pkt_hdr->p.input_flags.udp = (val == ODP_PROTO_L4_TYPE_UDP);
+	pkt_hdr->p.input_flags.sctp = (val == ODP_PROTO_L4_TYPE_SCTP);
+	pkt_hdr->p.input_flags.icmp = (val == ODP_PROTO_L4_TYPE_ICMPV4) ||
+				      (val == ODP_PROTO_L4_TYPE_ICMPV6);
 }

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2228,10 +2228,11 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 	/* Parse Layer 4 headers */
 	switch (ip_proto) {
 	case _ODP_IPPROTO_ICMPV4:
-	/* Fall through */
+		/* Do nothing */
+		break;
 
 	case _ODP_IPPROTO_ICMPV6:
-		prs->input_flags.icmp = 1;
+		/* Do nothing */
 		break;
 
 	case _ODP_IPPROTO_IPIP:
@@ -2241,29 +2242,25 @@ int packet_parse_common_l3_l4(packet_parser_t *prs, const uint8_t *parseptr,
 	case _ODP_IPPROTO_TCP:
 		if (odp_unlikely(offset + _ODP_TCPHDR_LEN > seg_len))
 			return -1;
-		prs->input_flags.tcp = 1;
 		parse_tcp(prs, &parseptr, NULL);
 		break;
 
 	case _ODP_IPPROTO_UDP:
 		if (odp_unlikely(offset + _ODP_UDPHDR_LEN > seg_len))
 			return -1;
-		prs->input_flags.udp = 1;
 		parse_udp(prs, &parseptr, NULL);
 		break;
 
 	case _ODP_IPPROTO_AH:
 		prs->input_flags.ipsec = 1;
-		prs->input_flags.ipsec_ah = 1;
 		break;
 
 	case _ODP_IPPROTO_ESP:
 		prs->input_flags.ipsec = 1;
-		prs->input_flags.ipsec_esp = 1;
 		break;
 
 	case _ODP_IPPROTO_SCTP:
-		prs->input_flags.sctp = 1;
+		/* Do nothing */
 		break;
 
 	default:
@@ -2573,9 +2570,4 @@ void odp_packet_l4_type_set(odp_packet_t pkt, odp_proto_l4_type_t val)
 	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
 
 	pkt_hdr->p.input_flags.l4_type = val;
-	pkt_hdr->p.input_flags.tcp = (val == ODP_PROTO_L4_TYPE_TCP);
-	pkt_hdr->p.input_flags.udp = (val == ODP_PROTO_L4_TYPE_UDP);
-	pkt_hdr->p.input_flags.sctp = (val == ODP_PROTO_L4_TYPE_SCTP);
-	pkt_hdr->p.input_flags.icmp = (val == ODP_PROTO_L4_TYPE_ICMPV4) ||
-				      (val == ODP_PROTO_L4_TYPE_ICMPV6);
 }

--- a/platform/linux-generic/odp_packet_flags.c
+++ b/platform/linux-generic/odp_packet_flags.c
@@ -83,17 +83,23 @@ int odp_packet_has_vlan_qinq(odp_packet_t pkt)
 
 int odp_packet_has_arp(odp_packet_t pkt)
 {
-	retflag(pkt, input_flags.arp);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	return pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L3_TYPE_ARP;
 }
 
 int odp_packet_has_ipv4(odp_packet_t pkt)
 {
-	retflag(pkt, input_flags.ipv4);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	return pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L3_TYPE_IPV4;
 }
 
 int odp_packet_has_ipv6(odp_packet_t pkt)
 {
-	retflag(pkt, input_flags.ipv6);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	return pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L3_TYPE_IPV6;
 }
 
 int odp_packet_has_ip_bcast(odp_packet_t pkt)
@@ -226,17 +232,32 @@ void odp_packet_has_vlan_qinq_set(odp_packet_t pkt, int val)
 
 void odp_packet_has_arp_set(odp_packet_t pkt, int val)
 {
-	setflag(pkt, input_flags.arp, val);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	if (val)
+		odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_ARP);
+	else if (pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L3_TYPE_ARP)
+		odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_NONE);
 }
 
 void odp_packet_has_ipv4_set(odp_packet_t pkt, int val)
 {
-	setflag(pkt, input_flags.ipv4, val);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	if (val)
+		odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_IPV4);
+	else if (pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L3_TYPE_IPV4)
+		odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_NONE);
 }
 
 void odp_packet_has_ipv6_set(odp_packet_t pkt, int val)
 {
-	setflag(pkt, input_flags.ipv6, val);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	if (val)
+		odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_IPV6);
+	else if (pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L3_TYPE_IPV6)
+		odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_NONE);
 }
 
 void odp_packet_has_ip_bcast_set(odp_packet_t pkt, int val)

--- a/platform/linux-generic/odp_packet_flags.c
+++ b/platform/linux-generic/odp_packet_flags.c
@@ -8,6 +8,7 @@
 
 #include <odp/api/plat/packet_flag_inlines.h>
 #include <odp/api/packet_flags.h>
+#include <odp/api/deprecated.h>
 #include <odp_packet_internal.h>
 
 #define retflag(pkt, x) do {                             \
@@ -239,6 +240,7 @@ void odp_packet_has_vlan_qinq_set(odp_packet_t pkt, int val)
 	setflag(pkt, input_flags.vlan_qinq, val);
 }
 
+#if ODP_DEPRECATED_API
 void odp_packet_has_arp_set(odp_packet_t pkt, int val)
 {
 	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
@@ -268,6 +270,7 @@ void odp_packet_has_ipv6_set(odp_packet_t pkt, int val)
 	else if (pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L3_TYPE_IPV6)
 		odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_NONE);
 }
+#endif
 
 void odp_packet_has_ip_bcast_set(odp_packet_t pkt, int val)
 {
@@ -294,6 +297,7 @@ void odp_packet_has_ipsec_set(odp_packet_t pkt, int val)
 	setflag(pkt, input_flags.ipsec, val);
 }
 
+#if ODP_DEPRECATED_API
 void odp_packet_has_udp_set(odp_packet_t pkt, int val)
 {
 	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
@@ -337,6 +341,7 @@ void odp_packet_has_icmp_set(odp_packet_t pkt, int val)
 	else if (pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L4_TYPE_ICMPV6)
 		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_NONE);
 }
+#endif
 
 void odp_packet_has_flow_hash_clr(odp_packet_t pkt)
 {

--- a/platform/linux-generic/odp_packet_flags.c
+++ b/platform/linux-generic/odp_packet_flags.c
@@ -129,22 +129,31 @@ int odp_packet_has_ipsec(odp_packet_t pkt)
 
 int odp_packet_has_udp(odp_packet_t pkt)
 {
-	retflag(pkt, input_flags.udp);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	return pkt_hdr->p.input_flags.l4_type == ODP_PROTO_L4_TYPE_UDP;
 }
 
 int odp_packet_has_tcp(odp_packet_t pkt)
 {
-	retflag(pkt, input_flags.tcp);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	return pkt_hdr->p.input_flags.l4_type == ODP_PROTO_L4_TYPE_TCP;
 }
 
 int odp_packet_has_sctp(odp_packet_t pkt)
 {
-	retflag(pkt, input_flags.sctp);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	return pkt_hdr->p.input_flags.l4_type == ODP_PROTO_L4_TYPE_SCTP;
 }
 
 int odp_packet_has_icmp(odp_packet_t pkt)
 {
-	retflag(pkt, input_flags.icmp);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	return pkt_hdr->p.input_flags.l4_type == ODP_PROTO_L4_TYPE_ICMPV4 ||
+	       pkt_hdr->p.input_flags.l4_type == ODP_PROTO_L4_TYPE_ICMPV6;
 }
 
 odp_packet_color_t odp_packet_color(odp_packet_t pkt)
@@ -287,22 +296,46 @@ void odp_packet_has_ipsec_set(odp_packet_t pkt, int val)
 
 void odp_packet_has_udp_set(odp_packet_t pkt, int val)
 {
-	setflag(pkt, input_flags.udp, val);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	if (val)
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_UDP);
+	else if (pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L4_TYPE_UDP)
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_NONE);
 }
 
 void odp_packet_has_tcp_set(odp_packet_t pkt, int val)
 {
-	setflag(pkt, input_flags.tcp, val);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	if (val)
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_TCP);
+	else if (pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L4_TYPE_TCP)
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_NONE);
 }
 
 void odp_packet_has_sctp_set(odp_packet_t pkt, int val)
 {
-	setflag(pkt, input_flags.sctp, val);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	if (val)
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_SCTP);
+	else if (pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L4_TYPE_SCTP)
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_NONE);
 }
 
 void odp_packet_has_icmp_set(odp_packet_t pkt, int val)
 {
-	setflag(pkt, input_flags.icmp, val);
+	odp_packet_hdr_t *pkt_hdr = odp_packet_hdr(pkt);
+
+	if (val && odp_packet_has_ipv6(pkt))
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_ICMPV6);
+	else if (val)
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_ICMPV4);
+	else if (pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L4_TYPE_ICMPV4)
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_NONE);
+	else if (pkt_hdr->p.input_flags.l3_type == ODP_PROTO_L4_TYPE_ICMPV6)
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_NONE);
 }
 
 void odp_packet_has_flow_hash_clr(odp_packet_t pkt)

--- a/test/validation/api/classification/odp_classification_common.c
+++ b/test/validation/api/classification/odp_classification_common.c
@@ -350,7 +350,7 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 		udp->dst_port = odp_cpu_to_be_16(CLS_DEFAULT_DPORT);
 		udp->length = odp_cpu_to_be_16(payload_len + ODPH_UDPHDR_LEN);
 		udp->chksum = 0;
-		odp_packet_has_udp_set(pkt, 1);
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_UDP);
 		if (odph_udp_tcp_chksum(pkt, ODPH_CHKSUM_GENERATE, NULL) != 0) {
 			LOG_ERR("odph_udp_tcp_chksum failed\n");
 			return ODP_PACKET_INVALID;
@@ -360,7 +360,7 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 		tcp->dst_port = odp_cpu_to_be_16(CLS_DEFAULT_DPORT);
 		tcp->hl = ODPH_TCPHDR_LEN / 4;
 		tcp->cksm = 0;
-		odp_packet_has_tcp_set(pkt, 1);
+		odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_TCP);
 		if (odph_udp_tcp_chksum(pkt, ODPH_CHKSUM_GENERATE, NULL) != 0) {
 			LOG_ERR("odph_udp_tcp_chksum failed\n");
 			return ODP_PACKET_INVALID;

--- a/test/validation/api/classification/odp_classification_common.c
+++ b/test/validation/api/classification/odp_classification_common.c
@@ -321,10 +321,10 @@ odp_packet_t create_packet(cls_packet_info_t pkt_info)
 		ip->proto = next_hdr;
 		ip->tot_len = odp_cpu_to_be_16(l3_len);
 		ip->ttl = DEFAULT_TTL;
-		odp_packet_has_ipv4_set(pkt, 1);
+		odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_IPV4);
 	} else {
 		/* ipv6 */
-		odp_packet_has_ipv6_set(pkt, 1);
+		odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_IPV6);
 		ipv6 = (odph_ipv6hdr_t *)odp_packet_l3_ptr(pkt, NULL);
 		version     = ODPH_IPV6        << ODPH_IPV6HDR_VERSION_SHIFT;
 		tc          = DEFAULT_TOS << ODPH_IPV6HDR_TC_SHIFT;

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -1052,10 +1052,6 @@ void packet_test_in_flags(void)
 	TEST_INFLAG(pkt, ipfrag);
 	TEST_INFLAG(pkt, ipopt);
 	TEST_INFLAG(pkt, ipsec);
-	TEST_INFLAG(pkt, udp);
-	TEST_INFLAG(pkt, tcp);
-	TEST_INFLAG(pkt, sctp);
-	TEST_INFLAG(pkt, icmp);
 
 	odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_NONE);
 	CU_ASSERT_EQUAL(odp_packet_l3_type(pkt), ODP_PROTO_L3_TYPE_NONE);
@@ -1069,17 +1065,73 @@ void packet_test_in_flags(void)
 	CU_ASSERT(!odp_packet_has_ipv4(pkt));
 	CU_ASSERT(!odp_packet_has_ipv6(pkt));
 
+	odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_NONE);
+	CU_ASSERT_EQUAL(odp_packet_l4_type(pkt), ODP_PROTO_L4_TYPE_NONE);
+	CU_ASSERT(!odp_packet_has_tcp(pkt));
+	CU_ASSERT(!odp_packet_has_udp(pkt));
+	CU_ASSERT(!odp_packet_has_sctp(pkt));
+	CU_ASSERT(!odp_packet_has_icmp(pkt));
+
 	odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_IPV4);
 	CU_ASSERT_EQUAL(odp_packet_l3_type(pkt), ODP_PROTO_L3_TYPE_IPV4);
 	CU_ASSERT(!odp_packet_has_arp(pkt));
 	CU_ASSERT(odp_packet_has_ipv4(pkt));
 	CU_ASSERT(!odp_packet_has_ipv6(pkt));
 
+	odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_ICMPV4);
+	CU_ASSERT_EQUAL(odp_packet_l4_type(pkt), ODP_PROTO_L4_TYPE_ICMPV4);
+	CU_ASSERT(!odp_packet_has_tcp(pkt));
+	CU_ASSERT(!odp_packet_has_udp(pkt));
+	CU_ASSERT(!odp_packet_has_sctp(pkt));
+	CU_ASSERT(odp_packet_has_icmp(pkt));
+
+	odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_TCP);
+	CU_ASSERT_EQUAL(odp_packet_l4_type(pkt), ODP_PROTO_L4_TYPE_TCP);
+	CU_ASSERT(odp_packet_has_tcp(pkt));
+	CU_ASSERT(!odp_packet_has_udp(pkt));
+	CU_ASSERT(!odp_packet_has_sctp(pkt));
+	CU_ASSERT(!odp_packet_has_icmp(pkt));
+
+	odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_UDP);
+	CU_ASSERT_EQUAL(odp_packet_l4_type(pkt), ODP_PROTO_L4_TYPE_UDP);
+	CU_ASSERT(!odp_packet_has_tcp(pkt));
+	CU_ASSERT(odp_packet_has_udp(pkt));
+	CU_ASSERT(!odp_packet_has_sctp(pkt));
+	CU_ASSERT(!odp_packet_has_icmp(pkt));
+
+	odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_SCTP);
+	CU_ASSERT_EQUAL(odp_packet_l4_type(pkt), ODP_PROTO_L4_TYPE_SCTP);
+	CU_ASSERT(!odp_packet_has_tcp(pkt));
+	CU_ASSERT(!odp_packet_has_udp(pkt));
+	CU_ASSERT(odp_packet_has_sctp(pkt));
+	CU_ASSERT(!odp_packet_has_icmp(pkt));
+
+	odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_AH);
+	CU_ASSERT_EQUAL(odp_packet_l4_type(pkt), ODP_PROTO_L4_TYPE_AH);
+	CU_ASSERT(!odp_packet_has_tcp(pkt));
+	CU_ASSERT(!odp_packet_has_udp(pkt));
+	CU_ASSERT(!odp_packet_has_sctp(pkt));
+	CU_ASSERT(!odp_packet_has_icmp(pkt));
+
+	odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_ESP);
+	CU_ASSERT_EQUAL(odp_packet_l4_type(pkt), ODP_PROTO_L4_TYPE_ESP);
+	CU_ASSERT(!odp_packet_has_tcp(pkt));
+	CU_ASSERT(!odp_packet_has_udp(pkt));
+	CU_ASSERT(!odp_packet_has_sctp(pkt));
+	CU_ASSERT(!odp_packet_has_icmp(pkt));
+
 	odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_IPV6);
 	CU_ASSERT_EQUAL(odp_packet_l3_type(pkt), ODP_PROTO_L3_TYPE_IPV6);
 	CU_ASSERT(!odp_packet_has_arp(pkt));
 	CU_ASSERT(!odp_packet_has_ipv4(pkt));
 	CU_ASSERT(odp_packet_has_ipv6(pkt));
+
+	odp_packet_l4_type_set(pkt, ODP_PROTO_L4_TYPE_ICMPV6);
+	CU_ASSERT_EQUAL(odp_packet_l4_type(pkt), ODP_PROTO_L4_TYPE_ICMPV6);
+	CU_ASSERT(!odp_packet_has_tcp(pkt));
+	CU_ASSERT(!odp_packet_has_udp(pkt));
+	CU_ASSERT(!odp_packet_has_sctp(pkt));
+	CU_ASSERT(odp_packet_has_icmp(pkt));
 }
 
 void packet_test_error_flags(void)

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -2552,6 +2552,10 @@ void packet_test_parse(void)
 		CU_ASSERT(odp_packet_has_udp(pkt[i]));
 		CU_ASSERT(!odp_packet_has_ipv6(pkt[i]));
 		CU_ASSERT(!odp_packet_has_tcp(pkt[i]));
+		CU_ASSERT_EQUAL(odp_packet_l3_type(pkt[i]),
+				ODP_PROTO_L3_TYPE_IPV4);
+		CU_ASSERT_EQUAL(odp_packet_l4_type(pkt[i]),
+				ODP_PROTO_L4_TYPE_UDP);
 	}
 
 	odp_packet_free_multi(pkt, num_pkt);
@@ -2582,6 +2586,10 @@ void packet_test_parse(void)
 		CU_ASSERT(odp_packet_has_udp(pkt[i]));
 		CU_ASSERT(!odp_packet_has_ipv6(pkt[i]));
 		CU_ASSERT(!odp_packet_has_tcp(pkt[i]));
+		CU_ASSERT_EQUAL(odp_packet_l3_type(pkt[i]),
+				ODP_PROTO_L3_TYPE_IPV4);
+		CU_ASSERT_EQUAL(odp_packet_l4_type(pkt[i]),
+				ODP_PROTO_L4_TYPE_UDP);
 	}
 
 	odp_packet_free_multi(pkt, num_pkt);
@@ -2612,6 +2620,10 @@ void packet_test_parse(void)
 		CU_ASSERT(odp_packet_has_tcp(pkt[i]));
 		CU_ASSERT(!odp_packet_has_ipv6(pkt[i]));
 		CU_ASSERT(!odp_packet_has_udp(pkt[i]));
+		CU_ASSERT_EQUAL(odp_packet_l3_type(pkt[i]),
+				ODP_PROTO_L3_TYPE_IPV4);
+		CU_ASSERT_EQUAL(odp_packet_l4_type(pkt[i]),
+				ODP_PROTO_L4_TYPE_TCP);
 	}
 
 	odp_packet_free_multi(pkt, num_pkt);
@@ -2643,6 +2655,10 @@ void packet_test_parse(void)
 		CU_ASSERT(odp_packet_has_udp(pkt[i]));
 		CU_ASSERT(!odp_packet_has_ipv4(pkt[i]));
 		CU_ASSERT(!odp_packet_has_tcp(pkt[i]));
+		CU_ASSERT_EQUAL(odp_packet_l3_type(pkt[i]),
+				ODP_PROTO_L3_TYPE_IPV6);
+		CU_ASSERT_EQUAL(odp_packet_l4_type(pkt[i]),
+				ODP_PROTO_L4_TYPE_UDP);
 	}
 
 	odp_packet_free_multi(pkt, num_pkt);
@@ -2674,6 +2690,10 @@ void packet_test_parse(void)
 		CU_ASSERT(odp_packet_has_tcp(pkt[i]));
 		CU_ASSERT(!odp_packet_has_ipv4(pkt[i]));
 		CU_ASSERT(!odp_packet_has_udp(pkt[i]));
+		CU_ASSERT_EQUAL(odp_packet_l3_type(pkt[i]),
+				ODP_PROTO_L3_TYPE_IPV6);
+		CU_ASSERT_EQUAL(odp_packet_l4_type(pkt[i]),
+				ODP_PROTO_L4_TYPE_TCP);
 	}
 
 	odp_packet_free_multi(pkt, num_pkt);

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -1047,9 +1047,6 @@ void packet_test_in_flags(void)
 	TEST_INFLAG(pkt, jumbo);
 	TEST_INFLAG(pkt, vlan);
 	TEST_INFLAG(pkt, vlan_qinq);
-	TEST_INFLAG(pkt, arp);
-	TEST_INFLAG(pkt, ipv4);
-	TEST_INFLAG(pkt, ipv6);
 	TEST_INFLAG(pkt, ip_bcast);
 	TEST_INFLAG(pkt, ip_mcast);
 	TEST_INFLAG(pkt, ipfrag);
@@ -1059,6 +1056,30 @@ void packet_test_in_flags(void)
 	TEST_INFLAG(pkt, tcp);
 	TEST_INFLAG(pkt, sctp);
 	TEST_INFLAG(pkt, icmp);
+
+	odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_NONE);
+	CU_ASSERT_EQUAL(odp_packet_l3_type(pkt), ODP_PROTO_L3_TYPE_NONE);
+	CU_ASSERT(!odp_packet_has_arp(pkt));
+	CU_ASSERT(!odp_packet_has_ipv4(pkt));
+	CU_ASSERT(!odp_packet_has_ipv6(pkt));
+
+	odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_ARP);
+	CU_ASSERT_EQUAL(odp_packet_l3_type(pkt), ODP_PROTO_L3_TYPE_ARP);
+	CU_ASSERT(odp_packet_has_arp(pkt));
+	CU_ASSERT(!odp_packet_has_ipv4(pkt));
+	CU_ASSERT(!odp_packet_has_ipv6(pkt));
+
+	odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_IPV4);
+	CU_ASSERT_EQUAL(odp_packet_l3_type(pkt), ODP_PROTO_L3_TYPE_IPV4);
+	CU_ASSERT(!odp_packet_has_arp(pkt));
+	CU_ASSERT(odp_packet_has_ipv4(pkt));
+	CU_ASSERT(!odp_packet_has_ipv6(pkt));
+
+	odp_packet_l3_type_set(pkt, ODP_PROTO_L3_TYPE_IPV6);
+	CU_ASSERT_EQUAL(odp_packet_l3_type(pkt), ODP_PROTO_L3_TYPE_IPV6);
+	CU_ASSERT(!odp_packet_has_arp(pkt));
+	CU_ASSERT(!odp_packet_has_ipv4(pkt));
+	CU_ASSERT(odp_packet_has_ipv6(pkt));
 }
 
 void packet_test_error_flags(void)

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -739,7 +739,7 @@ static odp_packet_t make_pkt(odp_pool_t  pkt_pool,
 	odp_packet_l3_offset_set(odp_pkt, l3_offset);
 	if (pkt_info->use_ipv6) {
 		/* IPv6 Header */
-		odp_packet_has_ipv6_set(odp_pkt, 1);
+		odp_packet_l3_type_set(odp_pkt, ODP_PROTO_L3_TYPE_IPV6);
 		version     = ODPH_IPV6        << ODPH_IPV6HDR_VERSION_SHIFT;
 		tc          = pkt_info->ip_tos << ODPH_IPV6HDR_TC_SHIFT;
 		flow        = unique_id        << ODPH_IPV6HDR_FLOW_LABEL_SHIFT;
@@ -754,7 +754,7 @@ static odp_packet_t make_pkt(odp_pool_t  pkt_pool,
 		memcpy(ipv6_hdr->dst_addr, IPV6_DST_ADDR, ODPH_IPV6ADDR_LEN);
 	} else {
 		/* IPv4 Header */
-		odp_packet_has_ipv4_set(odp_pkt, 1);
+		odp_packet_l3_type_set(odp_pkt, ODP_PROTO_L3_TYPE_IPV4);
 		ipv4_hdr              = (odph_ipv4hdr_t *)(buf + l3_offset);
 		ipv4_hdr->ver_ihl     = (ODPH_IPV4 << 4) | ODPH_IPV4HDR_IHL_MIN;
 		ipv4_hdr->tos         = pkt_info->ip_tos;

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -775,7 +775,7 @@ static odp_packet_t make_pkt(odp_pool_t  pkt_pool,
 
 	if (pkt_info->use_tcp) {
 		/* TCP Header */
-		odp_packet_has_tcp_set(odp_pkt, 1);
+		odp_packet_l4_type_set(odp_pkt, ODP_PROTO_L4_TYPE_TCP);
 		tcp_hdr->src_port = odp_cpu_to_be_16(DEFAULT_TCP_SRC_PORT);
 		tcp_hdr->dst_port = odp_cpu_to_be_16(DEFAULT_TCP_DST_PORT);
 		tcp_hdr->seq_no   = odp_cpu_to_be_32(cpu_tcp_seq_num);
@@ -790,7 +790,7 @@ static odp_packet_t make_pkt(odp_pool_t  pkt_pool,
 		cpu_tcp_seq_num       += payload_len;
 	} else {
 		/* UDP Header */
-		odp_packet_has_udp_set(odp_pkt, 1);
+		odp_packet_l4_type_set(odp_pkt, ODP_PROTO_L4_TYPE_UDP);
 		udp_hdr->src_port = odp_cpu_to_be_16(DEFAULT_UDP_SRC_PORT);
 		udp_hdr->dst_port = odp_cpu_to_be_16(DEFAULT_UDP_DST_PORT);
 		udp_hdr->length   = odp_cpu_to_be_16(l4_len);


### PR DESCRIPTION
Implement new packet API. For simplicity add setting functions for L3/L4 packet types.
While we are at it, should we add L2 packet type (only ETH for now) for completeness?