### PR TITLE
[PATCH v6] Select scheduler+queue in runtime, basing on environment

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -41,10 +41,14 @@ build:
     - if [ "${CC#clang}" != "${CC}" ] ; then export CXX="${CC/clang/clang++}"; fi
     - ./configure $CONF
     - make -j $(nproc)
-    - sudo env ODP_SHM_DIR=/dev/shm/odp ODP_TEST_OUT_XML=yes make check -k
-
-  on_success:
-    - ./scripts/shippable-post.sh
+    - sudo env ODP_SHM_DIR=/dev/shm/odp ODP_TEST_OUT_XML=yes ODP_SCHEDULER=basic make check
+    - ./scripts/shippable-post.sh basic
+    - sudo env ODP_SHM_DIR=/dev/shm/odp ODP_TEST_OUT_XML=yes ODP_SCHEDULER=sp make check
+    - ./scripts/shippable-post.sh sp
+    - sudo env ODP_SHM_DIR=/dev/shm/odp ODP_TEST_OUT_XML=yes ODP_SCHEDULER=iquery make check
+    - ./scripts/shippable-post.sh iquery
+    - sudo env ODP_SHM_DIR=/dev/shm/odp ODP_TEST_OUT_XML=yes ODP_SCHEDULER=scalable make check
+    - ./scripts/shippable-post.sh scalable
 
   on_failure:
     - ./scripts/shippable-post.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,6 @@ env:
         - CONF=""
         - CONF="--disable-abi-compat"
         - CONF="--enable-deprecated"
-        - CONF="--enable-schedule-sp"
-        - CONF="--enable-schedule-iquery"
-        - CONF="--enable-schedule-scalable"
         - CONF="--enable-dpdk-zero-copy"
         - CONF="--disable-static-applications"
         - CONF="--disable-host-optimization"
@@ -253,8 +250,16 @@ script:
           $CROSS $EXTRA_CONF $CONF
         - make -j $(nproc)
         - mkdir /dev/shm/odp
+        # Run all tests only for default configuration
         - if [ -z "$CROSS_ARCH" ] ; then
-          sudo LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check ;
+            if [ -n "$CONF" ] ; then
+              sudo LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check ;
+            else
+              sudo ODP_SCHEDULER=basic LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check ;
+              sudo ODP_SCHEDULER=sp LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check ;
+              sudo ODP_SCHEDULER=iquery LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check ;
+              sudo ODP_SCHEDULER=scalable LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check ;
+            fi
           fi
         - make install
 
@@ -293,7 +298,10 @@ jobs:
                             --enable-debug=full
                             --enable-helper-linux
                           - CCACHE_DISABLE=1 make -j $(nproc)
