### PR TITLE
linux-gen: ipsec: parse IPv6 next header in tunnel case

### DIFF
--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -844,6 +844,7 @@ static int ipsec_out_tunnel_parse_ipv6(ipsec_state_t *state,
 	state->out_tunnel.ip_flabel = (ipv6hdr->ver_tc_flow &
 				       _ODP_IPV6HDR_FLOW_LABEL_MASK) >>
 		_ODP_IPV6HDR_FLOW_LABEL_SHIFT;
+	state->ip_next_hdr = ipv6hdr->next_hdr;
 
 	return 0;
 }


### PR DESCRIPTION
IPsec parsing code will fail to update next header field in internal
state in case of outbound tunnel processing of IPv6 packets.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>
Fixes: https://bugs.linaro.org/show_bug.cgi?id=3764