### PR TITLE
[PATCH v1] helper: thread: don't use getopt library

### DIFF
--- a/example/classifier/odp_classifier.c
+++ b/example/classifier/odp_classifier.c
@@ -805,9 +805,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	static const char *shortopts = "+c:t:i:p:m:t:h";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
-
-	opterr = 0; /* do not issue errors on helper options */
+	argc = odph_parse_options(argc, argv);
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts,

--- a/example/generator/odp_generator.c
+++ b/example/generator/odp_generator.c
@@ -1492,7 +1492,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	static const char *shortopts = "+I:a:b:s:d:p:i:m:n:t:w:c:x:he:f:yr:z";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	appl_args->mode = -1; /* Invalid, must be changed by parsing */
 	appl_args->number = -1;
@@ -1505,8 +1505,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->dstport = 0;
 	appl_args->csum = 0;
 	appl_args->sched = 0;
-
-	opterr = 0; /* do not issue errors on helper options */
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);

--- a/example/ipsec/odp_ipsec.c
+++ b/example/ipsec/odp_ipsec.c
@@ -1366,13 +1366,11 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	static const char *shortopts = "+c:i:m:h:r:p:a:e:t:s:";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	printf("\nParsing command line options\n");
 
 	appl_args->mode = 0;  /* turn off async crypto API by default */
-
-	opterr = 0; /* do not issue errors on helper options */
 
 	while (!rc) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);

--- a/example/ipsec_api/odp_ipsec.c
+++ b/example/ipsec_api/odp_ipsec.c
@@ -1059,11 +1059,9 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	static const char *shortopts = "+c:i:h:lm:r:p:a:e:t:s:";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	printf("\nParsing command line options\n");
-
-	opterr = 0; /* do not issue errors on helper options */
 
 	while (!rc) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);

--- a/example/l2fwd_simple/odp_l2fwd_simple.c
+++ b/example/l2fwd_simple/odp_l2fwd_simple.c
@@ -143,31 +143,15 @@ int main(int argc, char **argv)
 	odph_odpthread_t thd[MAX_WORKERS];
 	odp_instance_t instance;
 	odph_odpthread_params_t thr_params;
-	int opt;
-	int long_index;
 	odph_ethaddr_t correct_src;
 	uint32_t mtu1, mtu2;
 
-	static const struct option longopts[] = { {NULL, 0, NULL, 0} };
-	static const char *shortopts = "";
-
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
-	/*
-	 * parse own options: currentely none, but this will move optind
-	 * to the first non-option argument. (in case there where helprt args)
-	 */
-	opterr = 0; /* do not issue errors on helper options */
-	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
-		if (-1 == opt)
-			break;  /* No more options */
-	}
-
-	if (argc != optind + 4 ||
-	    odph_eth_addr_parse(&global.dst, argv[optind + 2]) != 0 ||
-	    odph_eth_addr_parse(&global.src, argv[optind + 3]) != 0) {
+	if (argc != 5 ||
+	    odph_eth_addr_parse(&global.dst, argv[3]) != 0 ||
+	    odph_eth_addr_parse(&global.src, argv[4]) != 0) {
 		printf("Usage: odp_l2fwd_simple eth0 eth1 01:02:03:04:05:06"
 		       " 07:08:09:0a:0b:0c\n");
 		printf("Where eth0 and eth1 are the used interfaces"
@@ -201,10 +185,8 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
-	global.if0 = create_pktio(argv[optind], pool, &global.if0in,
-								&global.if0out);
-	global.if1 = create_pktio(argv[optind + 1], pool, &global.if1in,
-								&global.if1out);
+	global.if0 = create_pktio(argv[1], pool, &global.if0in, &global.if0out);
+	global.if1 = create_pktio(argv[2], pool, &global.if1in, &global.if1out);
 
 	/* Do some operations to increase code coverage in tests */
 	if (odp_pktio_mac_addr(global.if0, &correct_src, sizeof(correct_src))

--- a/example/packet/odp_pktio.c
+++ b/example/packet/odp_pktio.c
@@ -570,12 +570,10 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	static const char *shortopts = "+c:i:+m:t:h";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	appl_args->mode = APPL_MODE_PKT_SCHED;
 	appl_args->time = 0; /**< loop forever */
-
-	opterr = 0; /* do not issue errors on helper options */
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);

--- a/example/switch/odp_switch.c
+++ b/example/switch/odp_switch.c
@@ -760,12 +760,10 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	static const char *shortopts = "+c:+t:+a:i:h";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	appl_args->time = 0; /* loop forever if time to run is 0 */
 	appl_args->accuracy = 10; /* get and print pps stats second */
-
-	opterr = 0; /* do not issue errors on helper options */
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);

--- a/example/time/time_global_test.c
+++ b/example/time/time_global_test.c
@@ -259,7 +259,7 @@ int main(int argc, char *argv[])
 	odph_odpthread_params_t thr_params;
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, NULL, NULL);
+	argc = odph_parse_options(argc, argv);
 
 	printf("\nODP global time test starts\n");
 

--- a/example/timer/odp_timer_test.c
+++ b/example/timer/odp_timer_test.c
@@ -275,7 +275,7 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 	static const char *shortopts = "+c:r:m:x:p:t:h";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	/* defaults */
 	odp_timer_capability(ODP_CLOCK_CPU, &timer_capa);
@@ -288,8 +288,6 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 	args->max_us        = 10000000;
 	args->period_us     = 1000000;
 	args->tmo_count     = 30;
-
-	opterr = 0; /* do not issue errors on helper options */
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);