-                          - sudo CCACHE_DISABLE=1 LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" PATH=${PATH//:\.\/node_modules\/\.bin/} make check
+                          - sudo CCACHE_DISABLE=1 ODP_SCHEDULER=basic LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" make check
+                          - sudo CCACHE_DISABLE=1 ODP_SCHEDULER=sp LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" make check
+                          - sudo CCACHE_DISABLE=1 ODP_SCHEDULER=iquery LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" make check
+                          - sudo CCACHE_DISABLE=1 ODP_SCHEDULER=scalable LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" make check
                           - find . -type f -iname '*.[ch]' -not -path ".git/*" -execdir gcov {} \; ; bash <(curl -s https://codecov.io/bash) -X coveragepy
                 - stage: test
                   env: TEST=distcheck

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -172,13 +172,13 @@ __LIB__libodp_linux_la_SOURCES = \
 			   pktio/ring.c \
 			   odp_pkt_queue.c \
 			   odp_pool.c \
-			   odp_queue.c \
+			   odp_queue_basic.c \
 			   odp_queue_if.c \
 			   odp_queue_lf.c \
 			   odp_queue_scalable.c \
 			   odp_rwlock.c \
 			   odp_rwlock_recursive.c \
-			   odp_schedule.c \
+			   odp_schedule_basic.c \
 			   odp_schedule_if.c \
 			   odp_schedule_sp.c \
 			   odp_schedule_iquery.c \

--- a/platform/linux-generic/include/odp_internal.h
+++ b/platform/linux-generic/include/odp_internal.h
@@ -100,6 +100,9 @@ int odp_pool_init_local(void);
 int odp_pool_term_global(void);
 int odp_pool_term_local(void);
 
+int _odp_queue_init_global(void);
+int _odp_queue_term_global(void);
+
 int odp_pktio_init_global(void);
 int odp_pktio_term_global(void);
 int odp_pktio_init_local(void);

--- a/platform/linux-generic/include/odp_internal.h
+++ b/platform/linux-generic/include/odp_internal.h
@@ -103,6 +103,9 @@ int odp_pool_term_local(void);
 int _odp_queue_init_global(void);
 int _odp_queue_term_global(void);
 
+int _odp_schedule_init_global(void);
+int _odp_schedule_term_global(void);
+
 int odp_pktio_init_global(void);
 int odp_pktio_term_global(void);
 int odp_pktio_init_local(void);

--- a/platform/linux-generic/m4/odp_schedule.m4
+++ b/platform/linux-generic/m4/odp_schedule.m4
@@ -1,23 +1,6 @@
-AC_ARG_ENABLE([schedule-sp],
-    [  --enable-schedule-sp    enable strict priority scheduler],
-    [if test x$enableval = xyes; then
-	schedule_sp_enabled=yes
-	AC_DEFINE([ODP_SCHEDULE_SP], [1],
-		  [Define to 1 to enable strict priority scheduler])
-    fi])
-
-AC_ARG_ENABLE([schedule-iquery],
-    [  --enable-schedule-iquery    enable interests query (sparse bitmap) scheduler],
-    [if test x$enableval = xyes; then
-	schedule_iquery_enabled=yes
-	AC_DEFINE([ODP_SCHEDULE_IQUERY], [1],
-		  [Define to 1 to enable interests query scheduler])
-    fi])
-
-AC_ARG_ENABLE([schedule_scalable],
-    [  --enable-schedule-scalable   enable scalable scheduler],
-    [if test x$enableval = xyes; then
-	schedule_scalable_enabled=yes
-	AC_DEFINE([ODP_SCHEDULE_SCALABLE], [1],
-		  [Define to 1 to enable scalable scheduler])
-    fi])
+AC_ARG_ENABLE([scheduler-default],
+	      [AS_HELP_STRING([enable-scheduler-default],
+			      [Choose default scheduler (default is basic)])],
+	      [], [enable_scheduler_default=basic])
+AC_DEFINE_UNQUOTED([ODP_SCHEDULE_DEFAULT], ["$enable_scheduler_default"],
+		   [Define to name default scheduler])

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -96,7 +96,7 @@ int odp_init_global(odp_instance_t *instance,
 	}
 	stage = QUEUE_INIT;
 
-	if (sched_fn->init_global()) {
+	if (_odp_schedule_init_global()) {
 		ODP_ERR("ODP schedule init failed.\n");
 		goto init_failed;
 	}
@@ -231,7 +231,7 @@ int _odp_term_global(enum init_stage stage)
 		/* Fall through */
 
 	case SCHED_INIT:
-		if (sched_fn->term_global()) {
+		if (_odp_schedule_term_global()) {
 			ODP_ERR("ODP schedule term failed.\n");
 			rc = -1;
 		}

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -90,7 +90,7 @@ int odp_init_global(odp_instance_t *instance,
 	}
 	stage = POOL_INIT;
 
-	if (queue_fn->init_global()) {
+	if (_odp_queue_init_global()) {
 		ODP_ERR("ODP queue init failed.\n");
 		goto init_failed;
 	}
@@ -238,7 +238,7 @@ int _odp_term_global(enum init_stage stage)
 		/* Fall through */
 
 	case QUEUE_INIT:
-		if (queue_fn->term_global()) {
+		if (_odp_queue_term_global()) {
 			ODP_ERR("ODP queue term failed.\n");
 			rc = -1;
 		}

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -790,7 +790,7 @@ static odp_queue_t queue_to_ext(queue_t q_int)
 }
 
 /* API functions */
-queue_api_t queue_default_api = {
+queue_api_t queue_basic_api = {
 	.queue_create = queue_create,
 	.queue_destroy = queue_destroy,
 	.queue_lookup = queue_lookup,
@@ -812,7 +812,7 @@ queue_api_t queue_default_api = {
 };
 
 /* Functions towards internal components */
-queue_fn_t queue_default_fn = {
+queue_fn_t queue_basic_fn = {
 	.init_global = queue_init_global,
 	.term_global = queue_term_global,
 	.init_local = queue_init_local,

--- a/platform/linux-generic/odp_queue_if.c
+++ b/platform/linux-generic/odp_queue_if.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include <odp_queue_if.h>
+#include <odp_internal.h>
 
 extern const queue_api_t queue_scalable_api;
 extern const queue_fn_t queue_scalable_fn;
@@ -110,4 +111,14 @@ void odp_queue_param_init(odp_queue_param_t *param)
 int odp_queue_info(odp_queue_t queue, odp_queue_info_t *info)
 {
 	return queue_api->queue_info(queue, info);
+}
+
+int _odp_queue_init_global(void)
+{
+	return queue_fn->init_global();
+}
+
+int _odp_queue_term_global(void)
+{
+	return queue_fn->term_global();
 }

--- a/platform/linux-generic/odp_queue_if.c
+++ b/platform/linux-generic/odp_queue_if.c
@@ -12,15 +12,15 @@
 extern const queue_api_t queue_scalable_api;
 extern const queue_fn_t queue_scalable_fn;
 
-extern const queue_api_t queue_default_api;
-extern const queue_fn_t queue_default_fn;
+extern const queue_api_t queue_basic_api;
+extern const queue_fn_t queue_basic_fn;
 
 #ifdef ODP_SCHEDULE_SCALABLE
 const queue_api_t *queue_api = &queue_scalable_api;
 const queue_fn_t *queue_fn = &queue_scalable_fn;
 #else
-const queue_api_t *queue_api = &queue_default_api;
-const queue_fn_t *queue_fn = &queue_default_fn;
+const queue_api_t *queue_api = &queue_basic_api;
+const queue_fn_t *queue_fn = &queue_basic_fn;
 #endif
 
 odp_queue_t odp_queue_create(const char *name, const odp_queue_param_t *param)

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -1407,7 +1407,7 @@ static int schedule_num_grps(void)
 }
 
 /* Fill in scheduler interface */
-const schedule_fn_t schedule_default_fn = {
+const schedule_fn_t schedule_basic_fn = {
 	.status_sync = 0,
 	.pktio_start = schedule_pktio_start,
 	.thr_add = schedule_thr_add,
@@ -1429,7 +1429,7 @@ const schedule_fn_t schedule_default_fn = {
 };
 
 /* Fill in scheduler API calls */
-const schedule_api_t schedule_default_api = {
+const schedule_api_t schedule_basic_api = {
 	.schedule_wait_time       = schedule_wait_time,
 	.schedule                 = schedule,
 	.schedule_multi           = schedule_multi,

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include <odp_schedule_if.h>
+#include <odp_internal.h>
 
 extern const schedule_fn_t schedule_sp_fn;
 extern const schedule_api_t schedule_sp_api;
@@ -145,3 +146,12 @@ void odp_schedule_order_lock_wait(uint32_t lock_index)
 	sched_api->schedule_order_lock_wait(lock_index);
 }
 
+int _odp_schedule_init_global(void)
+{
+	return sched_fn->init_global();
+}
+
+int _odp_schedule_term_global(void)
+{
+	return sched_fn->term_global();
+}

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -12,8 +12,8 @@
 extern const schedule_fn_t schedule_sp_fn;
 extern const schedule_api_t schedule_sp_api;
 
-extern const schedule_fn_t schedule_default_fn;
-extern const schedule_api_t schedule_default_api;
+extern const schedule_fn_t schedule_basic_fn;
+extern const schedule_api_t schedule_basic_api;
 
 extern const schedule_fn_t schedule_iquery_fn;
 extern const schedule_api_t schedule_iquery_api;
@@ -31,8 +31,8 @@ const schedule_api_t *sched_api = &schedule_iquery_api;
 const schedule_fn_t  *sched_fn  = &schedule_scalable_fn;
 const schedule_api_t *sched_api = &schedule_scalable_api;
 #else
-const schedule_fn_t  *sched_fn  = &schedule_default_fn;
-const schedule_api_t *sched_api = &schedule_default_api;
+const schedule_fn_t  *sched_fn  = &schedule_basic_fn;
+const schedule_api_t *sched_api = &schedule_basic_api;
 #endif
 
 uint64_t odp_schedule_wait_time(uint64_t ns)

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -8,7 +8,7 @@ RUN sudo apt-get update && sudo apt-get install -yy \
   autoconf \
   automake \
   ccache \
-  clang-3.8 \
+  clang-4.0 \
   gcc-4.8 \
   graphviz \
   kmod \
@@ -24,5 +24,5 @@ RUN sudo apt-get update && sudo apt-get install -yy \
   xsltproc
 
 RUN sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 10
-RUN sudo ln -s /usr/bin/clang-3.8 /usr/bin/clang
-RUN sudo ln -s /usr/bin/clang++-3.8 /usr/bin/clang++
+RUN sudo ln -s /usr/bin/clang-4.0 /usr/bin/clang
+RUN sudo ln -s /usr/bin/clang++-4.0 /usr/bin/clang++

--- a/scripts/shippable-post.sh
+++ b/scripts/shippable-post.sh
@@ -2,8 +2,14 @@
 
 wget https://raw.githubusercontent.com/shawnliang/cunit-to-junit/master/cunit-to-junit.xsl
 
+mkdir -p "$SHIPPABLE_BUILD_DIR/shippable/testresults"
+
+SCHED=${1:-default}
+echo $SCHED
+
 for FILE in `find  ./test ./platform/ -name  "*.xml"`; do
 	bname="`basename $FILE`";
+	echo Processing $FILE as ${SCHED}-${bname}
 	xsltproc --novalid cunit-to-junit.xsl "$FILE" > \
-		"$SHIPPABLE_BUILD_DIR/shippable/testresults/${bname}"
+		"$SHIPPABLE_BUILD_DIR/shippable/testresults/${SCHED}-${bname}"
 done


### PR DESCRIPTION
This would allow us to drop compile-time option in favour of runtime configuration. We do compile all schedulers anyway, so it's a minor step to select them in runtime. This would allow us to do code coverage for non-default schedulers.