### PR TITLE
[PATCH v6] WIP: work around on aarch64 runtime fails

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -34,18 +34,18 @@ build:
 
   ci:
     - mkdir -p $HOME/odp-shmdir
+    - export CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes
     - ./bootstrap
-    - if [ "${CC#clang}" != "${CC}" ] ; then export CXX="${CC/clang/clang++}"; fi
-    - if [ "${CC#clang}" != "${CC}" ] ; then export CFLAGS="-fPIC"; fi
+    - if [ "${CC}" == "clang" ] ; then export CXX=clang LD=clang CLFAGS="-fPIC"; fi
     - ./configure $CONF
     - make -j $(nproc)
-    - sudo env CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes ODP_SCHEDULER=basic make check
+    - sudo -E ODP_SCHEDULER=basic make check
     - ./scripts/shippable-post.sh basic
-    - sudo env CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes ODP_SCHEDULER=sp make check
+    - sudo -E ODP_SCHEDULER=sp make check
     - ./scripts/shippable-post.sh sp
-    - sudo env CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes ODP_SCHEDULER=iquery make check
+    - sudo -E ODP_SCHEDULER=iquery make check
     - ./scripts/shippable-post.sh iquery
-    - sudo env CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes ODP_SCHEDULER=scalable make check
+    - sudo -E ODP_SCHEDULER=scalable make check
     - ./scripts/shippable-post.sh scalable
     - rm -rf $HOME/odp-shmdir
 

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -36,7 +36,7 @@ build:
     - mkdir -p $HOME/odp-shmdir
     - export CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes
     - ./bootstrap
-    - if [ "${CC}" == "clang" ] ; then export CXX=clang LD=clang CLFAGS="-fPIC"; fi
+    - if [ "${CC}" == "clang" ] ; then export CXX=clang LD=clang CFLAGS="-fPIC"; fi
     - ./configure $CONF
     - make -j $(nproc)
     - sudo -E ODP_SCHEDULER=basic make check

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -36,7 +36,7 @@ build:
     - mkdir -p $HOME/odp-shmdir
     - export CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes
     - ./bootstrap
-    - if [ "${CC}" == "clang" ] ; then export CXX=clang LD=clang CFLAGS="-fPIC"; fi
+    - if [ "${CC}" == "clang" ] ; then export CXX=clang LD=clang; fi
     - ./configure $CONF
     - make -j $(nproc)
     - sudo -E ODP_SCHEDULER=basic make check

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -6,7 +6,7 @@ compiler:
 
 env:
     - CONF="--disable-test-perf --disable-test-perf-proc"
-    # - CONF="--disable-abi-compat --disable-test-perf --disable-test-perf-proc"
+    - CONF="--disable-abi-compat --disable-test-perf --disable-test-perf-proc"
     # - CONF="--enable-schedule-sp"
     # - CONF="--enable-schedule-iquery"
     # - CONF="--enable-dpdk-zero-copy"

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -36,6 +36,7 @@ build:
     - mkdir -p $HOME/odp-shmdir
     - ./bootstrap
     - if [ "${CC#clang}" != "${CC}" ] ; then export CXX="${CC/clang/clang++}"; fi
+    - if [ "${CC#clang}" != "${CC}" ] ; then export CFLAGS="-fPIC"; fi
     - ./configure $CONF
     - make -j $(nproc)
     - sudo env CI=true ODP_SHM_DIR=$HOME/odp-shmdir ODP_TEST_OUT_XML=yes ODP_SCHEDULER=basic make check

--- a/example/ipfragreass/odp_ipfragreass_atomics_arm.h
+++ b/example/ipfragreass/odp_ipfragreass_atomics_arm.h
@@ -9,7 +9,8 @@
 
 #include <example_debug.h>
 
-#if __SIZEOF_POINTER__ == 8 && defined(__aarch64__)
+/* todo fix clang hung bug on aarch64 */
+#if __SIZEOF_POINTER__ == 8 && defined(__aarch64_disable__)
 static inline __int128 lld(__int128 *var, int mo)
 {
 	__int128 old;

--- a/platform/linux-generic/arch/aarch64/odp_cpu.h
+++ b/platform/linux-generic/arch/aarch64/odp_cpu.h
@@ -20,7 +20,7 @@
  * LLD/SCD is on ARM the fastest way to enqueue and dequeue elements from a
  * linked list queue.
  */
-#define CONFIG_LLDSCD
+// #define CONFIG_LLDSCD
 
 /*
  * Use DMB;STR instead of STRL on ARM

--- a/platform/linux-generic/include/odp_bitset.h
+++ b/platform/linux-generic/include/odp_bitset.h
@@ -27,7 +27,12 @@
 /* Find a suitable data type that supports lock-free atomic operations */
 #if defined(__aarch64__) && defined(__SIZEOF_INT128__) && \
 	__SIZEOF_INT128__ == 16
-#define LOCKFREE16
+/* Todo: on thunder-x with gcc4.8 and gcc5 lockfree 16 code with -O0
+ * compiles to hung forever code. With -O2 everything works.
+ * Disable lock free function for now as temporary fix.
+ *
+ * #define LOCKFREE16
+ */
 typedef __int128 bitset_t;
 #define ATOM_BITSET_SIZE (CHAR_BIT * __SIZEOF_INT128__)
 


### PR DESCRIPTION
Quick workaround to make Shippable happy with calling tests on thunder-x. Some more clean patch is needed.