### PR TITLE
[PATCH v1] codecov: disable check by patch

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,9 +14,7 @@ coverage:
         threshold: 5%
     patch:
       default:
-        enabled: yes
-        target: 70%
-        threshold: 5%
+        enabled: no
     changes: no
 
 parsers:


### PR DESCRIPTION
Inside PRs there is check for code coverage for patch lines.
There is no big reason for that check due to patch also can
only remove lines. Only complete project has to be checked
for code coverage.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>