### PR TITLE
[PATCH v4] linux-gen: add runtime configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
                         - gcc
                         - clang-3.8
                         - automake autoconf libtool libssl-dev graphviz mscgen
+                        - libconfig-dev
                         - codespell
                         - libpcap-dev
                         - libnuma-dev
@@ -253,7 +254,7 @@ script:
         # Run all tests only for default configuration
         - if [ -z "$CROSS_ARCH" ] ; then
             if [ -n "$CONF" ] ; then
-              sudo LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check ;
+              sudo ODP_CONFIG_FILE="`pwd`/config/odp-linux-generic.conf" LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check ;
             else
               sudo ODP_SCHEDULER=basic LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check ;
               sudo ODP_SCHEDULER=sp LD_LIBRARY_PATH="$HOME/cunit-install/$CROSS_ARCH/lib:$LD_LIBRARY_PATH" ODP_SHM_DIR=/dev/shm/odp make check ;

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -19,7 +19,7 @@ Prerequisites for building the OpenDataPlane (ODP) API
 
 3. Required libraries
 
-   Libraries currently required to link: openssl, libatomic
+   Libraries currently required to link: openssl, libatomic, libconfig
 
 3.1 OpenSSL native compile
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ SUBDIRS = \
 
 @DX_RULES@
 
-EXTRA_DIST = bootstrap CHANGELOG config/README
+EXTRA_DIST = bootstrap CHANGELOG config/README config/odp-$(with_platform).conf
 
 distcheck-hook:
 	if test -n "$(DX_CLEANFILES)" ; \

--- a/config/README
+++ b/config/README
@@ -1,2 +1,12 @@
 ODP configuration options
 -------------------------
+
+Runtime configuration options can be passed to an ODP instance by
+setting ODP_CONFIG_FILE environment variable to point to a libconfig
+format configuration file. A template configuration file with default
+values is provided in config/odp-linux-generic.conf. The values set in
+config/odp-linux-generic.conf are hardcoded during configure/build
+phase. If ODP_CONFIG_FILE is not set at runtime, hardcoded default
+values are used instead of any configuration file. A configuration file
+passed using ODP_CONFIG_FILE doesn't have to include all available
+options. The missing options are replaced with hardcoded default values.

--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -1,0 +1,32 @@
+# ODP runtime configuration options
+#
+# This template configuration file (odp-linux-generic.conf) is hardcoded
+# during configure/build phase and the values defined here are used if
+# optional ODP_CONFIG_FILE is not set. This configuration file MUST
+# include all configuration options.
+#
+# ODP_CONFIG_FILE can be used to override default values and it doesn't
+# have to include all available options. The missing options are
+# replaced with hardcoded default values.
+#
+# The options defined here are implementation specific and valid option
+# values should be checked from the implementation code.
+#
+# See libconfig syntax: https://hyperrealm.github.io/libconfig/libconfig_manual.html#Configuration-Files
+
+# Mandatory fields
+odp_implementation = "linux-generic"
+config_file_version = "0.0.1"
+
+# DPDK pktio options
+pktio_dpdk: {
+	# Default options
+	num_rx_desc = 128
+	num_tx_desc = 512
+	rx_drop_en = 0
+
+	# Driver specific options (use PMD names from DPDK)
+	net_ixgbe: {
+		rx_drop_en = 1
+	}
+}

--- a/m4/odp_libconfig.m4
+++ b/m4/odp_libconfig.m4
@@ -1,0 +1,20 @@
+# ODP_LIBCONFIG
+# -------------
+AC_DEFUN([ODP_LIBCONFIG],
+[dnl
+##########################################################################
+# Check for libconfig availability
+##########################################################################
+PKG_CHECK_MODULES([LIBCONFIG], [libconfig])
+
+##########################################################################
+# Create a header file odp_libconfig_config.h which containins null
+# terminated hex dump of odp-linux.conf
+##########################################################################
+AC_CONFIG_COMMANDS([platform/${with_platform}/include/odp_libconfig_config.h],
+[mkdir -p platform/${with_platform}/include
+ (cd ${srcdir}/config ; xxd -i odp-${with_platform}.conf) | \
+   sed 's/\([[0-9a-f]]\)$/\0, 0x00/' > \
+   platform/${with_platform}/include/odp_libconfig_config.h],
+ [with_platform=$with_platform])
+]) # ODP_LIBCONFIG

