### PR TITLE
[PATCH v1] build: fix autoconf error caused by double-registering config item

### DIFF
--- a/m4/odp_libconfig.m4
+++ b/m4/odp_libconfig.m4
@@ -1,5 +1,5 @@
-# ODP_LIBCONFIG
-# -------------
+# ODP_LIBCONFIG(PLATFORM)
+# -----------------------
 AC_DEFUN([ODP_LIBCONFIG],
 [dnl
 ##########################################################################
@@ -19,10 +19,10 @@ fi
 # Create a header file odp_libconfig_config.h which containins null
 # terminated hex dump of odp-linux.conf
 ##########################################################################
-AC_CONFIG_COMMANDS([platform/${with_platform}/include/odp_libconfig_config.h],
-[mkdir -p platform/${with_platform}/include
- (cd ${srcdir}/config ; xxd -i odp-${with_platform}.conf) | \
+AC_CONFIG_COMMANDS([platform/$1/include/odp_libconfig_config.h],
+[mkdir -p platform/$1/include
+ (cd ${srcdir}/config ; xxd -i odp-$1.conf) | \
    sed 's/\([[0-9a-f]]\)$/\0, 0x00/' > \
-   platform/${with_platform}/include/odp_libconfig_config.h],
+   platform/$1/include/odp_libconfig_config.h],
  [with_platform=$with_platform])
 ]) # ODP_LIBCONFIG

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -6,7 +6,7 @@ ODP_ATOMIC
 ODP_PTHREAD
 ODP_TIMER
 ODP_OPENSSL
-ODP_LIBCONFIG
+ODP_LIBCONFIG([linux-generic])
 m4_include([platform/linux-generic/m4/odp_pcap.m4])
 m4_include([platform/linux-generic/m4/odp_netmap.m4])
 m4_include([platform/linux-generic/m4/odp_dpdk.m4])


### PR DESCRIPTION
Autoconf uses provided tag as is, when registering config command.
Require platform code to pass platform argument, so that different
config commands will be registered.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>