--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -146,74 +146,19 @@ int odph_odpthread_setaffinity(const int cpu);
 int odph_odpthread_getaffinity(void);
 
 /**
- * Merge getopt options
- *
- * Given two sets of getopt options (each containing possibly both short
- * options -a string- and long options -a option array-) this function
- * return a single set (i.e. a string for short and an array for long)
- * being the concatenation of the two given sets.
- * Due to the fact that the size of these arrays is unknown at compilation
- * time, this function actually mallocs the the resulting arrays.
- * The fourth and fith parameters are actually pointers where these malloc'ed
- * areas are returned.
- * This means that the caller of this function has to free the two returned
- * areas!
- *
- * @param shortopts1 first set of short options (a string)
- * @param shortopts2 second set of short options (a string)
- * @param longopts1  first set of long options (a getopt option array)
- * @param longopts2  second set of long options (a getopt option array)
- * @param shortopts  a pointer where the address of the short options list
- *		     (a string) is returned. It contains the concatenation of
- *		     the two given short option strings.
- * @param longopts   a pointer where the address of the long options list
- *		     (a getopt option array) is returned.
- *		     It contains the concatenation of the two given long
- *		     option arrays.
- * if any of shortopts1, shortopts2, longopts1, longopts2 is NULL, the
- * corresponding list as assumed to be empty.
- * if any of shortopts, longopts is NULL, the corresponding malloc is not
- * performed.
- *
- * @return On success: 0 : both shortopts and longopts are returned (assuming
- *			   the given pointer where not null), possibly
- *			   pointing to an empty string or an empty option array.
- *			   On success, the caller is due to free these areas.
- *	   On failure: -1: Nothing is malloc'ed.
- */
-int odph_merge_getopt_options(const char *shortopts1,
-			      const char *shortopts2,
-			      const struct option *longopts1,
-			      const struct option *longopts2,
-			      char **shortopts,
-			      struct option **longopts);
-
-/**
  * Parse linux helper options
  *
- * Parse the command line options. Pick up options meant for the helper itself.
- * If the caller is also having a set of option to parse, it should include
- * their description here (shortopts desribes the short options and longopts
- * describes the long options, as for getopt_long()).
- * This function will issue errors on unknown arguments, so callers failing
- * to pass their own command line options description here will see their
- * options rejected.
- * (the caller wants to set opterr to zero when parsing its own stuff
- * with getopts to avoid reacting on helper's options).
+ * Parse the command line options. Pick up (--odph_ prefixed) options meant for
+ * the helper itself. When helper options are found, those are removed from
+ * argv[] and remaining options are packed to the beginning of the array.
  *
- * @param argc argument count
- * @param argv argument values
- * @param caller_shortopts caller's set of short options (string). or NULL.
- * @param caller_longopts  caller's set of long options (getopt option array).
- *			   or NULL.
+ * @param argc   Argument count
+ * @param argv   Argument vector
  *
- * @return On success: 0
- *	   On failure: -1 failure occurs if a value passed for a helper
- *			  option is invalid, or on meeting unknown options.
+ * @return New argument count. Original argument count decremented by
+ *         the number of removed helper options.
  */
