### PR TITLE
[PATCH v1] fdserver: change session ID after fork

### DIFF
--- a/platform/linux-generic/odp_fdserver.c
+++ b/platform/linux-generic/odp_fdserver.c
@@ -654,6 +654,12 @@ int _odp_fdserver_init_global(void)
 		/* orphans being "adopted" by the init process...	*/
 		prctl(PR_SET_PDEATHSIG, SIGTERM);
 
+		res = setsid();
+		if (res == -1) {
+			ODP_ERR("Could not setsid()");
+			exit(1);
+		}
+
 		/* allocate the space for the file descriptor<->key table: */
 		fd_table = malloc(FDSERVER_MAX_ENTRIES * sizeof(fdentry_t));
 		if (!fd_table) {


### PR DESCRIPTION
This is to avoid the fdserver process from handling signals sent to the
process group.
This patch partly fixes: https://bugs.linaro.org/show_bug.cgi?id=3690

Signed-off-by: Josep Puigdemont <josep.puigdemont@linaro.org>