### PR TITLE
[PATCH v1] configure.ac: update version to v1.19.0.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,9 +3,9 @@ AC_PREREQ([2.5])
 # Set correct API version
 ##########################################################################
 m4_define([odpapi_generation_version], [1])
-m4_define([odpapi_major_version], [18])
+m4_define([odpapi_major_version], [19])
 m4_define([odpapi_minor_version], [0])
-m4_define([odpapi_point_version], [1])
+m4_define([odpapi_point_version], [0])
 m4_define([odpapi_version],
     [odpapi_generation_version.odpapi_major_version.odpapi_minor_version.odpapi_point_version])
 AC_INIT([OpenDataPlane],[odpapi_version],[lng-odp@lists.linaro.org])


### PR DESCRIPTION
as we discussed we have change in api and there we increase api version. No api function just, just text clarificaion. But because of text can be understood in diferent way with new note and without it api version change has to be increased. So this is 1.19.0.0

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>