### PR TITLE
[PATCH v1] linux-gen: dpdk: fix runtime/default config read order

### DIFF
--- a/platform/linux-generic/include/odp_libconfig_internal.h
+++ b/platform/linux-generic/include/odp_libconfig_internal.h
@@ -22,6 +22,11 @@ int _odp_libconfig_term_global(void);
 
 int _odp_libconfig_lookup_int(const char *path, int *value);
 
+int _odp_libconfig_lookup_ext_int(const char *base_path,
+				  const char *local_path,
+				  const char *name,
+				  int *value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/odp_libconfig.c
+++ b/platform/linux-generic/odp_libconfig.c
@@ -97,3 +97,41 @@ int _odp_libconfig_lookup_int(const char *path, int *value)
 
 	return  (ret_def == CONFIG_TRUE || ret_rt == CONFIG_TRUE) ? 1 : 0;
 }
+
+static int lookup_int(config_t *cfg,
+		      const char *base_path,
+		      const char *local_path,
+		      const char *name,
+		      int *value)
+{
+	char path[256];
+
+	if (local_path) {
+		snprintf(path, sizeof(path), "%s.%s.%s", base_path,
+			 local_path, name);
+		if (config_lookup_int(cfg, path, value) == CONFIG_TRUE)
+			return 1;
+	}
+
+	snprintf(path, sizeof(path), "%s.%s", base_path, name);
+	if (config_lookup_int(cfg, path, value) == CONFIG_TRUE)
+		return 1;
+
+	return 0;
+}
+
+int _odp_libconfig_lookup_ext_int(const char *base_path,
+				  const char *local_path,
+				  const char *name,
+				  int *value)
+{
+	if (lookup_int(&odp_global_data.libconfig_runtime,
+		       base_path, local_path, name, value))
+		return 1;
+
+	if (lookup_int(&odp_global_data.libconfig_default,
+		       base_path, local_path, name, value))
+		return 1;
+
+	return 0;
+}

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -94,22 +94,16 @@ void refer_constructors(void)
 }
 #endif
 
-static int lookup_opt(const char *path, const char *drv_name, int *val)
+static int lookup_opt(const char *opt_name, const char *drv_name, int *val)
 {
 	const char *base = "pktio_dpdk";
-	char opt_path[256];
-	int ret = 0;
+	int ret;
 
-	/* Default option */
-	snprintf(opt_path, sizeof(opt_path), "%s.%s", base, path);
-	ret += _odp_libconfig_lookup_int(opt_path, val);
-
-	/* Driver specific option overrides default option */
-	snprintf(opt_path, sizeof(opt_path), "%s.%s.%s", base, drv_name, path);
-	ret += _odp_libconfig_lookup_int(opt_path, val);
-
+	ret = _odp_libconfig_lookup_ext_int(base, drv_name, opt_name, val);
 	if (ret == 0)
-		ODP_ERR("Unable to find DPDK configuration option: %s\n", path);
+		ODP_ERR("Unable to find DPDK configuration option: %s\n",
+			opt_name);
+
 	return ret;
 }
 


### PR DESCRIPTION
If used runtime configuration is missing driver specific options, use top
level dpdk pktio options, not the hard coded driver specific options.