### PR TITLE
[PATCH v1] validation: tm: auto skip test on Shippable in addition to Travis

### DIFF
--- a/test/validation/api/traffic_mngr/traffic_mngr.sh
+++ b/test/validation/api/traffic_mngr/traffic_mngr.sh
@@ -31,9 +31,7 @@ TEST_SKIPPED=77
 traffic_mngr_main${EXEEXT}
 ret=$?
 
-SIGSEGV=139
-
-if [ "${TRAVIS}" = "true" ] && [ $ret -ne 0 ] && [ $ret -ne ${SIGSEGV} ]; then
+if [ "${CI}" = "true" ] && [ $ret -eq 255 ]; then
 	echo "SKIP: skip due to not isolated environment"
 	exit ${TEST_SKIPPED}
 fi


### PR DESCRIPTION
Apply the same workaround as we have on Travis: retun 77 to mark the
test as skipped if we detect failure while running on top of CI.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>