-int odph_parse_options(int argc, char *argv[],
-		       const char *caller_shortopts,
-		       const struct option *caller_longopts);
+int odph_parse_options(int argc, char *argv[]);
 
 /**
  * @}

--- a/helper/test/odpthreads.c
+++ b/helper/test/odpthreads.c
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, NULL, NULL);
+	argc = odph_parse_options(argc, argv);
 
 	if (odp_init_global(&odp_instance, NULL, NULL)) {
 		ODPH_ERR("Error: ODP global init failed.\n");

--- a/helper/threads.c
+++ b/helper/threads.c
@@ -330,129 +330,26 @@ int odph_odpthread_getaffinity(void)
 	return -1;
 }
 
-/*
- * return the number of elements in an array of getopt options, excluding the
- * terminating {0,0,0,0}
- */
-static int get_getopt_options_length(const struct option *longopts)
+int odph_parse_options(int argc, char *argv[])
 {
-	int l = 0;
+	int i, j;
 
-	if (!longopts)
-		return 0;
+	helper_options.proc = 0;
 
-	while (longopts[l].name)
-		l++;
+	/* Find and remove option */
+	for (i = 0; i < argc;) {
+		if (strcmp(argv[i], "--odph_proc") == 0) {
+			helper_options.proc = 1;
 
-	return l;
-}
+			for (j = i; j < argc - 1; j++)
+				argv[j] = argv[j + 1];
 
-/* Merge getopt options */
-int odph_merge_getopt_options(const char *shortopts1,
-			      const char *shortopts2,
-			      const struct option *longopts1,
-			      const struct option *longopts2,
-			      char **shortopts,
-			      struct option **longopts)
-{
-	int shortopts1_len;
-	int shortopts2_len;
-	int longopts1_len;
-	int longopts2_len;
-	int index;
-	int res_index = 0;
-	struct option termination = {0, 0, 0, 0};
+			argc--;
+			continue;
+		}
 
-	/* merge short options: */
-	if (shortopts) {
-		shortopts1_len = (shortopts1) ? strlen(shortopts1) : 0;
-		shortopts2_len = (shortopts2) ? strlen(shortopts2) : 0;
-		*shortopts = malloc(shortopts1_len + shortopts2_len + 1);
-		if (!*shortopts)
-			return -1;
-
-		(*shortopts)[0] = 0;
-
-		if (shortopts1)
-			strcpy((*shortopts), shortopts1);
-		if (shortopts2)
-			strcat((*shortopts), shortopts2);
+		i++;
 	}
 
-	/* merge long options */
-	if (!longopts)
-		return 0;
-
-	longopts1_len = get_getopt_options_length(longopts1);
-	longopts2_len = get_getopt_options_length(longopts2);
-	*longopts = malloc(sizeof(struct option) *
-					(longopts1_len + longopts2_len + 1));
-	if (!*longopts) {
-		if (shortopts)
-			free(*shortopts);
-		return -1;
-	}
-
-	for (index = 0; (longopts1) && (longopts1[index].name); index++)
-		(*longopts)[res_index++] = longopts1[index];
-
-	for (index = 0; (longopts2) && (longopts2[index].name); index++)
-		(*longopts)[res_index++] = longopts2[index];
-
-	(*longopts)[res_index] = termination;
-
-	return 0;
-}
-
-/*
- * Parse command line options to extract options affecting helpers.
- */
-int odph_parse_options(int argc, char *argv[],
-		       const char *caller_shortopts,
-		       const struct option *caller_longopts)
-{
-	int c;
-	char *shortopts;
-	struct option *longopts;
-	int res = 0;
-
-	static struct option helper_long_options[] = {
-		/* These options set a flag. */
-		{"odph_proc",   no_argument, &helper_options.proc, 1},
-		{0, 0, 0, 0}
-		};
-
-	static const char *helper_short_options = "";
-
-	/* defaults: */
-	helper_options.proc = false;
-
-	/* merge caller's command line options descriptions with helper's: */
-	if (odph_merge_getopt_options(caller_shortopts, helper_short_options,
-				      caller_longopts, helper_long_options,
-				      &shortopts, &longopts) < 0)
-		return -1;
-
-	while (1) {
-		/* getopt_long stores the option index here. */
-		int option_index = 0;
-
-		c = getopt_long (argc, argv,
-				 shortopts, longopts, &option_index);
-
-		/* Detect the end of the options. */
-		if (c == -1)
-			break;
-
-		/* check for unknown options or missing arguments */
-		if (c == '?' || c == ':')
-			res = -1;
-	}
-
-	optind = 0; /* caller expects this to be zero if it parses too*/
-
-	free(shortopts);
-	free(longopts);
-
-	return res;
+	return argc;
 }

--- a/platform/linux-generic/test/mmap_vlan_ins/mmap_vlan_ins.c
+++ b/platform/linux-generic/test/mmap_vlan_ins/mmap_vlan_ins.c
@@ -137,36 +137,14 @@ int main(int argc, char **argv)
 	odph_odpthread_t thd[MAX_WORKERS];
 	odp_instance_t instance;
 	odph_odpthread_params_t thr_params;
-	int opt;
-	int long_index;
-
-	static const struct option longopts[] = { {NULL, 0, NULL, 0} };
-	static const char *shortopts = "";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
-	/*
-	 * parse own options: currentely none, but this will move optind
-	 * to the first non-option argument. (in case there where helprt args)
-	 */
-	opterr = 0; /* do not issue errors on helper options */
-	while (1) {
-		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
-		if (-1 == opt)
-			break;  /* No more options */
-	}
-
-	if (argc != optind + 4 ||
-	    odph_eth_addr_parse(&global.dst, argv[optind + 2]) != 0 ||
-	    odph_eth_addr_parse(&global.src, argv[optind + 3]) != 0) {
-		printf("Usage: odp_l2fwd_simple eth0 eth1 01:02:03:04:05:06"
-		       " 07:08:09:0a:0b:0c\n");
-		printf("Where eth0 and eth1 are the used interfaces"
-		       " (must have 2 of them)\n");
-		printf("And the hexadecimal numbers are destination MAC address"
-		       " and source MAC address\n");
-		exit(1);
+	if (argc < 3) {
+		printf("Too few arguments (%i).\n"
+		       "Two interface names needed as arguments.\n", argc);
+		exit(0);
 	}
 
 	if (odp_init_global(&instance, NULL, NULL)) {
@@ -193,10 +171,8 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
-	global.if0 = create_pktio(argv[optind], pool, &global.if0in,
-								&global.if0out);
-	global.if1 = create_pktio(argv[optind + 1], pool, &global.if1in,
-								&global.if1out);
+	global.if0 = create_pktio(argv[1], pool, &global.if0in, &global.if0out);
+	global.if1 = create_pktio(argv[2], pool, &global.if1in, &global.if1out);
 
 	odp_cpumask_default_worker(&cpumask, MAX_WORKERS);
 

--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -394,5 +394,6 @@ int odp_cunit_register(odp_suiteinfo_t testsuites[])
 int odp_cunit_parse_options(int argc, char *argv[])
 {
 	progname = argv[0];
-	return odph_parse_options(argc, argv, NULL, NULL);
+	odph_parse_options(argc, argv);
+	return 0;
 }

--- a/test/performance/odp_bench_packet.c
+++ b/test/performance/odp_bench_packet.c
@@ -1318,9 +1318,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	static const char *shortopts =  "b:i:h";
 
 	/* Let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
-
-	opterr = 0; /* Do not issue errors on helper options */
+	argc = odph_parse_options(argc, argv);
 
 	appl_args->bench_idx = 0; /* Run all benchmarks */
 	appl_args->burst_size = TEST_DEF_BURST;

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -1197,7 +1197,7 @@ static void parse_args(int argc, char *argv[], crypto_args_t *cargs)
 	static const char *shortopts = "+a:c:df:hi:m:nl:spr";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	cargs->in_place = 0;
 	cargs->in_flight = 1;
@@ -1207,8 +1207,6 @@ static void parse_args(int argc, char *argv[], crypto_args_t *cargs)
 	cargs->alg_config = NULL;
 	cargs->reuse_packet = 0;
 	cargs->schedule = 0;
-
-	opterr = 0; /* do not issue errors on helper options */
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -929,7 +929,7 @@ static void parse_args(int argc, char *argv[], ipsec_args_t *cargs)
 	static const char *shortopts = "+a:c:df:hi:m:nl:sptu";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	cargs->in_place = 0;
 	cargs->in_flight = 1;
@@ -939,8 +939,6 @@ static void parse_args(int argc, char *argv[], ipsec_args_t *cargs)
 	cargs->alg_config = NULL;
 	cargs->schedule = 0;
 	cargs->ah = 0;
-
-	opterr = 0; /* do not issue errors on helper options */
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);

--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -1184,7 +1184,7 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	static const char *shortopts =  "+c:+t:+a:i:m:o:r:d:s:e:k:g:vh";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	appl_args->time = 0; /* loop forever if time to run is 0 */
 	appl_args->accuracy = 1; /* get and print pps stats second */
@@ -1194,8 +1194,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	appl_args->error_check = 0; /* don't check packet errors by default */
 	appl_args->verbose = 0;
 	appl_args->chksum = 0; /* don't use checksum offload by default */
-
-	opterr = 0; /* do not issue errors on helper options */
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);

--- a/test/performance/odp_pktio_ordered.c
+++ b/test/performance/odp_pktio_ordered.c
@@ -868,15 +868,13 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	static const char *shortopts =  "+c:+t:+a:i:m:d:r:f:e:h";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	appl_args->time = 0; /* loop forever if time to run is 0 */
 	appl_args->accuracy = DEF_STATS_INT;
 	appl_args->num_rx_q = DEF_NUM_RX_QUEUES;
 	appl_args->num_flows = DEF_NUM_FLOWS;
 	appl_args->extra_rounds = DEF_EXTRA_ROUNDS;
-
-	opterr = 0; /* do not issue errors on helper options */
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);

