### PR TITLE
[PATCH v1] build: make so numbering to be tied to ODP versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,18 +28,17 @@ AM_SILENT_RULES([yes])
 ##########################################################################
 # Set platform library version
 #
-# Follow version rules described here:
-# https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-# Version is Current:Revision:Age
-# 1. if there are only source changes, use C:R+1:A
-# 2. if interfaces were added use C+1:0:A+1
-# 3. if interfaces were removed, then use C+1:0:0
+# ODP does not promise backwards compatibility between releases, so we
+# just enforce major:minor:release as version number.
 ##########################################################################
 
-ODP_LIBSO_VERSION=118:0:0
+m4_define([odpso_version],
+    [odpapi_generation_version[]odpapi_major_version:odpapi_minor_version:odpapi_point_version])
+
+ODP_LIBSO_VERSION=odpso_version
 AC_SUBST(ODP_LIBSO_VERSION)
 
-ODPHELPER_LIBSO_VERSION=114:0:2
+ODPHELPER_LIBSO_VERSION=odpso_version
 AC_SUBST(ODPHELPER_LIBSO_VERSION)
 
 # Checks for programs.


### PR DESCRIPTION
We do not make any promises on ABI backwards compatibility, we have been
using -version-number instead of -version-info for ages, so affirm this
approach. Drop misleading comment and tie SO version numbers to ODP
relase numbers.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>