### PR TITLE
[PATCH v1] non-optimized (default) host support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ env:
         - CONF="--enable-schedule-scalable"
         - CONF="--enable-dpdk-zero-copy"
         - CONF="--disable-static-applications"
+        - CONF="--disable-host-optimization"
+        - CONF="--disable-host-optimization --disable-abi-compat"
         - DPDK_SHARED="y" CONF="--disable-static-applications"
 
 compiler:

--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,7 @@ ODP_CFLAGS="$ODP_CFLAGS $ODP_CFLAGS_EXTRA"
 # Check if compiler supports cmpxchng16 on x86-based architectures
 ##########################################################################
 case "${host}" in
-  i?86? | x86*)
+  i?86* | x86*)
   if test "${CC}" != "gcc" -o ${CC_VERSION_MAJOR} -ge 5; then
      ODP_CHECK_CFLAG([-mcx16])
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -164,14 +164,6 @@ AS_CASE([$host],
 AC_SUBST([ARCH_DIR])
 
 ##########################################################################
-# Warn on the defaults if arch is undefined
-##########################################################################
-if test "${ARCH_DIR}" = "default";
-then
-    AC_MSG_WARN([ARCH_DIR is undefined, please add your ARCH_DIR based on host=${host}])
-fi
-
-##########################################################################
 # Architecture for ABI support
 ##########################################################################
 AS_CASE([$host],
@@ -184,6 +176,23 @@ AS_CASE([$host],
   [ARCH_ABI=default-linux]
 )
 AC_SUBST([ARCH_ABI])
+
+AC_ARG_ENABLE([host-optimization],
+	      [AS_HELP_STRING([--disable-host-optimization],
+			      [disables using host-specific ARCH and ABI files])],
+			      [], [enable_host_optimization=yes])
+if test "x$enable_host_optimization" = "xno" ; then
+	ARCH_DIR=default
+	ARCH_ABI=default-linux
+fi
+
+##########################################################################
+# Warn on the defaults if arch is undefined
+##########################################################################
+if test "${ARCH_DIR}" = "default";
+then
+    AC_MSG_WARN([ARCH_DIR is undefined, please add your ARCH_DIR based on host=${host}])
+fi
 
 if test "${ARCH_ABI}" = "default-linux";
 then

--- a/configure.ac
+++ b/configure.ac
@@ -159,17 +159,16 @@ AS_CASE([$host],
   [powerpc*], [ARCH_DIR=powerpc],
   [aarch64*], [ARCH_DIR=aarch64],
   [arm*], [ARCH_DIR=arm],
-  [ARCH_DIR=undefined]
+  [ARCH_DIR=default]
 )
 AC_SUBST([ARCH_DIR])
 
 ##########################################################################
 # Warn on the defaults if arch is undefined
 ##########################################################################
-if test "${ARCH_DIR}" = "undefined";
+if test "${ARCH_DIR}" = "default";
 then
-    echo "ARCH_DIR is undefined, please add your ARCH_DIR based on host=${host}"
-    exit 1
+    AC_MSG_WARN([ARCH_DIR is undefined, please add your ARCH_DIR based on host=${host}])
 fi
 
 ##########################################################################
@@ -280,6 +279,7 @@ AM_CONDITIONAL([HAVE_MSCGEN], [test "x${MSCGEN}" = "xmscgen"])
 AM_CONDITIONAL([helper_linux], [test x$helper_linux = xyes ])
 AM_CONDITIONAL([ARCH_IS_ARM], [test "x${ARCH_DIR}" = "xarm"])
 AM_CONDITIONAL([ARCH_IS_AARCH64], [test "x${ARCH_DIR}" = "xaarch64"])
+AM_CONDITIONAL([ARCH_IS_DEFAULT], [test "x${ARCH_DIR}" = "xdefault"])
 AM_CONDITIONAL([ARCH_IS_MIPS64], [test "x${ARCH_DIR}" = "xmips64"])
 AM_CONDITIONAL([ARCH_IS_POWERPC], [test "x${ARCH_DIR}" = "xpowerpc"])
 AM_CONDITIONAL([ARCH_IS_X86], [test "x${ARCH_DIR}" = "xx86"])

--- a/configure.ac
+++ b/configure.ac
@@ -211,7 +211,8 @@ AC_SUBST(PKGCONFIG_VERSION)
 ODP_ABI_COMPAT=1
 abi_compat=yes
 AC_ARG_ENABLE([abi-compat],
-    [  --disable-abi-compat    disables ABI compatible mode, enables inline code in header files],
+    [AS_HELP_STRING([--disable-abi-compat],
+		    [disables ABI compatible mode, enables inline code in header files])],
     [if test "x$enableval" = "xno"; then
 	ODP_ABI_COMPAT=0
 	abi_compat=no

--- a/configure.ac
+++ b/configure.ac
@@ -181,14 +181,13 @@ AS_CASE([$host],
   [powerpc*], [ARCH_ABI=power64-linux],
   [aarch64*], [ARCH_ABI=arm64-linux],
   [arm*],     [ARCH_ABI=arm32-linux],
-  [ARCH_ABI=undefined]
+  [ARCH_ABI=default-linux]
 )
 AC_SUBST([ARCH_ABI])
 
-if test "${ARCH_ABI}" = "undefined";
+if test "${ARCH_ABI}" = "default-linux";
 then
-    echo "ARCH_ABI is undefined, please add your ARCH_ABI based on host=${host}"
-    exit 1
+    AC_MSG_WARN([ARCH_ABI is undefined, please add your ARCH_ABI based on host=${host}])
 fi
 
 ##########################################################################

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -226,6 +226,44 @@ odpapiabiarchinclude_HEADERS = \
 	odp/arch/arm64-linux/odp/api/abi/traffic_mngr.h \
 	odp/arch/arm64-linux/odp/api/abi/version.h
 endif
+if ARCH_IS_DEFAULT
+odpapiabiarchinclude_HEADERS = \
+	odp/arch/default-linux/odp/api/abi/align.h \
+	odp/arch/default-linux/odp/api/abi/atomic.h \
+	odp/arch/default-linux/odp/api/abi/barrier.h \
+	odp/arch/default-linux/odp/api/abi/buffer.h \
+	odp/arch/default-linux/odp/api/abi/byteorder.h \
+	odp/arch/default-linux/odp/api/abi/classification.h \
+	odp/arch/default-linux/odp/api/abi/cpu.h \
+	odp/arch/default-linux/odp/api/abi/cpumask.h \
+	odp/arch/default-linux/odp/api/abi/crypto.h \
+	odp/arch/default-linux/odp/api/abi/debug.h \
+	odp/arch/default-linux/odp/api/abi/event.h \
+	odp/arch/default-linux/odp/api/abi/init.h \
+	odp/arch/default-linux/odp/api/abi/ipsec.h \
+	odp/arch/default-linux/odp/api/abi/packet.h \
+	odp/arch/default-linux/odp/api/abi/packet_flags.h \
+	odp/arch/default-linux/odp/api/abi/packet_io.h \
+	odp/arch/default-linux/odp/api/abi/pool.h \
+	odp/arch/default-linux/odp/api/abi/queue.h \
+	odp/arch/default-linux/odp/api/abi/rwlock.h \
+	odp/arch/default-linux/odp/api/abi/rwlock_recursive.h \
+	odp/arch/default-linux/odp/api/abi/schedule.h \
+	odp/arch/default-linux/odp/api/abi/schedule_types.h \
+	odp/arch/default-linux/odp/api/abi/shared_memory.h \
+	odp/arch/default-linux/odp/api/abi/spinlock.h \
+	odp/arch/default-linux/odp/api/abi/spinlock_recursive.h \
+	odp/arch/default-linux/odp/api/abi/std_clib.h \
+	odp/arch/default-linux/odp/api/abi/std_types.h \
+	odp/arch/default-linux/odp/api/abi/sync.h \
+	odp/arch/default-linux/odp/api/abi/thread.h \
+	odp/arch/default-linux/odp/api/abi/thrmask.h \
+	odp/arch/default-linux/odp/api/abi/ticketlock.h \
+	odp/arch/default-linux/odp/api/abi/time.h \
+	odp/arch/default-linux/odp/api/abi/timer.h \
+	odp/arch/default-linux/odp/api/abi/traffic_mngr.h \
+	odp/arch/default-linux/odp/api/abi/version.h
+endif
 if ARCH_IS_MIPS64
 odpapiabiarchinclude_HEADERS = \
 	odp/arch/mips64-linux/odp/api/abi/align.h \

--- a/include/odp/arch/default-linux/odp/api/abi/align.h
+++ b/include/odp/arch/default-linux/odp/api/abi/align.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/align.h>

--- a/include/odp/arch/default-linux/odp/api/abi/atomic.h
+++ b/include/odp/arch/default-linux/odp/api/abi/atomic.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/atomic.h>

--- a/include/odp/arch/default-linux/odp/api/abi/barrier.h
+++ b/include/odp/arch/default-linux/odp/api/abi/barrier.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/barrier.h>

--- a/include/odp/arch/default-linux/odp/api/abi/buffer.h
+++ b/include/odp/arch/default-linux/odp/api/abi/buffer.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/buffer.h>

--- a/include/odp/arch/default-linux/odp/api/abi/byteorder.h
+++ b/include/odp/arch/default-linux/odp/api/abi/byteorder.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/byteorder.h>

--- a/include/odp/arch/default-linux/odp/api/abi/classification.h
+++ b/include/odp/arch/default-linux/odp/api/abi/classification.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/classification.h>

--- a/include/odp/arch/default-linux/odp/api/abi/cpu.h
+++ b/include/odp/arch/default-linux/odp/api/abi/cpu.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_API_ABI_CPU_H_
+#define ODP_API_ABI_CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ODP_CACHE_LINE_SIZE 64
+
+static inline void odp_cpu_pause(void)
+{
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/odp/arch/default-linux/odp/api/abi/cpumask.h
+++ b/include/odp/arch/default-linux/odp/api/abi/cpumask.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/cpumask.h>

--- a/include/odp/arch/default-linux/odp/api/abi/crypto.h
+++ b/include/odp/arch/default-linux/odp/api/abi/crypto.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/crypto.h>

--- a/include/odp/arch/default-linux/odp/api/abi/debug.h
+++ b/include/odp/arch/default-linux/odp/api/abi/debug.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/debug.h>

--- a/include/odp/arch/default-linux/odp/api/abi/event.h
+++ b/include/odp/arch/default-linux/odp/api/abi/event.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/event.h>

--- a/include/odp/arch/default-linux/odp/api/abi/init.h
+++ b/include/odp/arch/default-linux/odp/api/abi/init.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/init.h>

--- a/include/odp/arch/default-linux/odp/api/abi/ipsec.h
+++ b/include/odp/arch/default-linux/odp/api/abi/ipsec.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/ipsec.h>

--- a/include/odp/arch/default-linux/odp/api/abi/packet.h
+++ b/include/odp/arch/default-linux/odp/api/abi/packet.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/packet.h>

--- a/include/odp/arch/default-linux/odp/api/abi/packet_flags.h
+++ b/include/odp/arch/default-linux/odp/api/abi/packet_flags.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/packet_flags.h>

--- a/include/odp/arch/default-linux/odp/api/abi/packet_io.h
+++ b/include/odp/arch/default-linux/odp/api/abi/packet_io.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/packet_io.h>

--- a/include/odp/arch/default-linux/odp/api/abi/pool.h
+++ b/include/odp/arch/default-linux/odp/api/abi/pool.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/pool.h>

--- a/include/odp/arch/default-linux/odp/api/abi/queue.h
+++ b/include/odp/arch/default-linux/odp/api/abi/queue.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/queue.h>

--- a/include/odp/arch/default-linux/odp/api/abi/rwlock.h
+++ b/include/odp/arch/default-linux/odp/api/abi/rwlock.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/rwlock.h>

--- a/include/odp/arch/default-linux/odp/api/abi/rwlock_recursive.h
+++ b/include/odp/arch/default-linux/odp/api/abi/rwlock_recursive.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/rwlock_recursive.h>

--- a/include/odp/arch/default-linux/odp/api/abi/schedule.h
+++ b/include/odp/arch/default-linux/odp/api/abi/schedule.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/schedule.h>

--- a/include/odp/arch/default-linux/odp/api/abi/schedule_types.h
+++ b/include/odp/arch/default-linux/odp/api/abi/schedule_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/schedule_types.h>

--- a/include/odp/arch/default-linux/odp/api/abi/shared_memory.h
+++ b/include/odp/arch/default-linux/odp/api/abi/shared_memory.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/shared_memory.h>

--- a/include/odp/arch/default-linux/odp/api/abi/spinlock.h
+++ b/include/odp/arch/default-linux/odp/api/abi/spinlock.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/spinlock.h>

--- a/include/odp/arch/default-linux/odp/api/abi/spinlock_recursive.h
+++ b/include/odp/arch/default-linux/odp/api/abi/spinlock_recursive.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/spinlock_recursive.h>

--- a/include/odp/arch/default-linux/odp/api/abi/std_clib.h
+++ b/include/odp/arch/default-linux/odp/api/abi/std_clib.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/std_clib.h>

--- a/include/odp/arch/default-linux/odp/api/abi/std_types.h
+++ b/include/odp/arch/default-linux/odp/api/abi/std_types.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/std_types.h>

--- a/include/odp/arch/default-linux/odp/api/abi/sync.h
+++ b/include/odp/arch/default-linux/odp/api/abi/sync.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/sync.h>

--- a/include/odp/arch/default-linux/odp/api/abi/thread.h
+++ b/include/odp/arch/default-linux/odp/api/abi/thread.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/thread.h>

--- a/include/odp/arch/default-linux/odp/api/abi/thrmask.h
+++ b/include/odp/arch/default-linux/odp/api/abi/thrmask.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/thrmask.h>

--- a/include/odp/arch/default-linux/odp/api/abi/ticketlock.h
+++ b/include/odp/arch/default-linux/odp/api/abi/ticketlock.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/ticketlock.h>

--- a/include/odp/arch/default-linux/odp/api/abi/time.h
+++ b/include/odp/arch/default-linux/odp/api/abi/time.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/time.h>

--- a/include/odp/arch/default-linux/odp/api/abi/timer.h
+++ b/include/odp/arch/default-linux/odp/api/abi/timer.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/timer.h>

--- a/include/odp/arch/default-linux/odp/api/abi/traffic_mngr.h
+++ b/include/odp/arch/default-linux/odp/api/abi/traffic_mngr.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/traffic_mngr.h>

--- a/include/odp/arch/default-linux/odp/api/abi/version.h
+++ b/include/odp/arch/default-linux/odp/api/abi/version.h
@@ -1,0 +1,7 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <odp/api/abi-default/version.h>

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -13,12 +13,6 @@ AM_CPPFLAGS +=  $(OPENSSL_CPPFLAGS)
 AM_CPPFLAGS +=  $(DPDK_CPPFLAGS)
 AM_CPPFLAGS +=  $(NETMAP_CPPFLAGS)
 
-if PKTIO_DPDK
-if ARCH_IS_X86
-AM_CFLAGS += -msse4.2
-endif
-endif
-
 if !ODP_ABI_COMPAT
 odpapiplatincludedir= $(includedir)/odp/api/plat
 odpapiplatinclude_HEADERS = \

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -241,6 +241,16 @@ noinst_HEADERS += arch/aarch64/odp_atomic.h \
 		  arch/default/odp_cpu_idling.h \
 		  arch/aarch64/odp_llsc.h
 endif
+if ARCH_IS_DEFAULT
+__LIB__libodp_linux_la_SOURCES += arch/default/odp_cpu_cycles.c \
+				  arch/default/odp_global_time.c \
+				  arch/default/odp_sysinfo_parse.c
+if !ODP_ABI_COMPAT
+odpapiabiarchinclude_HEADERS += arch/default/odp/api/abi/cpu.h
+endif
+noinst_HEADERS += arch/default/odp_cpu.h \
+		  arch/default/odp_cpu_idling.h
+endif
 if ARCH_IS_MIPS64
 __LIB__libodp_linux_la_SOURCES += arch/mips64/odp_cpu_cycles.c \
 				  arch/default/odp_global_time.c \

--- a/platform/linux-generic/arch/default/odp/api/abi/cpu.h
+++ b/platform/linux-generic/arch/default/odp/api/abi/cpu.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_API_ABI_CPU_H_
+#define ODP_API_ABI_CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ODP_CACHE_LINE_SIZE 64
+
+static inline void odp_cpu_pause(void)
+{
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/m4/odp_dpdk.m4
+++ b/platform/linux-generic/m4/odp_dpdk.m4
@@ -34,6 +34,12 @@ then
     ODP_DPDK([$DPDK_PATH], [],
 	     [AC_MSG_FAILURE([can't find DPDK])])
 
+    case "${host}" in
+      i?86* | x86*)
+	DPDK_CPPFLAGS="${DPDK_CPPFLAGS} -msse4.2"
+      ;;
+    esac
+
     AC_DEFINE([ODP_PKTIO_DPDK], [1],
 	      [Define to 1 to enable DPDK packet I/O support])
     AC_DEFINE_UNQUOTED([ODP_DPDK_ZERO_COPY], [$zero_copy],


### PR DESCRIPTION
Provide fallback code to compile and run ODP without any host-specific optimizations. This would allow one to run ODP apps on systems not officially supported by us.