### PR TITLE
[PATCH v5] validation: timer: fix test failure

### DIFF
--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -282,15 +282,28 @@ static void handle_tmo(odp_event_t ev, bool stale, uint64_t prev_tick)
 		if (ttp && ttp->tick != TICK_INVALID)
 			CU_FAIL("Stale timeout for active timer");
 	} else {
-		if (!odp_timeout_fresh(tmo))
-			CU_FAIL("Wrong status (stale) for fresh timeout");
-		/* Fresh timeout => local timer must have matching tick */
-		if (ttp && ttp->tick != tick) {
-			LOG_DBG("Wrong tick: expected %" PRIu64
-				" actual %" PRIu64 "\n",
-				ttp->tick, tick);
-			CU_FAIL("odp_timeout_tick() wrong tick");
+		if (ttp && ttp->tick == TICK_INVALID) {
+			/* Timer was cancelled when it has already expired */
+
+			if (odp_timeout_fresh(tmo))
+				CU_FAIL("Wrong status (fresh) "
+					"for cancelled timeout");
+		} else {
+			if (!odp_timeout_fresh(tmo))
+				CU_FAIL("Wrong status (stale) "
+					"for fresh timeout");
+
+			/* Fresh timeout => local timer must have matching tick
+			 */
+			if (ttp && ttp->tick != tick) {
+				LOG_DBG("Wrong tick: expected %" PRIu64
+					" actual %" PRIu64 "\n",
+					ttp->tick, tick);
+				CU_FAIL("odp_timeout_tick() wrong tick");
+			}
 		}
+		if (ttp && ttp->ev != ODP_EVENT_INVALID)
+			CU_FAIL("Wrong state for fresh timer (event)");
 		/* Check that timeout was delivered 'timely' */
 		if (tick > odp_timer_current_tick(tp))
 			CU_FAIL("Timeout delivered early");
@@ -401,9 +414,11 @@ static int worker_entrypoint(void *arg TEST_UNUSED)
 		    (rand_r(&seed) % 2 == 0)) {
 			/* Timer active, cancel it */
 			rc = odp_timer_cancel(tt[i].tim, &tt[i].ev);
-			if (rc != 0)
+			if (rc != 0) {
 				/* Cancel failed, timer already expired */
 				ntoolate++;
+				LOG_DBG("Failed to cancel timer, probably already expired\n");
+			}
 			tt[i].tick = TICK_INVALID;
 			ncancel++;
 		} else {

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -386,7 +386,10 @@ static int worker_entrypoint(void *arg TEST_UNUSED)
 		      odp_timer_ns_to_tick(tp, (rand_r(&seed) % RANGE_MS)
 					       * 1000000ULL);
 		timer_rc = odp_timer_set_abs(tt[i].tim, tck, &tt[i].ev);
-		if (timer_rc != ODP_TIMER_SUCCESS) {
+		if (timer_rc == ODP_TIMER_TOOEARLY) {
+			LOG_ERR("Missed tick, setting timer\n");
+		} else if (timer_rc != ODP_TIMER_SUCCESS) {
+			LOG_ERR("Failed to set timer: %d\n", timer_rc);
 			CU_FAIL("Failed to set timer");
 		} else {
 			tt[i].tick = tck;


### PR DESCRIPTION
timer_main test was regularly failing due to worker code receiving
timeout events for cancelled timers. I'm fixing worker code to handle
these events correctly, however this might signify a loophole in API
definition or in linux-generic implementation. Shoud application be able
to copy with timers that are cancelled after expiration (but before
event reception)? Should implementation mark such timers as non-fresh?

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>
Fixes: https://bugs.linaro.org/show_bug.cgi?id=3517