### PR TITLE
[PATCH v5] linux-gen: netmap: optimal ring configuration for VALE

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -31,6 +31,15 @@ pktio_dpdk: {
 	}
 }
 
+# netmap pktio options
+pktio_netmap: {
+	# Interface specific options
+	virt: {
+		nr_rx_slots = 0
+		nr_tx_slots = 0
+	}
+}
+
 queue_basic: {
 	# Maximum queue size. Value must be a power of two.
 	max_queue_size = 8192

--- a/platform/linux-generic/include/odp_packet_netmap.h
+++ b/platform/linux-generic/include/odp_packet_netmap.h
@@ -19,6 +19,12 @@
 
 #define NM_MAX_DESC 64
 
+/** netmap runtime configuration options */
+typedef struct {
+	int nr_rx_slots;
+	int nr_tx_slots;
+} netmap_opt_t;
+
 /** Ring for mapping pktin/pktout queues to netmap descriptors */
 struct netmap_ring_t {
 	unsigned first; /**< Index of first netmap descriptor */
@@ -61,6 +67,7 @@ typedef struct {
 	netmap_ring_t rx_desc_ring[PKTIO_MAX_QUEUES];
 	/** mapping of pktout queues to netmap tx descriptors */
 	netmap_ring_t tx_desc_ring[PKTIO_MAX_QUEUES];
+	netmap_opt_t opt;               /**< options */
 } pkt_netmap_t;
 
 #endif


### PR DESCRIPTION
Configure ring optimally for VALE. On my test laptop, this increases
odp_l2fwd performance from 1.9 MPPS to 2.3 MPPS, so it gives over 20%
more performance.

Signed-off-by: Juha-Matti Tilli <juha-matti.tilli@iki.fi>