### PR TITLE
[PATCH v1] linux-generic: random: split from crypto module

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -175,6 +175,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_queue_if.c \
 			   odp_queue_lf.c \
 			   odp_queue_scalable.c \
+			   odp_random.c \
 			   odp_rwlock.c \
 			   odp_rwlock_recursive.c \
 			   odp_schedule_basic.c \

--- a/platform/linux-generic/odp_crypto.c
+++ b/platform/linux-generic/odp_crypto.c
@@ -23,7 +23,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <openssl/rand.h>
 #include <openssl/hmac.h>
 #include <openssl/cmac.h>
 #include <openssl/evp.h>
@@ -1952,47 +1951,6 @@ int _odp_crypto_term_local(void)
 	}
 
 	return 0;
-}
-
-odp_random_kind_t odp_random_max_kind(void)
-{
-	return ODP_RANDOM_CRYPTO;
-}
-
-int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
-{
-	int rc;
-
-	switch (kind) {
-	case ODP_RANDOM_BASIC:
-	case ODP_RANDOM_CRYPTO:
-		rc = RAND_bytes(buf, len);
-		return (1 == rc) ? (int)len /*success*/: -1 /*failure*/;
-
-	case ODP_RANDOM_TRUE:
-	default:
-		return -1;
-	}
-}
-
-int32_t odp_random_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
-{
-	union {
-		uint32_t rand_word;
-		uint8_t rand_byte[4];
-	} u;
-	uint32_t i = 0, j;
-	uint32_t seed32 = (*seed) & 0xffffffff;
-
-	while (i < len) {
-		u.rand_word = rand_r(&seed32);
-
-		for (j = 0; j < 4 && i < len; j++, i++)
-			*buf++ = u.rand_byte[j];
-	}
-
-	*seed = seed32;
-	return len;
 }
 
 odp_crypto_compl_t odp_crypto_compl_from_event(odp_event_t ev)

--- a/platform/linux-generic/odp_random.c
+++ b/platform/linux-generic/odp_random.c
@@ -1,0 +1,54 @@
+/* Copyright (c) 2014-2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include <odp_posix_extensions.h>
+#include <odp_internal.h>
+#include <odp/api/random.h>
+
+#include <openssl/rand.h>
+
+odp_random_kind_t odp_random_max_kind(void)
+{
+	return ODP_RANDOM_CRYPTO;
+}
+
+int32_t odp_random_data(uint8_t *buf, uint32_t len, odp_random_kind_t kind)
+{
+	int rc;
+
+	switch (kind) {
+	case ODP_RANDOM_BASIC:
+	case ODP_RANDOM_CRYPTO:
+		rc = RAND_bytes(buf, len);
+		return (1 == rc) ? (int)len /*success*/: -1 /*failure*/;
+
+	case ODP_RANDOM_TRUE:
+	default:
+		return -1;
+	}
+}
+
+int32_t odp_random_test_data(uint8_t *buf, uint32_t len, uint64_t *seed)
+{
+	union {
+		uint32_t rand_word;
+		uint8_t rand_byte[4];
+	} u;
+	uint32_t i = 0, j;
+	uint32_t seed32 = (*seed) & 0xffffffff;
+
+	while (i < len) {
+		u.rand_word = rand_r(&seed32);
+
+		for (j = 0; j < 4 && i < len; j++, i++)
+			*buf++ = u.rand_byte[j];
+	}
+
+	*seed = seed32;
+	return len;
+}


### PR DESCRIPTION
While random and crypto might share some implementation details, in case
of linux-generic and linux-DPDK it might be easier to split them to two
different files.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>