### PR TITLE
[PATCH v2] shippable: disable perf-proc tests

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -5,8 +5,8 @@ compiler:
   - clang
 
 env:
-    - CONF="--disable-test-perf"
-    - CONF="--disable-abi-compat --disable-test-perf"
+    - CONF="--disable-test-perf --disable-test-perf-proc"
+    - CONF="--disable-abi-compat --disable-test-perf --disable-test-perf-proc"
     # - CONF="--enable-schedule-sp"
     # - CONF="--enable-schedule-iquery"
     # - CONF="--enable-dpdk-zero-copy"
@@ -18,7 +18,7 @@ env:
 matrix:
   allow_failures:
     - compiler: clang
-      env: CONF="--disable-abi-compat --disable-test-perf"
+      env: CONF="--disable-abi-compat --disable-test-perf --disable-test-perf-proc"
 
 build:
   pre_ci:


### PR DESCRIPTION
These tests have tendency of hanging up Shippable occasionally.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>