### PR TITLE
[PATCH v1] checkpatch: update to the latest version

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -10,5 +10,10 @@
 --ignore=PREFER_SCANF
 --ignore=VOLATILE
 --ignore=AVOID_EXTERNS
+--ignore=CONST_STRUCT
+--ignore=PREFER_KERNEL_TYPES
+--ignore=CONSTANT_COMPARISON
+--ignore=BLOCK_COMMENT_STYLE
+--ignore=UNNECESSARY_PARENTHESES
 --codespell
 --codespellfile=/usr/share/codespell/dictionary.txt


### PR DESCRIPTION
Update checkpatch script to the latest version
(2d453e3b41c80d1a2c02b02d672f5dcd73f95a12). Ignores some new unnecessary
checks. PRIu8 and PRIu16 camel case warnings are also ignored.

Signed-off-by: Matias Elo <matias.elo@nokia.com>