### PR TITLE
[PATCH v1] linux-gen: dpdk: bump supported dpdk version to v17.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ env:
         # for individual commit validation. But you you want to track tests history
         # you need generated new one at https://codecov.io specific for your repo.
         - CODECOV_TOKEN=a733c34c-5f5c-4ff1-af4b-e9f5edb1ab5e
-        - DPDK_VERS="17.08"
+        - DPDK_VERS="17.11"
     matrix:
         - CONF=""
         - CONF="--disable-abi-compat"
@@ -59,8 +59,6 @@ env:
         - CONF="--disable-host-optimization"
         - CONF="--disable-host-optimization --disable-abi-compat"
         - DPDK_SHARED="y" CONF="--disable-static-applications"
-        - DPDK_VERS="17.11" CONF=""
-        - DPDK_VERS="17.11" DPDK_SHARED="y" CONF="--disable-static-applications"
 
 compiler:
         - gcc
@@ -196,7 +194,7 @@ install:
            fi
            DPDK_TARGET="${DPDK_TARGET}gcc"
            if [ ! -f "dpdk/${TARGET}/usr/local/lib/libdpdk.$LIBDPDKEXT" ]; then
-            git -c advice.detachedHead=false clone -q --depth=1 --single-branch --branch=v${DPDK_VERS} http://dpdk.org/git/dpdk dpdk
+            git -c advice.detachedHead=false clone -q --depth=1 --single-branch --branch=${DPDK_VERS} http://dpdk.org/git/dpdk-stable dpdk
             pushd dpdk
             git log --oneline --decorate
             # AArch64 && ARMv7 fixup
@@ -207,6 +205,10 @@ install:
             make config T=${DPDK_TARGET} O=${TARGET}
             pushd ${TARGET}
             sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config
+            # OCTEON TX driver includes ARM v8.1 instructions
+            sed -ri 's,(CONFIG_RTE_LIBRTE_OCTEONTX_PMD=).*,\1n,' .config
+            sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OCTEONTX_SSOVF=).*,\1n,' .config
+            sed -ri 's,(CONFIG_RTE_LIBRTE_OCTEONTX_MEMPOOL=).*,\1n,' .config
             if test -n "${DPDK_MACHINE}" ; then
               sed -ri 's,(CONFIG_RTE_MACHINE=).*,\1"'${DPDK_MACHINE}'",' .config
             fi

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -174,7 +174,7 @@ Prerequisites for building the OpenDataPlane (ODP) API
 
 3.4.1 Building DPDK and ODP with DPDK pktio support
 
-   DPDK packet I/O has been tested to work with DPDK v17.08.
+   DPDK packet I/O has been tested to work with DPDK v17.11.
 
    Follow steps in ./scripts/build-pktio-dpdk
 

--- a/m4/odp_dpdk.m4
+++ b/m4/odp_dpdk.m4
@@ -9,6 +9,8 @@ cur_driver=`basename "$filename" .a | sed -e 's/^lib//'`
 AS_VAR_APPEND([DPDK_PMDS], [-l$cur_driver,])
 AS_CASE([$cur_driver],
     [rte_pmd_nfp], [AS_VAR_APPEND([DPDK_LIBS], [" -lm"])],
+    [rte_pmd_mlx4], [AS_VAR_APPEND([DPDK_LIBS], [" -lmlx4 -libverbs"])],
+    [rte_pmd_mlx5], [AS_VAR_APPEND([DPDK_LIBS], [" -lmlx5 -libverbs"])],
     [rte_pmd_pcap], [AS_VAR_APPEND([DPDK_LIBS], [" -lpcap"])],
     [rte_pmd_openssl], [AS_VAR_APPEND([DPDK_LIBS], [" -lcrypto"])])
 done

--- a/scripts/build-pktio-dpdk
+++ b/scripts/build-pktio-dpdk
@@ -16,7 +16,7 @@ if [ "$?" != "0" ]; then
 	exit 1
 fi
 
-git -c advice.detachedHead=false clone -q --depth=1 --single-branch --branch=v17.08 http://dpdk.org/git/dpdk dpdk
+git -c advice.detachedHead=false clone -q --depth=1 --single-branch --branch=17.11 http://dpdk.org/git/dpdk-stable dpdk
 pushd dpdk
 git log --oneline --decorate
 


### PR DESCRIPTION
Bump supported DPDK version to LTS version 17.11. Also adds dependecies for
optional Mellanox PMD drivers.

Signed-off-by: Matias Elo <matias.elo@nokia.com>