### PR TITLE
[PATCH v1] shippable: do not use huge pages

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -33,22 +33,20 @@ build:
     options:
 
   ci:
-    - echo 1000 | sudo tee /proc/sys/vm/nr_hugepages
-    - sudo mkdir -p /mnt/huge
-    - sudo mount -t hugetlbfs nodev /mnt/huge
-    - mkdir -p /dev/shm/odp
+    - mkdir -p $HOME/odp-shmdir
     - ./bootstrap
     - if [ "${CC#clang}" != "${CC}" ] ; then export CXX="${CC/clang/clang++}"; fi
     - ./configure $CONF
     - make -j $(nproc)
-    - sudo env CI=true ODP_SHM_DIR=/dev/shm/odp ODP_TEST_OUT_XML=yes ODP_SCHEDULER=basic make check
+    - sudo env CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes ODP_SCHEDULER=basic make check
     - ./scripts/shippable-post.sh basic
-    - sudo env CI=true ODP_SHM_DIR=/dev/shm/odp ODP_TEST_OUT_XML=yes ODP_SCHEDULER=sp make check
+    - sudo env CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes ODP_SCHEDULER=sp make check
     - ./scripts/shippable-post.sh sp
-    - sudo env CI=true ODP_SHM_DIR=/dev/shm/odp ODP_TEST_OUT_XML=yes ODP_SCHEDULER=iquery make check
+    - sudo env CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes ODP_SCHEDULER=iquery make check
     - ./scripts/shippable-post.sh iquery
-    - sudo env CI=true ODP_SHM_DIR=/dev/shm/odp ODP_TEST_OUT_XML=yes ODP_SCHEDULER=scalable make check
+    - sudo env CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes ODP_SCHEDULER=scalable make check
     - ./scripts/shippable-post.sh scalable
+    - rm -rf $HOME/odp-shmdir
 
   on_failure:
     - ./scripts/shippable-post.sh


### PR DESCRIPTION
huge pages under docker are trickly also /dev/shm/ is limited
to 64Mb. Use different folder for shared memory files.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>