### PR TITLE
[PATCH v1] linux-gen: packet: rearrange odp_packet_hdr_t members

### DIFF
--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -96,6 +96,9 @@ typedef struct {
 	 * Members below are not initialized by packet_init()
 	 */
 
+	/* Type of extra data */
+	uint8_t extra_type;
+
 	/* Flow hash value */
 	uint32_t flow_hash;
 
@@ -108,16 +111,14 @@ typedef struct {
 	/* Result for crypto packet op */
 	odp_crypto_packet_result_t crypto_op_result;
 
-#ifdef ODP_PKTIO_DPDK
-	/* Type of extra data */
-	uint8_t extra_type;
-	/* Extra space for packet descriptors. E.g. DPDK mbuf  */
-	uint8_t ODP_ALIGNED_CACHE extra[PKT_EXTRA_LEN];
-#endif
-
 	/* Context for IPsec */
 	odp_ipsec_packet_result_t ipsec_ctx;
 
+#ifdef ODP_PKTIO_DPDK
+	/* Extra space for packet descriptors. E.g. DPDK mbuf. Keep as the last
+	 * member before data. */
+	uint8_t ODP_ALIGNED_CACHE extra[PKT_EXTRA_LEN];
+#endif
 	/* Packet data storage */
 	uint8_t data[0];
 } odp_packet_hdr_t;


### PR DESCRIPTION
Save 64 bytes by rearranging odp_packet_hdr_t members.

Signed-off-by: Matias Elo <matias.elo@nokia.com>