### PR TITLE
[PATCH v1] linux-gen: dpdk: fix linking to libnuma

### DIFF
--- a/platform/linux-generic/m4/odp_dpdk.m4
+++ b/platform/linux-generic/m4/odp_dpdk.m4
@@ -40,6 +40,14 @@ then
       ;;
     esac
 
+    OLD_LIBS=$LIBS
+    LIBS="-lnuma"
+    AC_TRY_LINK_FUNC([numa_num_configured_nodes],
+		     [AC_DEFINE([HAVE_NUMA_LIBRARY], [1],
+				[Define to 1 if numa library is usable])
+		     AS_VAR_APPEND([DPDK_LIBS_LIBODP], [" -lnuma"])])
+    LIBS=$OLD_LIBS
+
     AC_DEFINE([ODP_PKTIO_DPDK], [1],
 	      [Define to 1 to enable DPDK packet I/O support])
     AC_DEFINE_UNQUOTED([ODP_DPDK_ZERO_COPY], [$zero_copy],

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -50,7 +50,7 @@
 #include <rte_version.h>
 
 /* NUMA is not supported on all platforms */
-#ifdef RTE_EAL_NUMA_AWARE_HUGEPAGES
+#ifdef HAVE_NUMA_LIBRARY
 #include <numa.h>
 #else
 #define numa_num_configured_nodes() 1


### PR DESCRIPTION
Linking to dpdk/numa can fail with the following message:
/usr/bin/x86_64-linux-gnu-ld: lib/.libs/libodp-linux.a(dpdk.o): undefined reference to symbol 'numa_num_configured_nodes@@libnuma_1.2'
//usr/lib/x86_64-linux-gnu/libnuma.so.1: error adding symbols: DSO missing from command line

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>