### PR TITLE
linux-gen: dpdk: fix runtime config read order

### DIFF
--- a/platform/linux-generic/include/odp_libconfig_internal.h
+++ b/platform/linux-generic/include/odp_libconfig_internal.h
@@ -17,6 +17,12 @@
 extern "C" {
 #endif
 
+enum libconfig_opt_type {
+	LIBCONFIG_OPT_NOT_FOUND = 0,
+	LIBCONFIG_OPT_DEFAULT,
+	LIBCONFIG_OPT_RUNTIME
+};
+
 int _odp_libconfig_init_global(void);
 int _odp_libconfig_term_global(void);
 

--- a/platform/linux-generic/odp_libconfig.c
+++ b/platform/linux-generic/odp_libconfig.c
@@ -85,15 +85,17 @@ int _odp_libconfig_term_global(void)
 
 int _odp_libconfig_lookup_int(const char *path, int *value)
 {
-	int ret_def = CONFIG_FALSE;
-	int ret_rt = CONFIG_FALSE;
+	int ret;
 
-	ret_def = config_lookup_int(&odp_global_data.libconfig_default, path,
-				    value);
+	ret = config_lookup_int(&odp_global_data.libconfig_runtime, path,
+				value);
+	if (ret == CONFIG_TRUE)
+		return LIBCONFIG_OPT_RUNTIME;
 
-	/* Runtime option overrides default value */
-	ret_rt = config_lookup_int(&odp_global_data.libconfig_runtime, path,
-				   value);
+	ret = config_lookup_int(&odp_global_data.libconfig_default, path,
+				value);
+	if (ret == CONFIG_TRUE)
+		return LIBCONFIG_OPT_DEFAULT;
 
-	return  (ret_def == CONFIG_TRUE || ret_rt == CONFIG_TRUE) ? 1 : 0;
+	return LIBCONFIG_OPT_NOT_FOUND;
 }

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -98,19 +98,36 @@ static int lookup_opt(const char *path, const char *drv_name, int *val)
 {
 	const char *base = "pktio_dpdk";
 	char opt_path[256];
-	int ret = 0;
+	int drv_ret = 0;
+	int def_ret = 0;
+	int drv_val = 0;
+	int def_val = 0;
+
+	/* Driver specific option */
+	snprintf(opt_path, sizeof(opt_path), "%s.%s.%s", base, drv_name, path);
+	drv_ret = _odp_libconfig_lookup_int(opt_path, &drv_val);
+	if (drv_ret == LIBCONFIG_OPT_RUNTIME) {
+		*val = drv_val;
+		return 1;
+	}
 
 	/* Default option */
 	snprintf(opt_path, sizeof(opt_path), "%s.%s", base, path);
-	ret += _odp_libconfig_lookup_int(opt_path, val);
+	def_ret = _odp_libconfig_lookup_int(opt_path, &def_val);
+	if (def_ret == LIBCONFIG_OPT_RUNTIME) {
+		*val = def_val;
+		return 1;
+	}
 
-	/* Driver specific option overrides default option */
-	snprintf(opt_path, sizeof(opt_path), "%s.%s.%s", base, drv_name, path);
-	ret += _odp_libconfig_lookup_int(opt_path, val);
+	if (drv_ret == LIBCONFIG_OPT_DEFAULT) {
+		*val = drv_val;
+		return 1;
+	} else if (def_ret == LIBCONFIG_OPT_DEFAULT) {
+		*val = def_val;
+		return 1;
+	}
 
-	if (ret == 0)
-		ODP_ERR("Unable to find DPDK configuration option: %s\n", path);
-	return ret;
+	return 0;
 }
 
 static int init_options(pktio_entry_t *pktio_entry,


### PR DESCRIPTION
If used runtime configuration is missing driver specific options, use top
level dpdk pktio options, not the hard coded driver specific options.

Internal _odp_libconfig_lookup_int() function changed to return the found
option type (not found/default/runtime).

Signed-off-by: Matias Elo <matias.elo@nokia.com>