### PR TITLE
[PATCH v3] build: don't use xxd to hexdump config file

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -21,8 +21,6 @@ Prerequisites for building the OpenDataPlane (ODP) API
 
    Libraries currently required to link: openssl, libatomic, libconfig
 
-   Required tools: xxd
-
 3.1 OpenSSL native compile
 
    For native compilation, simply load the necessary libraries using the appropriate

--- a/platform/linux-generic/odp_libconfig.c
+++ b/platform/linux-generic/odp_libconfig.c
@@ -16,8 +16,6 @@
 #include <odp_libconfig_internal.h>
 #include <odp_libconfig_config.h>
 
-#define CONF_STR_NAME ((const char *)odp_linux_generic_conf)
-
 extern struct odp_global_data_s odp_global_data;
 
 int _odp_libconfig_init_global(void)
@@ -33,7 +31,7 @@ int _odp_libconfig_init_global(void)
 	config_init(config);
 	config_init(config_rt);
 
-	if (!config_read_string(config, CONF_STR_NAME)) {
+	if (!config_read_string(config, config_builtin)) {
 		ODP_ERR("Failed to read default config: %s(%d): %s\n",
 			config_error_file(config), config_error_line(config),
 			config_error_text(config));


### PR DESCRIPTION
Use standard od and sed programs to hexdump config file, removing
dependency on xxd.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>