### PR TITLE
[PATCH v2] configure: enable all Automake warnings and make them errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ ODP_VERSION_API_MAJOR=odpapi_major_version
 AC_SUBST(ODP_VERSION_API_MAJOR)
 ODP_VERSION_API_MINOR=odpapi_minor_version
 AC_SUBST(ODP_VERSION_API_MINOR)
-AM_INIT_AUTOMAKE([1.9 tar-pax subdir-objects foreign nostdinc])
+AM_INIT_AUTOMAKE([1.9 tar-pax subdir-objects foreign nostdinc -Wall -Werror])
 AC_CONFIG_SRCDIR([include/odp/api/spec/init.h])
 AM_CONFIG_HEADER([include/config.h])
 

--- a/platform/Makefile.inc
+++ b/platform/Makefile.inc
@@ -9,9 +9,9 @@ lib_LTLIBRARIES = $(LIB)/libodp-linux.la
 AM_LDFLAGS = -version-number '$(ODP_LIBSO_VERSION)'
 
 if ODP_ABI_COMPAT
-AM_LDFLAGS += -export-symbols-regex '^(_deprecated)?odp_'
+AM_LDFLAGS += -export-symbols-regex '^(_deprecated_)?odp_'
 else
-AM_LDFLAGS += -export-symbols-regex '^(_deprecated)?_?odp_'
+AM_LDFLAGS += -export-symbols-regex '^(_deprecated_)?_?odp_'
 endif
 
 AM_CFLAGS = "-DGIT_HASH=$(VERSION)"


### PR DESCRIPTION
Make Automake stop on all warnings it encounters when creating
Makefile.in's

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>