### PR TITLE
validation: shm: fix use of wrong name length define

### DIFF
--- a/test/validation/api/shmem/shmem.c
+++ b/test/validation/api/shmem/shmem.c
@@ -142,7 +142,7 @@ void shmem_test_basic(void)
 	for (i = 0; i < ODP_SHM_NAME_LEN; i++)
 		max_name[i] = 'A' + (i % 26);
 
-	max_name[ODP_QUEUE_NAME_LEN - 1] = 0;
+	max_name[ODP_SHM_NAME_LEN - 1] = 0;
 
 	/* NULL name */
 	shm = odp_shm_reserve(NULL,


### PR DESCRIPTION
Wrong name length define was used when setting terminating character for
shm name.

Signed-off-by: Matias Elo <matias.elo@nokia.com>