### PR TITLE
[PATCH v1] shippable: reenable non-ABI-compat build for GCC

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -6,7 +6,7 @@ compiler:
 
 env:
     - CONF="--disable-test-perf --disable-test-perf-proc"
-    # - CONF="--disable-abi-compat --disable-test-perf --disable-test-perf-proc"
+    - CONF="--disable-abi-compat --disable-test-perf --disable-test-perf-proc"
     # - CONF="--enable-schedule-sp"
     # - CONF="--enable-schedule-iquery"
     # - CONF="--enable-dpdk-zero-copy"
@@ -16,7 +16,7 @@ env:
     # - CROSS_ARCH="i386"
 
 matrix:
-  allow_failures:
+  exclude:
     - compiler: clang
       env: CONF="--disable-abi-compat --disable-test-perf --disable-test-perf-proc"
 


### PR DESCRIPTION
Non-ABI-compat build is broken only for Clang, so disable it only for
that compiler, rather than disabling it completely.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>