### PR TITLE
[PATCH v2] validation: scheduler: fix test_wait_time failure

### DIFF
--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -175,10 +175,8 @@ static void scheduler_test_wait_time(void)
 
 	/* check time correctness */
 	start_time = odp_time_local();
-	for (i = 1; i < 6; i++) {
+	for (i = 1; i < 6; i++)
 		odp_schedule(&queue, wait_time);
-		printf("%d..", i);
-	}
 	end_time = odp_time_local();
 
 	diff = odp_time_diff(end_time, start_time);


### PR DESCRIPTION
Resolve Bug https://bugs.linaro.org/show_bug.cgi?id=3675, the
elapsed time measurement could be enlarged unpredictably by inner
printf calls and exceed the upper limit of tolerance.

Signed-off-by: Yi He <yi.he@linaro.org>
Reviewed-by: Ola Liljedahl <ola.liljedahl@arm.com>
Reviewed-by: Brian Brooks <brian.brooks@arm.com>