### PR TITLE
[PATCH v1] Queue and scheduler config file options

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -30,3 +30,8 @@ pktio_dpdk: {
 		rx_drop_en = 1
 	}
 }
+
+queue_basic: {
+	# Default queue size. Value must be a power of two.
+	default_queue_size = 4096
+}

--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -38,3 +38,12 @@ queue_basic: {
 	# Default queue size. Value must be a power of two.
 	default_queue_size = 4096
 }
+
+sched_basic: {
+	# Priority level spread. Each priority level is spread into multiple
+	# scheduler internal queues. A higher spread value typically improves
+	# parallelism and thus is better for high thread counts, but causes
+	# uneven service level for low thread counts. Typically, optimal
+	# value is the number of threads using the scheduler.
+	prio_spread = 4
+}

--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -32,6 +32,9 @@ pktio_dpdk: {
 }
 
 queue_basic: {
+	# Maximum queue size. Value must be a power of two.
+	max_queue_size = 8192
+
 	# Default queue size. Value must be a power of two.
 	default_queue_size = 4096
 }

--- a/platform/linux-generic/include/odp_queue_internal.h
+++ b/platform/linux-generic/include/odp_queue_internal.h
@@ -63,19 +63,17 @@ union queue_entry_u {
 	uint8_t pad[ROUNDUP_CACHE_LINE(sizeof(struct queue_entry_s))];
 };
 
-typedef struct ODP_ALIGNED_CACHE {
-	/* Storage space for ring data */
-	uint32_t data[CONFIG_QUEUE_SIZE];
-} queue_ring_data_t;
-
 typedef struct queue_global_t {
-	queue_entry_t     queue[ODP_CONFIG_QUEUES];
-	queue_ring_data_t ring_data[ODP_CONFIG_QUEUES];
-	uint32_t          queue_lf_num;
-	uint32_t          queue_lf_size;
-	queue_lf_func_t   queue_lf_func;
+	queue_entry_t   queue[ODP_CONFIG_QUEUES];
+	uint32_t        *ring_data;
+	uint32_t        queue_lf_num;
+	uint32_t        queue_lf_size;
+	queue_lf_func_t queue_lf_func;
+	odp_shm_t       queue_gbl_shm;
+	odp_shm_t       queue_ring_shm;
 
 	struct {
+		uint32_t max_queue_size;
 		uint32_t default_queue_size;
 	} config;
 

--- a/platform/linux-generic/include/odp_queue_internal.h
+++ b/platform/linux-generic/include/odp_queue_internal.h
@@ -75,6 +75,10 @@ typedef struct queue_global_t {
 	uint32_t          queue_lf_size;
 	queue_lf_func_t   queue_lf_func;
 
+	struct {
+		uint32_t default_queue_size;
+	} config;
+
 } queue_global_t;
 
 extern queue_global_t *queue_glb;

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -46,7 +46,7 @@ ODP_STATIC_ASSERT((ODP_SCHED_PRIO_NORMAL > 0) &&
 #define GRP_WEIGHT_TBL_SIZE NUM_SCHED_GRPS
 
 /* Maximum priority queue spread */
-#define MAX_SPREAD 4
+#define MAX_SPREAD 8
 
 /* Minimum priority queue spread */
 #define MIN_SPREAD 1


### PR DESCRIPTION
Added first queue and scheduler configuration options into the configuration file. Queue size and scheduler internal queue spreading can be configured. Spread configuration enables tuning scheduler for small thread counts. 