### PR TITLE
[PATCH v1] shippable: disable abi compat mode tests on aarch64

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -6,7 +6,7 @@ compiler:
 
 env:
     - CONF="--disable-test-perf --disable-test-perf-proc"
-    - CONF="--disable-abi-compat --disable-test-perf --disable-test-perf-proc"
+    # - CONF="--disable-abi-compat --disable-test-perf --disable-test-perf-proc"
     # - CONF="--enable-schedule-sp"
     # - CONF="--enable-schedule-iquery"
     # - CONF="--enable-dpdk-zero-copy"


### PR DESCRIPTION
disable tests which fails under our docker runs with
native clang 4.8

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>