--- a/platform/Makefile.inc
+++ b/platform/Makefile.inc
@@ -3,6 +3,9 @@ include $(top_srcdir)/Makefile.inc
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libodp-linux.pc
 
+configdir = $(sysconfdir)/odp
+config_DATA = $(top_srcdir)/config/odp-$(with_platform).conf
+
 VPATH = $(srcdir) $(builddir)
 lib_LTLIBRARIES = $(LIB)/libodp-linux.la
 

--- a/platform/linux-generic/.gitignore
+++ b/platform/linux-generic/.gitignore
@@ -1,1 +1,2 @@
 libodp-linux.pc
+odp_libconfig_config.h

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -5,6 +5,7 @@ include $(top_srcdir)/platform/Makefile.inc
 
 AM_CPPFLAGS  =  $(ODP_INCLUDES)
 AM_CPPFLAGS +=  -I$(top_srcdir)/platform/$(with_platform)/include
+AM_CPPFLAGS +=  -I$(top_builddir)/platform/$(with_platform)/include
 AM_CPPFLAGS +=  -I$(top_srcdir)/platform/$(with_platform)/arch
 AM_CPPFLAGS +=  -I$(top_srcdir)/platform/$(with_platform)/arch/@ARCH_DIR@
 AM_CPPFLAGS +=  -I$(top_srcdir)/platform/$(with_platform)/arch/default
@@ -12,6 +13,12 @@ AM_CPPFLAGS +=  -I$(top_srcdir)/platform/$(with_platform)/arch/default
 AM_CPPFLAGS +=  $(OPENSSL_CPPFLAGS)
 AM_CPPFLAGS +=  $(DPDK_CPPFLAGS)
 AM_CPPFLAGS +=  $(NETMAP_CPPFLAGS)
+
+AM_CFLAGS +=  $(LIBCONFIG_CFLAGS)
+
+DISTCLEANFILES = include/odp_libconfig_config.h
+include/odp_libconfig_config.h: $(top_srcdir)/config/odp-$(with_platform).conf $(top_builddir)/config.status
+	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@
 
 if !ODP_ABI_COMPAT
 odpapiplatincludedir= $(includedir)/odp/api/plat
@@ -94,6 +101,7 @@ noinst_HEADERS = \
 		  include/odp_forward_typedefs_internal.h \
 		  include/odp_internal.h \
 		  include/odp_ipsec_internal.h \
+		  include/odp_libconfig_internal.h \
 		  include/odp_llqueue.h \
 		  include/odp_macros_internal.h \
 		  include/odp_name_table_internal.h \
@@ -131,6 +139,9 @@ noinst_HEADERS = \
 		  include/protocols/thash.h \
 		  include/protocols/udp.h
 
+nodist_noinst_HEADERS = \
+		  include/odp_libconfig_config.h
+
 __LIB__libodp_linux_la_SOURCES = \
 			   _fdserver.c \
 			   _ishm.c \
@@ -154,6 +165,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_ipsec.c \
 			   odp_ipsec_events.c \
 			   odp_ipsec_sad.c \
+			   odp_libconfig.c \
 			   odp_name_table.c \
 			   odp_packet.c \
 			   odp_packet_flags.c \
@@ -287,6 +299,7 @@ endif
 
 __LIB__libodp_linux_la_LIBADD = $(ATOMIC_LIBS)
 __LIB__libodp_linux_la_LIBADD += $(OPENSSL_LIBS)
+__LIB__libodp_linux_la_LIBADD += $(LIBCONFIG_LIBS)
 __LIB__libodp_linux_la_LIBADD += $(DPDK_LIBS_LIBODP)
 __LIB__libodp_linux_la_LIBADD += $(PTHREAD_LIBS)
 __LIB__libodp_linux_la_LIBADD += $(TIMER_LIBS)

