### PR TITLE
linux-generic: misc: add _odp_typeval64() internal macro

### DIFF
--- a/platform/linux-generic/include/odp/api/plat/strong_types.h
+++ b/platform/linux-generic/include/odp/api/plat/strong_types.h
@@ -31,8 +31,11 @@
 /** Internal macro to get value of an ODP handle */
 #define _odp_typeval(handle) ((uint32_t)(uintptr_t)(handle))
 
+/** Internal macro to get 64-bit value of an ODP handle */
+#define _odp_typeval64(handle) ((uint64_t)(uintptr_t)(handle))
+
 /** Internal macro to get printable value of an ODP handle */
-#define _odp_pri(handle) ((uint64_t)_odp_typeval(handle))
+#define _odp_pri(handle) _odp_typeval64(handle)
 
 /** Internal macro to convert a scalar to a typed handle */
 #define _odp_cast_scalar(type, val) ((type)(uintptr_t)(val))


### PR DESCRIPTION
Add the internal macro _odp_typeval64() to extract a full 64-bit value
from ODP handles and use this in the _odp_pri() internal macro used
by the various odp_xxx_to_u64() APIs to avoid truncation issues on
64-bit systems.

Signed-off-by: Bill Fischofer <bill.fischofer@linaro.org>