### PR TITLE
[PATCH v2] linux-gen: fix compilation warnings

### DIFF
--- a/platform/linux-generic/odp_fdserver.c
+++ b/platform/linux-generic/odp_fdserver.c
@@ -588,7 +588,9 @@ int _odp_fdserver_init_global(void)
 
 	/* bind to new named socket: */
 	local.sun_family = AF_UNIX;
-	strncpy(local.sun_path, sockpath, sizeof(local.sun_path));
+	memcpy(local.sun_path, sockpath, sizeof(local.sun_path));
+	local.sun_path[sizeof(local.sun_path) - 1] = '\0';
+
 	res = bind(sock, (struct sockaddr *)&local, sizeof(struct sockaddr_un));
 	if (res == -1) {
 		ODP_ERR("_odp_fdserver_init_global: %s\n", strerror(errno));

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -475,8 +475,7 @@ static int create_file(int block_index, huge_flag_t huge, uint64_t len,
 	 * external ref:
 	 */
 	if (flags & _ODP_ISHM_EXPORT) {
-		strncpy(new_block->filename, filename,
-			ISHM_FILENAME_MAXLEN - 1);
+		memcpy(new_block->filename, filename, ISHM_FILENAME_MAXLEN);
 		snprintf(new_block->exptname, ISHM_FILENAME_MAXLEN,
 			 ISHM_EXPTNAME_FORMAT,
 			 odp_global_data.shm_dir,


### PR DESCRIPTION
gcc 8 complains when strncpy may truncate the destination string,
possibly not copying the null terminating character.

This solves these two compilation warnings:
odp_fdserver.c:591:2: error: ‘strncpy’ output may be truncated
  copying 108 bytes from a string of length 254 [-Werror=stringop-truncation]
odp_ishm.c:478:3: error: ‘strncpy’ output may be truncated
  copying 191 bytes from a string of length 191 [-Werror=stringop-truncation]

Signed-off-by: Josep Puigdemont <josep.puigdemont@linaro.org>