### PR TITLE
test: misc: use C++ I/O instead of C

### DIFF
--- a/test/miscellaneous/odp_api_from_cpp.cpp
+++ b/test/miscellaneous/odp_api_from_cpp.cpp
@@ -1,11 +1,11 @@
-#include <cstdio>
+#include <iostream>
 #include <odp_api.h>
 #include <odp/helper/odph_api.h>
 
 int main(int argc ODP_UNUSED, const char *argv[] ODP_UNUSED)
 {
-	printf("\tODP API version: %s\n", odp_version_api_str());
-	printf("\tODP implementation version: %s\n", odp_version_impl_str());
+	std::cout << "\tODP API version: " << odp_version_api_str() << std::endl;
+	std::cout << "\tODP implementation version: " << odp_version_impl_str() << std::endl;
 
 	return 0;
 }


### PR DESCRIPTION
To verify that this test is really compiled using C++ compiler use cout
instead of printf.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>