--- a/test/performance/odp_pktio_perf.c
+++ b/test/performance/odp_pktio_perf.c
@@ -961,7 +961,7 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 	static const char *shortopts = "+c:t:b:pR:l:r:i:d:vh";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	args->cpu_count      = 0; /* all CPUs */
 	args->num_tx_workers = 0; /* defaults to cpu_count+1/2 */
@@ -972,8 +972,6 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 	args->search         = 1;
 	args->schedule       = 1;
 	args->verbose        = 0;
-
-	opterr = 0; /* do not issue errors on helper options */
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts,

--- a/test/performance/odp_sched_latency.c
+++ b/test/performance/odp_sched_latency.c
@@ -550,7 +550,7 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 	static const char *shortopts = "+c:s:l:t:m:n:o:p:rh";
 
 	/* Let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	args->sync_type = ODP_SCHED_SYNC_PARALLEL;
 	args->sample_per_prio = SAMPLE_EVENT_PER_PRIO;
@@ -561,7 +561,6 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 	args->prio[LO_PRIO].events_per_queue = EVENTS_PER_LO_PRIO_QUEUE;
 	args->prio[HI_PRIO].events_per_queue = EVENTS_PER_HI_PRIO_QUEUE;
 
-	opterr = 0; /* Do not issue errors on helper options */
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
 

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -364,7 +364,7 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->num_pktio_queue = 0;
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);

--- a/test/performance/odp_scheduling.c
+++ b/test/performance/odp_scheduling.c
@@ -761,9 +761,8 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 	static const char *shortopts = "+c:fh";
 
 	/* let helper collect its own arguments (e.g. --odph_proc) */
-	odph_parse_options(argc, argv, shortopts, longopts);
+	argc = odph_parse_options(argc, argv);
 
-	opterr = 0; /* do not issue errors on helper options */
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
 


### PR DESCRIPTION
Don't use getopt library calls for helper options. Getopt
library reset is not portable in practice. Library interface
includes global variables and different internal state
variables depending on POSIX version. There's no need for helper
to use getopt calls or set getopt global variables at all. It's
much more simple (and portable) to remove helper options from
argv[] and return new value for argc.

Signed-off-by: Petri Savolainen <petri.savolainen@linaro.org>