### PR TITLE
[PATCH v1] doc: allow user to provide exta asciidoctor flags

### DIFF
--- a/doc/Makefile.inc
+++ b/doc/Makefile.inc
@@ -13,4 +13,5 @@ SUFFIXES = .svg .msc .gv .html .adoc
 .adoc.html:
 	asciidoctor $(ASCIIDOC_FLAGS) --out-file=$@ $<
 
-ASCIIDOC_FLAGS =-a data-uri -b html5 -a icons=font -a toc2
+ASCIIDOC_FLAGS =-a data-uri -b html5 -a icons=font -a toc2 \
+	$(EXTRA_ASCIIDOC_FLAGS)


### PR DESCRIPTION
Allow user to provide extra asciidoctor flags. E.g. this allows one to
override icons and/or fonts placement.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>