--- a/platform/linux-generic/include/odp_internal.h
+++ b/platform/linux-generic/include/odp_internal.h
@@ -23,6 +23,7 @@ extern "C" {
 #include <odp_errno_define.h>
 #include <stdio.h>
 #include <sys/types.h>
+#include <libconfig.h>
 
 #define MAX_CPU_NUMBER 128
 #define UID_MAXLEN 30
@@ -55,10 +56,14 @@ struct odp_global_data_s {
 	odp_cpumask_t control_cpus;
 	odp_cpumask_t worker_cpus;
 	int num_cpus_installed;
+	config_t libconfig_default;
+	config_t libconfig_runtime;
+
 };
 
 enum init_stage {
 	NO_INIT = 0,    /* No init stages completed */
+	LIBCONFIG_INIT,
 	CPUMASK_INIT,
 	TIME_INIT,
 	SYSINFO_INIT,

--- a/platform/linux-generic/include/odp_libconfig_internal.h
+++ b/platform/linux-generic/include/odp_libconfig_internal.h
@@ -1,0 +1,29 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+/**
+ * @file
+ *
+ * Common libconfig functions
+ */
+
+#ifndef ODP_LIBCONFIG_INTERNAL_H_
+#define ODP_LIBCONFIG_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int _odp_libconfig_init_global(void);
+int _odp_libconfig_term_global(void);
+
+int _odp_libconfig_lookup_int(const char *path, int *value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp_packet_dpdk.h
+++ b/platform/linux-generic/include/odp_packet_dpdk.h
@@ -21,8 +21,6 @@
 #define DPDK_NB_MBUF 16384
 #define DPDK_MBUF_BUF_SIZE RTE_MBUF_DEFAULT_BUF_SIZE
 #define DPDK_MEMPOOL_CACHE_SIZE 64
-#define DPDK_NM_RX_DESC  128
-#define DPDK_NM_TX_DESC  512
 
 ODP_STATIC_ASSERT((DPDK_NB_MBUF % DPDK_MEMPOOL_CACHE_SIZE == 0) &&
 		  (DPDK_MEMPOOL_CACHE_SIZE <= RTE_MEMPOOL_CACHE_MAX_SIZE) &&
@@ -32,6 +30,13 @@ ODP_STATIC_ASSERT((DPDK_NB_MBUF % DPDK_MEMPOOL_CACHE_SIZE == 0) &&
 
 /* Minimum RX burst size */
 #define DPDK_MIN_RX_BURST 4
+
+/** DPDK runtime configuration options */
+typedef struct {
+	int num_rx_desc;
+	int num_tx_desc;
+	int rx_drop_en;
+} dpdk_opt_t;
 
 /** Cache for storing packets */
 struct pkt_cache_t {
@@ -64,6 +69,7 @@ typedef struct ODP_ALIGNED_CACHE {
 	odp_ticketlock_t tx_lock[PKTIO_MAX_QUEUES];  /**< TX queue locks */
 	/** cache for storing extra RX packets */
 	pkt_cache_t rx_cache[PKTIO_MAX_QUEUES];
+	dpdk_opt_t opt;
 } pkt_dpdk_t;
 
 #endif

--- a/platform/linux-generic/libodp-linux.pc.in
+++ b/platform/linux-generic/libodp-linux.pc.in
@@ -6,6 +6,7 @@ includedir=@includedir@
 Name: libodp-linux
 Description: The ODP packet processing engine
 Version: @PKGCONFIG_VERSION@
+Requires.private: libconfig
 Libs: -L${libdir} -lodp-linux
 Libs.private: @OPENSSL_STATIC_LIBS@ @DPDK_LIBS@ @PCAP_LIBS@ @PTHREAD_LIBS@ @TIMER_LIBS@ -lpthread @ATOMIC_LIBS@
 Cflags: -I${includedir}

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -6,6 +6,7 @@ ODP_ATOMIC
 ODP_PTHREAD
 ODP_TIMER
 ODP_OPENSSL
+ODP_LIBCONFIG
 m4_include([platform/linux-generic/m4/odp_pcap.m4])
 m4_include([platform/linux-generic/m4/odp_netmap.m4])
 m4_include([platform/linux-generic/m4/odp_dpdk.m4])

--- a/platform/linux-generic/odp_libconfig.c
+++ b/platform/linux-generic/odp_libconfig.c
@@ -1,0 +1,99 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <libconfig.h>
+
+#include <odp/api/version.h>
+#include <odp_internal.h>
+#include <odp_debug_internal.h>
+#include <odp_libconfig_internal.h>
+#include <odp_libconfig_config.h>
+
+#define CONF_STR_NAME ((const char *)odp_linux_generic_conf)
+
+extern struct odp_global_data_s odp_global_data;
+
+int _odp_libconfig_init_global(void)
+{
+	const char *filename;
+	const char *vers;
+	const char *vers_rt;
+	const char *ipml;
+	const char *ipml_rt;
+	config_t *config = &odp_global_data.libconfig_default;
+	config_t *config_rt = &odp_global_data.libconfig_runtime;
+
+	config_init(config);
+	config_init(config_rt);
+
+	if (!config_read_string(config, CONF_STR_NAME)) {
+		ODP_ERR("Failed to read default config: %s(%d): %s\n",
+			config_error_file(config), config_error_line(config),
+			config_error_text(config));
+		goto fail;
+	}
+
+	filename = getenv("ODP_CONFIG_FILE");
+	if (filename == NULL)
+		return 0;
+
+	if (!config_read_file(config_rt, filename)) {
+		ODP_ERR("Failed to read config file: %s(%d): %s\n",
+			config_error_file(config_rt),
+			config_error_line(config_rt),
+			config_error_text(config_rt));
+		goto fail;
+	}
+
+	/* Check runtime configuration's implementation name and version */
+	if (!config_lookup_string(config, "odp_implementation", &ipml) ||
+	    !config_lookup_string(config_rt, "odp_implementation", &ipml_rt)) {
+		ODP_ERR("Configuration missing 'odp_implementation' field\n");
+		goto fail;
+	}
+	if (!config_lookup_string(config, "config_file_version", &vers) ||
+	    !config_lookup_string(config_rt, "config_file_version", &vers_rt)) {
+		ODP_ERR("Configuration missing 'config_file_version' field\n");
+		goto fail;
+	}
+	if (strcmp(vers, vers_rt) || strcmp(ipml, ipml_rt)) {
+		ODP_ERR("Runtime configuration mismatch\n");
+		goto fail;
+	}
+
+	return 0;
+fail:
+	config_destroy(config);
+	config_destroy(config_rt);
+	return -1;
+}
+
+int _odp_libconfig_term_global(void)
+{
+	config_destroy(&odp_global_data.libconfig_default);
+	config_destroy(&odp_global_data.libconfig_runtime);
+
+	return 0;
+}
+
+int _odp_libconfig_lookup_int(const char *path, int *value)
+{
+	int ret_def = CONFIG_FALSE;
+	int ret_rt = CONFIG_FALSE;
+
+	ret_def = config_lookup_int(&odp_global_data.libconfig_default, path,
+				    value);
+
+	/* Runtime option overrides default value */
+	ret_rt = config_lookup_int(&odp_global_data.libconfig_runtime, path,
+				   value);
+
+	return  (ret_def == CONFIG_TRUE || ret_rt == CONFIG_TRUE) ? 1 : 0;
+}

--- a/platform/linux-generic/test/ring/Makefile.am
+++ b/platform/linux-generic/test/ring/Makefile.am
@@ -16,6 +16,8 @@ PRELDADD += $(LIBCUNIT_COMMON)
 
 AM_CPPFLAGS += -I$(top_srcdir)/platform/linux-generic/include
 
+AM_CFLAGS += $(LIBCONFIG_CFLAGS)
+
 TESTNAME = linux-generic-ring
 
 TESTENV = tests-$(TESTNAME).env


### PR DESCRIPTION
Enables changing ODP runtime configuration options by using an optional
configuration file (libconfig). Path to the conf file is passed using
environment variable ODP_CONF_FILE. If ODP_CONF_FILE or a particular option
is not set, hardcoded default values are used instead. An template
configuration file is provided in config/odp-linux.conf.

Runtime configuration is initially used by DPDK pktio to set NIC options.

Adds new dependency to libconfig library.

V2:
- Replaced `printf()` calls (Bill)
- Use PKG_CHECK_MODULES and other build improvements (Dmitry)
- Hardcode config/odp-linux.conf contents into odp_libtool_config.h during config/build phase. This way default configuration options are always available.
- Libconfig configuration is only accessed using internal helper functions

V4:
- Further build fixes (Dmitry)
- Added mandatory 'odp_implementation' and 'config_file_version' fields to config template