### PR TITLE
Inline queue context function

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -36,6 +36,8 @@ odpapiplatinclude_HEADERS = \
 		  include/odp/api/plat/packet_inlines.h \
 		  include/odp/api/plat/pktio_inlines.h \
 		  include/odp/api/plat/pool_inline_types.h \
+		  include/odp/api/plat/queue_inlines.h \
+		  include/odp/api/plat/queue_inline_types.h \
 		  include/odp/api/plat/std_clib_inlines.h \
 		  include/odp/api/plat/strong_types.h \
 		  include/odp/api/plat/sync_inlines.h \
@@ -221,6 +223,7 @@ __LIB__libodp_linux_la_SOURCES += \
 			   odp_packet_api.c \
 			   odp_packet_flags_api.c \
 			   odp_pktio_api.c \
+			   odp_queue_api.c \
 			   odp_std_clib_api.c \
 			   odp_sync_api.c \
 			   odp_thread_api.c \

--- a/platform/linux-generic/include-abi/odp/api/abi/queue.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/queue.h
@@ -30,6 +30,9 @@ typedef ODP_HANDLE_T(odp_queue_t);
 
 #define ODP_QUEUE_NAME_LEN 32
 
+/* Inlined functions for non-ABI compat mode */
+#include <odp/api/plat/queue_inlines.h>
+
 /**
  * @}
  */

--- a/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inline_types.h
@@ -1,0 +1,35 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_PLAT_QUEUE_INLINE_TYPES_H_
+#define ODP_PLAT_QUEUE_INLINE_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+/* Queue entry field accessor */
+#define _odp_qentry_field(qentry, cast, field) \
+	(*(cast *)(uintptr_t)((uint8_t *)qentry + \
+	 _odp_queue_inline_offset.field))
+
+/* Queue entry field offsets for inline functions */
+typedef struct _odp_queue_inline_offset_t {
+	uint16_t context;
+
+} _odp_queue_inline_offset_t;
+
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/include/odp/api/plat/queue_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/queue_inlines.h
@@ -1,0 +1,36 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_PLAT_QUEUE_INLINES_H_
+#define ODP_PLAT_QUEUE_INLINES_H_
+
+#include <odp/api/plat/queue_inline_types.h>
+
+/** @cond _ODP_HIDE_FROM_DOXYGEN_ */
+
+extern _odp_queue_inline_offset_t _odp_queue_inline_offset;
+
+#ifndef _ODP_NO_INLINE
+	/* Inline functions by default */
+	#define _ODP_INLINE static inline
+	#define odp_queue_context __odp_queue_context
+#else
+	#define _ODP_INLINE
+#endif
+
+_ODP_INLINE void *odp_queue_context(odp_queue_t handle)
+{
+	void *context;
+	void *qentry = (void *)handle;
+
+	context = _odp_qentry_field(qentry, void *, context);
+
+	return context;
+}
+
+/** @endcond */
+
+#endif

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -105,7 +105,7 @@ typedef struct {
 	odp_time_t timestamp;
 
 	/* Classifier destination queue */
-	queue_t dst_queue;
+	void *dst_queue;
 
 	/* Result for crypto packet op */
 	odp_crypto_packet_result_t crypto_op_result;

--- a/platform/linux-generic/include/odp_packet_io_internal.h
+++ b/platform/linux-generic/include/odp_packet_io_internal.h
@@ -175,7 +175,7 @@ struct pktio_entry {
 
 	struct {
 		odp_queue_t        queue;
-		queue_t            queue_int;
+		void              *queue_int;
 		odp_pktin_queue_t  pktin;
 	} in_queue[PKTIO_MAX_QUEUES];
 

--- a/platform/linux-generic/include/odp_queue_if.h
+++ b/platform/linux-generic/include/odp_queue_if.h
@@ -27,7 +27,6 @@ typedef struct {
 	int (*queue_capability)(odp_queue_capability_t *capa);
 	int (*queue_context_set)(odp_queue_t queue, void *context,
 				 uint32_t len);
-	void *(*queue_context)(odp_queue_t queue);
 	int (*queue_enq)(odp_queue_t queue, odp_event_t ev);
 	int (*queue_enq_multi)(odp_queue_t queue, const odp_event_t events[],
 			       int num);

--- a/platform/linux-generic/include/odp_queue_if.h
+++ b/platform/linux-generic/include/odp_queue_if.h
@@ -44,29 +44,23 @@ typedef struct {
 	int (*queue_info)(odp_queue_t queue, odp_queue_info_t *info);
 } queue_api_t;
 
-/* Internal abstract queue handle */
-typedef struct { char dummy; } _queue_t;
-typedef _queue_t *queue_t;
-
-#define QUEUE_NULL ((queue_t)NULL)
-
 typedef int (*queue_init_global_fn_t)(void);
 typedef int (*queue_term_global_fn_t)(void);
 typedef int (*queue_init_local_fn_t)(void);
 typedef int (*queue_term_local_fn_t)(void);
-typedef queue_t (*queue_from_ext_fn_t)(odp_queue_t handle);
-typedef odp_queue_t (*queue_to_ext_fn_t)(queue_t q_int);
-typedef int (*queue_enq_fn_t)(queue_t q_int, odp_buffer_hdr_t *);
-typedef int (*queue_enq_multi_fn_t)(queue_t q_int, odp_buffer_hdr_t **, int);
-typedef odp_buffer_hdr_t *(*queue_deq_fn_t)(queue_t q_int);
-typedef int (*queue_deq_multi_fn_t)(queue_t q_int, odp_buffer_hdr_t **, int);
-typedef odp_pktout_queue_t (*queue_get_pktout_fn_t)(queue_t q_int);
-typedef void (*queue_set_pktout_fn_t)(queue_t q_int, odp_pktio_t pktio,
+typedef void *(*queue_from_ext_fn_t)(odp_queue_t handle);
+typedef odp_queue_t (*queue_to_ext_fn_t)(void *q_int);
+typedef int (*queue_enq_fn_t)(void *q_int, odp_buffer_hdr_t *);
+typedef int (*queue_enq_multi_fn_t)(void *q_int, odp_buffer_hdr_t **, int);
+typedef odp_buffer_hdr_t *(*queue_deq_fn_t)(void *q_int);
+typedef int (*queue_deq_multi_fn_t)(void *q_int, odp_buffer_hdr_t **, int);
+typedef odp_pktout_queue_t (*queue_get_pktout_fn_t)(void *q_int);
+typedef void (*queue_set_pktout_fn_t)(void *q_int, odp_pktio_t pktio,
 				      int index);
-typedef odp_pktin_queue_t (*queue_get_pktin_fn_t)(queue_t q_int);
-typedef void (*queue_set_pktin_fn_t)(queue_t q_int, odp_pktio_t pktio,
+typedef odp_pktin_queue_t (*queue_get_pktin_fn_t)(void *q_int);
+typedef void (*queue_set_pktin_fn_t)(void *q_int, odp_pktio_t pktio,
 				     int index);
-typedef void (*queue_set_enq_deq_fn_t)(queue_t q_int,
+typedef void (*queue_set_enq_deq_fn_t)(void *q_int,
 				       queue_enq_fn_t enq,
 				       queue_enq_multi_fn_t enq_multi,
 				       queue_deq_fn_t deq,

--- a/platform/linux-generic/include/odp_queue_internal.h
+++ b/platform/linux-generic/include/odp_queue_internal.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-
-/**
- * @file
- *
- * ODP queue - implementation internal
- */
-
 #ifndef ODP_QUEUE_INTERNAL_H_
 #define ODP_QUEUE_INTERNAL_H_
 
@@ -81,9 +74,9 @@ typedef struct queue_global_t {
 
 extern queue_global_t *queue_glb;
 
-static inline queue_t queue_index_to_qint(uint32_t queue_id)
+static inline void *queue_index_to_qint(uint32_t queue_id)
 {
-	return (queue_t)&queue_glb->queue[queue_id];
+	return &queue_glb->queue[queue_id];
 }
 
 static inline uint32_t queue_to_index(odp_queue_t handle)
@@ -96,14 +89,14 @@ static inline odp_queue_t queue_from_index(uint32_t queue_id)
 	return _odp_cast_scalar(odp_queue_t, queue_id + 1);
 }
 
-static inline queue_entry_t *qentry_from_int(queue_t q_int)
+static inline queue_entry_t *qentry_from_int(void *q_int)
 {
-	return (queue_entry_t *)(void *)(q_int);
+	return (queue_entry_t *)q_int;
 }
 
-static inline queue_t qentry_to_int(queue_entry_t *qentry)
+static inline void *qentry_to_int(queue_entry_t *qentry)
 {
-	return (queue_t)(qentry);
+	return qentry;
 }
 
 #ifdef __cplusplus

--- a/platform/linux-generic/include/odp_queue_internal.h
+++ b/platform/linux-generic/include/odp_queue_internal.h
@@ -89,16 +89,6 @@ static inline odp_queue_t queue_from_index(uint32_t queue_id)
 	return _odp_cast_scalar(odp_queue_t, queue_id + 1);
 }
 
-static inline queue_entry_t *qentry_from_int(void *q_int)
-{
-	return (queue_entry_t *)q_int;
-}
-
-static inline void *qentry_to_int(queue_entry_t *qentry)
-{
-	return qentry;
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/include/odp_queue_internal.h
+++ b/platform/linux-generic/include/odp_queue_internal.h
@@ -74,19 +74,21 @@ typedef struct queue_global_t {
 
 extern queue_global_t *queue_glb;
 
-static inline void *queue_index_to_qint(uint32_t queue_id)
+static inline uint32_t queue_to_index(odp_queue_t handle)
+{
+	queue_entry_t *qentry = (queue_entry_t *)(uintptr_t)handle;
+
+	return qentry->s.index;
+}
+
+static inline queue_entry_t *qentry_from_index(uint32_t queue_id)
 {
 	return &queue_glb->queue[queue_id];
 }
 
-static inline uint32_t queue_to_index(odp_queue_t handle)
-{
-	return _odp_typeval(handle) - 1;
-}
-
 static inline odp_queue_t queue_from_index(uint32_t queue_id)
 {
-	return _odp_cast_scalar(odp_queue_t, queue_id + 1);
+	return (odp_queue_t)qentry_from_index(queue_id);
 }
 
 #ifdef __cplusplus

--- a/platform/linux-generic/include/odp_queue_scalable_internal.h
+++ b/platform/linux-generic/include/odp_queue_scalable_internal.h
@@ -80,14 +80,14 @@ static inline uint32_t queue_to_id(odp_queue_t handle)
 	return _odp_typeval(handle) - 1;
 }
 
-static inline queue_entry_t *qentry_from_int(queue_t handle)
+static inline queue_entry_t *qentry_from_int(void *handle)
 {
-	return (queue_entry_t *)(void *)(handle);
+	return (queue_entry_t *)handle;
 }
 
-static inline queue_t qentry_to_int(queue_entry_t *qentry)
+static inline void *qentry_to_int(queue_entry_t *qentry)
 {
-	return (queue_t)(qentry);
+	return qentry;
 }
 
 static inline odp_queue_t queue_get_handle(queue_entry_t *queue)

--- a/platform/linux-generic/include/odp_queue_scalable_internal.h
+++ b/platform/linux-generic/include/odp_queue_scalable_internal.h
@@ -77,7 +77,7 @@ static inline void *shm_pool_alloc_align(_odp_ishm_pool_t *pool, uint32_t size)
 
 static inline uint32_t queue_to_id(odp_queue_t handle)
 {
-	return _odp_typeval(handle) - 1;
+	return qentry_from_ext(handle)->s.index;
 }
 
 static inline queue_entry_t *qentry_from_int(void *handle)

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -32,7 +32,7 @@ typedef int (*schedule_init_queue_fn_t)(uint32_t queue_index,
 typedef void (*schedule_destroy_queue_fn_t)(uint32_t queue_index);
 typedef int (*schedule_sched_queue_fn_t)(uint32_t queue_index);
 typedef int (*schedule_unsched_queue_fn_t)(uint32_t queue_index);
-typedef int (*schedule_ord_enq_multi_fn_t)(queue_t q_int,
+typedef int (*schedule_ord_enq_multi_fn_t)(void *q_int,
 					   void *buf_hdr[], int num, int *ret);
 typedef int (*schedule_init_global_fn_t)(void);
 typedef int (*schedule_term_global_fn_t)(void);

--- a/platform/linux-generic/include/odp_traffic_mngr_internal.h
+++ b/platform/linux-generic/include/odp_traffic_mngr_internal.h
@@ -282,7 +282,7 @@ struct tm_queue_obj_s {
 	uint8_t tm_idx;
 	uint8_t delayed_cnt;
 	uint8_t blocked_cnt;
-	queue_t tm_qentry;
+	void *tm_qentry;
 };
 
 struct tm_node_obj_s {

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -137,7 +137,7 @@ static void init_in_queues(pktio_entry_t *entry)
 
 	for (i = 0; i < PKTIO_MAX_QUEUES; i++) {
 		entry->s.in_queue[i].queue = ODP_QUEUE_INVALID;
-		entry->s.in_queue[i].queue_int = QUEUE_NULL;
+		entry->s.in_queue[i].queue_int = NULL;
 		entry->s.in_queue[i].pktin = PKTIN_INVALID;
 	}
 }
@@ -327,7 +327,7 @@ static void destroy_in_queues(pktio_entry_t *entry, int num)
 		if (entry->s.in_queue[i].queue != ODP_QUEUE_INVALID) {
 			odp_queue_destroy(entry->s.in_queue[i].queue);
 			entry->s.in_queue[i].queue = ODP_QUEUE_INVALID;
-			entry->s.in_queue[i].queue_int = QUEUE_NULL;
+			entry->s.in_queue[i].queue_int = NULL;
 		}
 	}
 }
@@ -637,7 +637,7 @@ static inline int pktin_recv_buf(pktio_entry_t *entry, int pktin_index,
 	return num_rx;
 }
 
-static int pktout_enqueue(queue_t q_int, odp_buffer_hdr_t *buf_hdr)
+static int pktout_enqueue(void *q_int, odp_buffer_hdr_t *buf_hdr)
 {
 	odp_packet_t pkt = packet_from_buf_hdr(buf_hdr);
 	int len = 1;
@@ -650,7 +650,7 @@ static int pktout_enqueue(queue_t q_int, odp_buffer_hdr_t *buf_hdr)
 	return (nbr == len ? 0 : -1);
 }
 
-static int pktout_enq_multi(queue_t q_int, odp_buffer_hdr_t *buf_hdr[], int num)
+static int pktout_enq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[], int num)
 {
 	odp_packet_t pkt_tbl[QUEUE_MULTI_MAX];
 	int nbr;
@@ -666,7 +666,7 @@ static int pktout_enq_multi(queue_t q_int, odp_buffer_hdr_t *buf_hdr[], int num)
 	return nbr;
 }
 
-static odp_buffer_hdr_t *pktin_dequeue(queue_t q_int)
+static odp_buffer_hdr_t *pktin_dequeue(void *q_int)
 {
 	odp_buffer_hdr_t *buf_hdr;
 	odp_buffer_hdr_t *hdr_tbl[QUEUE_MULTI_MAX];
@@ -705,7 +705,7 @@ static odp_buffer_hdr_t *pktin_dequeue(queue_t q_int)
 	return buf_hdr;
 }
 
-static int pktin_deq_multi(queue_t q_int, odp_buffer_hdr_t *buf_hdr[], int num)
+static int pktin_deq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[], int num)
 {
 	int nbr;
 	odp_buffer_hdr_t *hdr_tbl[QUEUE_MULTI_MAX];
@@ -765,7 +765,7 @@ int sched_cb_pktin_poll_one(int pktio_index,
 	odp_packet_hdr_t *pkt_hdr;
 	odp_buffer_hdr_t *buf_hdr;
 	odp_packet_t packets[QUEUE_MULTI_MAX];
-	queue_t queue;
+	void *q_int;
 
 	if (odp_unlikely(entry->s.state != PKTIO_STATE_STARTED)) {
 		if (entry->s.state < PKTIO_STATE_ACTIVE ||
@@ -785,9 +785,9 @@ int sched_cb_pktin_poll_one(int pktio_index,
 		pkt = packets[i];
 		pkt_hdr = packet_hdr(pkt);
 		if (odp_unlikely(pkt_hdr->p.input_flags.dst_queue)) {
-			queue = pkt_hdr->dst_queue;
+			q_int = pkt_hdr->dst_queue;
 			buf_hdr = packet_to_buf_hdr(pkt);
-			if (queue_fn->enq_multi(queue, &buf_hdr, 1) < 0) {
+			if (queue_fn->enq_multi(q_int, &buf_hdr, 1) < 0) {
 				/* Queue full? */
 				odp_packet_free(pkt);
 				__atomic_fetch_add(&entry->s.stats.in_discards,
@@ -836,7 +836,7 @@ int sched_cb_pktin_poll_old(int pktio_index, int num_queue, int index[])
 	}
 
 	for (idx = 0; idx < num_queue; idx++) {
-		queue_t q_int;
+		void *q_int;
 		int num_enq;
 
 		num = pktin_recv_buf(entry, index[idx], hdr_tbl,
@@ -1371,14 +1371,14 @@ int odp_pktio_stats_reset(odp_pktio_t pktio)
 	return ret;
 }
 
-static int abort_pktin_enqueue(queue_t q_int ODP_UNUSED,
+static int abort_pktin_enqueue(void *q_int ODP_UNUSED,
 			       odp_buffer_hdr_t *buf_hdr ODP_UNUSED)
 {
 	ODP_ABORT("attempted enqueue to a pktin queue");
 	return -1;
 }
 
-static int abort_pktin_enq_multi(queue_t q_int ODP_UNUSED,
+static int abort_pktin_enq_multi(void *q_int ODP_UNUSED,
 				 odp_buffer_hdr_t *buf_hdr[] ODP_UNUSED,
 				 int num ODP_UNUSED)
 {
@@ -1386,13 +1386,13 @@ static int abort_pktin_enq_multi(queue_t q_int ODP_UNUSED,
 	return 0;
 }
 
-static odp_buffer_hdr_t *abort_pktout_dequeue(queue_t q_int ODP_UNUSED)
+static odp_buffer_hdr_t *abort_pktout_dequeue(void *q_int ODP_UNUSED)
 {
 	ODP_ABORT("attempted dequeue from a pktout queue");
 	return NULL;
 }
 
-static int abort_pktout_deq_multi(queue_t q_int ODP_UNUSED,
+static int abort_pktout_deq_multi(void *q_int ODP_UNUSED,
 				  odp_buffer_hdr_t *buf_hdr[] ODP_UNUSED,
 				  int num ODP_UNUSED)
 {
@@ -1410,7 +1410,7 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 	unsigned i;
 	int rc;
 	odp_queue_t queue;
-	queue_t q_int;
+	void *q_int;
 	odp_pktin_queue_param_t default_param;
 
 	if (param == NULL) {
@@ -1506,7 +1506,7 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 
 		} else {
 			entry->s.in_queue[i].queue = ODP_QUEUE_INVALID;
-			entry->s.in_queue[i].queue_int = QUEUE_NULL;
+			entry->s.in_queue[i].queue_int = NULL;
 		}
 
 		entry->s.in_queue[i].pktin.index = i;
@@ -1598,7 +1598,7 @@ int odp_pktout_queue_config(odp_pktio_t pktio,
 		for (i = 0; i < num_queues; i++) {
 			odp_queue_t queue;
 			odp_queue_param_t queue_param;
-			queue_t q_int;
+			void *q_int;
 			char name[ODP_QUEUE_NAME_LEN];
 			int pktio_id = odp_pktio_index(pktio);
 

--- a/platform/linux-generic/odp_queue_api.c
+++ b/platform/linux-generic/odp_queue_api.c
@@ -1,0 +1,13 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include "config.h"
+
+#include <odp/api/queue.h>
+
+/* Non-inlined functions for ABI compat mode */
+#define _ODP_NO_INLINE
+#include <odp/api/plat/queue_inlines.h>

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -45,16 +45,9 @@ static int queue_init(queue_entry_t *queue, const char *name,
 
 queue_global_t *queue_glb;
 
-static inline queue_entry_t *get_qentry(uint32_t queue_id)
+static inline queue_entry_t *qentry_from_handle(odp_queue_t handle)
 {
-	return &queue_glb->queue[queue_id];
-}
-
-static inline queue_entry_t *handle_to_qentry(odp_queue_t handle)
-{
-	uint32_t queue_id = queue_to_index(handle);
-
-	return get_qentry(queue_id);
+	return (queue_entry_t *)(uintptr_t)handle;
 }
 
 static int queue_capa(odp_queue_capability_t *capa, int sched)
@@ -149,10 +142,10 @@ static int queue_init_global(void)
 
 	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
 		/* init locks */
-		queue_entry_t *queue = get_qentry(i);
+		queue_entry_t *queue = qentry_from_index(i);
 		LOCK_INIT(queue);
 		queue->s.index  = i;
-		queue->s.handle = queue_from_index(i);
+		queue->s.handle = (odp_queue_t)queue;
 	}
 
 	if (read_config_file(queue_glb)) {
@@ -208,7 +201,7 @@ static int queue_term_global(void)
 	int i;
 
 	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
-		queue = &queue_glb->queue[i];
+		queue = qentry_from_index(i);
 		LOCK(queue);
 		if (queue->s.status != QUEUE_STATUS_FREE) {
 			ODP_ERR("Not destroyed queue: %s\n", queue->s.name);
@@ -239,27 +232,27 @@ static int queue_capability(odp_queue_capability_t *capa)
 
 static odp_queue_type_t queue_type(odp_queue_t handle)
 {
-	return handle_to_qentry(handle)->s.type;
+	return qentry_from_handle(handle)->s.type;
 }
 
 static odp_schedule_sync_t queue_sched_type(odp_queue_t handle)
 {
-	return handle_to_qentry(handle)->s.param.sched.sync;
+	return qentry_from_handle(handle)->s.param.sched.sync;
 }
 
 static odp_schedule_prio_t queue_sched_prio(odp_queue_t handle)
 {
-	return handle_to_qentry(handle)->s.param.sched.prio;
+	return qentry_from_handle(handle)->s.param.sched.prio;
 }
 
 static odp_schedule_group_t queue_sched_group(odp_queue_t handle)
 {
-	return handle_to_qentry(handle)->s.param.sched.group;
+	return qentry_from_handle(handle)->s.param.sched.group;
 }
 
 static uint32_t queue_lock_count(odp_queue_t handle)
 {
-	queue_entry_t *queue = handle_to_qentry(handle);
+	queue_entry_t *queue = qentry_from_handle(handle);
 
 	return queue->s.param.sched.sync == ODP_SCHED_SYNC_ORDERED ?
 		queue->s.param.sched.lock_count : 0;
@@ -295,7 +288,7 @@ static odp_queue_t queue_create(const char *name,
 	}
 
 	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
-		queue = &queue_glb->queue[i];
+		queue = qentry_from_index(i);
 
 		if (queue->s.status != QUEUE_STATUS_FREE)
 			continue;
@@ -357,7 +350,7 @@ static odp_queue_t queue_create(const char *name,
 
 void sched_cb_queue_destroy_finalize(uint32_t queue_index)
 {
-	queue_entry_t *queue = get_qentry(queue_index);
+	queue_entry_t *queue = qentry_from_index(queue_index);
 
 	LOCK(queue);
 
@@ -370,7 +363,7 @@ void sched_cb_queue_destroy_finalize(uint32_t queue_index)
 
 void sched_cb_queue_set_status(uint32_t queue_index, int status)
 {
-	queue_entry_t *queue = get_qentry(queue_index);
+	queue_entry_t *queue = qentry_from_index(queue_index);
 
 	LOCK(queue);
 
@@ -382,7 +375,7 @@ void sched_cb_queue_set_status(uint32_t queue_index, int status)
 static int queue_destroy(odp_queue_t handle)
 {
 	queue_entry_t *queue;
-	queue = handle_to_qentry(handle);
+	queue = qentry_from_handle(handle);
 
 	if (handle == ODP_QUEUE_INVALID)
 		return -1;
@@ -432,14 +425,14 @@ static int queue_context_set(odp_queue_t handle, void *context,
 			     uint32_t len ODP_UNUSED)
 {
 	odp_mb_full();
-	handle_to_qentry(handle)->s.param.context = context;
+	qentry_from_handle(handle)->s.param.context = context;
 	odp_mb_full();
 	return 0;
 }
 
 static void *queue_context(odp_queue_t handle)
 {
-	return handle_to_qentry(handle)->s.param.context;
+	return qentry_from_handle(handle)->s.param.context;
 }
 
 static odp_queue_t queue_lookup(const char *name)
@@ -447,7 +440,7 @@ static odp_queue_t queue_lookup(const char *name)
 	uint32_t i;
 
 	for (i = 0; i < ODP_CONFIG_QUEUES; i++) {
-		queue_entry_t *queue = &queue_glb->queue[i];
+		queue_entry_t *queue = qentry_from_index(i);
 
 		if (queue->s.status == QUEUE_STATUS_FREE ||
 		    queue->s.status == QUEUE_STATUS_DESTROYED)
@@ -552,7 +545,7 @@ static int queue_int_enq(void *q_int, odp_buffer_hdr_t *buf_hdr)
 
 static int queue_enq_multi(odp_queue_t handle, const odp_event_t ev[], int num)
 {
-	queue_entry_t *queue = handle_to_qentry(handle);
+	queue_entry_t *queue = qentry_from_handle(handle);
 
 	if (odp_unlikely(num == 0))
 		return 0;
@@ -566,7 +559,7 @@ static int queue_enq_multi(odp_queue_t handle, const odp_event_t ev[], int num)
 
 static int queue_enq(odp_queue_t handle, odp_event_t ev)
 {
-	queue_entry_t *queue = handle_to_qentry(handle);
+	queue_entry_t *queue = qentry_from_handle(handle);
 
 	return queue->s.enqueue(queue,
 				(odp_buffer_hdr_t *)(uintptr_t)ev);
@@ -641,7 +634,7 @@ static odp_buffer_hdr_t *queue_int_deq(void *q_int)
 
 static int queue_deq_multi(odp_queue_t handle, odp_event_t ev[], int num)
 {
-	queue_entry_t *queue = handle_to_qentry(handle);
+	queue_entry_t *queue = qentry_from_handle(handle);
 
 	if (num > QUEUE_MULTI_MAX)
 		num = QUEUE_MULTI_MAX;
@@ -652,7 +645,7 @@ static int queue_deq_multi(odp_queue_t handle, odp_event_t ev[], int num)
 
 static odp_event_t queue_deq(odp_queue_t handle)
 {
-	queue_entry_t *queue = handle_to_qentry(handle);
+	queue_entry_t *queue = qentry_from_handle(handle);
 
 	return (odp_event_t)queue->s.dequeue(queue);
 }
@@ -739,7 +732,7 @@ static int queue_info(odp_queue_t handle, odp_queue_info_t *info)
 		return -1;
 	}
 
-	queue = get_qentry(queue_id);
+	queue = qentry_from_index(queue_id);
 
 	LOCK(queue);
 	status = queue->s.status;
@@ -762,14 +755,14 @@ static int queue_info(odp_queue_t handle, odp_queue_info_t *info)
 int sched_cb_queue_deq_multi(uint32_t queue_index, odp_event_t ev[], int num,
 			     int update_status)
 {
-	queue_entry_t *qe = get_qentry(queue_index);
+	queue_entry_t *qe = qentry_from_index(queue_index);
 
 	return deq_multi(qe, (odp_buffer_hdr_t **)ev, num, update_status);
 }
 
 int sched_cb_queue_empty(uint32_t queue_index)
 {
-	queue_entry_t *queue = get_qentry(queue_index);
+	queue_entry_t *queue = qentry_from_index(queue_index);
 	int ret = 0;
 
 	LOCK(queue);
@@ -851,7 +844,7 @@ static void queue_set_enq_deq_func(void *q_int,
 
 static void *queue_from_ext(odp_queue_t handle)
 {
-	return handle_to_qentry(handle);
+	return qentry_from_handle(handle);
 }
 
 static odp_queue_t queue_to_ext(void *q_int)

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -495,7 +495,7 @@ static inline int enq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[],
 	ring_st_t *ring_st;
 	uint32_t buf_idx[num];
 
-	queue = qentry_from_int(q_int);
+	queue = q_int;
 	ring_st = &queue->s.ring_st;
 
 	if (sched_fn->ord_enq_multi(q_int, (void **)buf_hdr, num, &ret))
@@ -560,7 +560,7 @@ static int queue_enq_multi(odp_queue_t handle, const odp_event_t ev[], int num)
 	if (num > QUEUE_MULTI_MAX)
 		num = QUEUE_MULTI_MAX;
 
-	return queue->s.enqueue_multi(qentry_to_int(queue),
+	return queue->s.enqueue_multi(queue,
 				      (odp_buffer_hdr_t **)(uintptr_t)ev, num);
 }
 
@@ -568,7 +568,7 @@ static int queue_enq(odp_queue_t handle, odp_event_t ev)
 {
 	queue_entry_t *queue = handle_to_qentry(handle);
 
-	return queue->s.enqueue(qentry_to_int(queue),
+	return queue->s.enqueue(queue,
 				(odp_buffer_hdr_t *)(uintptr_t)ev);
 }
 
@@ -620,14 +620,14 @@ static inline int deq_multi(queue_entry_t *queue, odp_buffer_hdr_t *buf_hdr[],
 static int queue_int_deq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[],
 			       int num)
 {
-	queue_entry_t *queue = qentry_from_int(q_int);
+	queue_entry_t *queue = q_int;
 
 	return deq_multi(queue, buf_hdr, num, 0);
 }
 
 static odp_buffer_hdr_t *queue_int_deq(void *q_int)
 {
-	queue_entry_t *queue = qentry_from_int(q_int);
+	queue_entry_t *queue = q_int;
 	odp_buffer_hdr_t *buf_hdr = NULL;
 	int ret;
 
@@ -646,7 +646,7 @@ static int queue_deq_multi(odp_queue_t handle, odp_event_t ev[], int num)
 	if (num > QUEUE_MULTI_MAX)
 		num = QUEUE_MULTI_MAX;
 
-	return queue->s.dequeue_multi(qentry_to_int(queue),
+	return queue->s.dequeue_multi(queue,
 				      (odp_buffer_hdr_t **)ev, num);
 }
 
@@ -654,7 +654,7 @@ static odp_event_t queue_deq(odp_queue_t handle)
 {
 	queue_entry_t *queue = handle_to_qentry(handle);
 
-	return (odp_event_t)queue->s.dequeue(qentry_to_int(queue));
+	return (odp_event_t)queue->s.dequeue(queue);
 }
 
 static int queue_init(queue_entry_t *queue, const char *name,
@@ -800,12 +800,14 @@ static uint64_t queue_to_u64(odp_queue_t hdl)
 
 static odp_pktout_queue_t queue_get_pktout(void *q_int)
 {
-	return qentry_from_int(q_int)->s.pktout;
+	queue_entry_t *qentry = q_int;
+
+	return qentry->s.pktout;
 }
 
 static void queue_set_pktout(void *q_int, odp_pktio_t pktio, int index)
 {
-	queue_entry_t *qentry = qentry_from_int(q_int);
+	queue_entry_t *qentry = q_int;
 
 	qentry->s.pktout.pktio = pktio;
 	qentry->s.pktout.index = index;
@@ -813,12 +815,14 @@ static void queue_set_pktout(void *q_int, odp_pktio_t pktio, int index)
 
 static odp_pktin_queue_t queue_get_pktin(void *q_int)
 {
-	return qentry_from_int(q_int)->s.pktin;
+	queue_entry_t *qentry = q_int;
+
+	return qentry->s.pktin;
 }
 
 static void queue_set_pktin(void *q_int, odp_pktio_t pktio, int index)
 {
-	queue_entry_t *qentry = qentry_from_int(q_int);
+	queue_entry_t *qentry = q_int;
 
 	qentry->s.pktin.pktio = pktio;
 	qentry->s.pktin.index = index;
@@ -830,7 +834,7 @@ static void queue_set_enq_deq_func(void *q_int,
 				   queue_deq_fn_t deq,
 				   queue_deq_multi_fn_t deq_multi)
 {
-	queue_entry_t *qentry = qentry_from_int(q_int);
+	queue_entry_t *qentry = q_int;
 
 	if (enq)
 		qentry->s.enqueue = enq;
@@ -847,12 +851,14 @@ static void queue_set_enq_deq_func(void *q_int,
 
 static void *queue_from_ext(odp_queue_t handle)
 {
-	return qentry_to_int(handle_to_qentry(handle));
+	return handle_to_qentry(handle);
 }
 
 static odp_queue_t queue_to_ext(void *q_int)
 {
-	return qentry_from_int(q_int)->s.handle;
+	queue_entry_t *qentry = q_int;
+
+	return qentry->s.handle;
 }
 
 /* API functions */

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -485,7 +485,7 @@ static inline void buffer_index_to_buf(odp_buffer_hdr_t *buf_hdr[],
 	}
 }
 
-static inline int enq_multi(queue_t q_int, odp_buffer_hdr_t *buf_hdr[],
+static inline int enq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[],
 			    int num)
 {
 	int sched = 0;
@@ -532,13 +532,13 @@ static inline int enq_multi(queue_t q_int, odp_buffer_hdr_t *buf_hdr[],
 	return num_enq;
 }
 
-static int queue_int_enq_multi(queue_t q_int, odp_buffer_hdr_t *buf_hdr[],
+static int queue_int_enq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[],
 			       int num)
 {
 	return enq_multi(q_int, buf_hdr, num);
 }
 
-static int queue_int_enq(queue_t q_int, odp_buffer_hdr_t *buf_hdr)
+static int queue_int_enq(void *q_int, odp_buffer_hdr_t *buf_hdr)
 {
 	int ret;
 
@@ -617,7 +617,7 @@ static inline int deq_multi(queue_entry_t *queue, odp_buffer_hdr_t *buf_hdr[],
 	return num_deq;
 }
 
-static int queue_int_deq_multi(queue_t q_int, odp_buffer_hdr_t *buf_hdr[],
+static int queue_int_deq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[],
 			       int num)
 {
 	queue_entry_t *queue = qentry_from_int(q_int);
@@ -625,7 +625,7 @@ static int queue_int_deq_multi(queue_t q_int, odp_buffer_hdr_t *buf_hdr[],
 	return deq_multi(queue, buf_hdr, num, 0);
 }
 
-static odp_buffer_hdr_t *queue_int_deq(queue_t q_int)
+static odp_buffer_hdr_t *queue_int_deq(void *q_int)
 {
 	queue_entry_t *queue = qentry_from_int(q_int);
 	odp_buffer_hdr_t *buf_hdr = NULL;
@@ -798,12 +798,12 @@ static uint64_t queue_to_u64(odp_queue_t hdl)
 	return _odp_pri(hdl);
 }
 
-static odp_pktout_queue_t queue_get_pktout(queue_t q_int)
+static odp_pktout_queue_t queue_get_pktout(void *q_int)
 {
 	return qentry_from_int(q_int)->s.pktout;
 }
 
-static void queue_set_pktout(queue_t q_int, odp_pktio_t pktio, int index)
+static void queue_set_pktout(void *q_int, odp_pktio_t pktio, int index)
 {
 	queue_entry_t *qentry = qentry_from_int(q_int);
 
@@ -811,12 +811,12 @@ static void queue_set_pktout(queue_t q_int, odp_pktio_t pktio, int index)
 	qentry->s.pktout.index = index;
 }
 
-static odp_pktin_queue_t queue_get_pktin(queue_t q_int)
+static odp_pktin_queue_t queue_get_pktin(void *q_int)
 {
 	return qentry_from_int(q_int)->s.pktin;
 }
 
-static void queue_set_pktin(queue_t q_int, odp_pktio_t pktio, int index)
+static void queue_set_pktin(void *q_int, odp_pktio_t pktio, int index)
 {
 	queue_entry_t *qentry = qentry_from_int(q_int);
 
@@ -824,7 +824,7 @@ static void queue_set_pktin(queue_t q_int, odp_pktio_t pktio, int index)
 	qentry->s.pktin.index = index;
 }
 
-static void queue_set_enq_deq_func(queue_t q_int,
+static void queue_set_enq_deq_func(void *q_int,
 				   queue_enq_fn_t enq,
 				   queue_enq_multi_fn_t enq_multi,
 				   queue_deq_fn_t deq,
@@ -845,12 +845,12 @@ static void queue_set_enq_deq_func(queue_t q_int,
 		qentry->s.dequeue_multi = deq_multi;
 }
 
-static queue_t queue_from_ext(odp_queue_t handle)
+static void *queue_from_ext(odp_queue_t handle)
 {
 	return qentry_to_int(handle_to_qentry(handle));
 }
 
-static odp_queue_t queue_to_ext(queue_t q_int)
+static odp_queue_t queue_to_ext(void *q_int)
 {
 	return qentry_from_int(q_int)->s.handle;
 }

--- a/platform/linux-generic/odp_queue_if.c
+++ b/platform/linux-generic/odp_queue_if.c
@@ -13,6 +13,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <odp/api/align.h>
+#include <odp/api/plat/queue_inline_types.h>
+
+#include <odp/visibility_begin.h>
+
+_odp_queue_inline_offset_t ODP_ALIGNED_CACHE _odp_queue_inline_offset;
+
+#include <odp/visibility_end.h>
+
 extern const queue_api_t queue_scalable_api;
 extern const queue_fn_t queue_scalable_fn;
 
@@ -45,11 +54,6 @@ int odp_queue_capability(odp_queue_capability_t *capa)
 int odp_queue_context_set(odp_queue_t queue, void *context, uint32_t len)
 {
 	return queue_api->queue_context_set(queue, context, len);
-}
-
-void *odp_queue_context(odp_queue_t queue)
-{
-	return queue_api->queue_context(queue);
 }
 
 int odp_queue_enq(odp_queue_t queue, odp_event_t ev)

--- a/platform/linux-generic/odp_queue_lf.c
+++ b/platform/linux-generic/odp_queue_lf.c
@@ -133,7 +133,7 @@ static inline int next_idx(int idx)
 	return next;
 }
 
-static int queue_lf_enq(queue_t q_int, odp_buffer_hdr_t *buf_hdr)
+static int queue_lf_enq(void *q_int, odp_buffer_hdr_t *buf_hdr)
 {
 	queue_entry_t *queue;
 	queue_lf_t *queue_lf;
@@ -183,7 +183,7 @@ static int queue_lf_enq(queue_t q_int, odp_buffer_hdr_t *buf_hdr)
 	return -1;
 }
 
-static int queue_lf_enq_multi(queue_t q_int, odp_buffer_hdr_t **buf_hdr,
+static int queue_lf_enq_multi(void *q_int, odp_buffer_hdr_t **buf_hdr,
 			      int num)
 {
 	(void)num;
@@ -194,7 +194,7 @@ static int queue_lf_enq_multi(queue_t q_int, odp_buffer_hdr_t **buf_hdr,
 	return 0;
 }
 
-static odp_buffer_hdr_t *queue_lf_deq(queue_t q_int)
+static odp_buffer_hdr_t *queue_lf_deq(void *q_int)
 {
 	queue_entry_t *queue;
 	queue_lf_t *queue_lf;
@@ -243,7 +243,7 @@ static odp_buffer_hdr_t *queue_lf_deq(queue_t q_int)
 	return NULL;
 }
 
-static int queue_lf_deq_multi(queue_t q_int, odp_buffer_hdr_t **buf_hdr,
+static int queue_lf_deq_multi(void *q_int, odp_buffer_hdr_t **buf_hdr,
 			      int num)
 {
 	odp_buffer_hdr_t *buf;

--- a/platform/linux-generic/odp_queue_lf.c
+++ b/platform/linux-generic/odp_queue_lf.c
@@ -144,7 +144,7 @@ static int queue_lf_enq(void *q_int, odp_buffer_hdr_t *buf_hdr)
 	ring_lf_node_t *node;
 	uint64_t counter;
 
-	queue    = qentry_from_int(q_int);
+	queue    = q_int;
 	queue_lf = queue->s.queue_lf;
 
 	i_node = 0;
@@ -204,7 +204,7 @@ static odp_buffer_hdr_t *queue_lf_deq(void *q_int)
 	ring_lf_node_t *node, *old;
 	uint64_t lowest;
 
-	queue    = qentry_from_int(q_int);
+	queue    = q_int;
 	queue_lf = queue->s.queue_lf;
 	i_node   = 0;
 

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -57,12 +57,12 @@ static inline odp_queue_t queue_from_id(uint32_t queue_id)
 	return _odp_cast_scalar(odp_queue_t, queue_id + 1);
 }
 
-static queue_t queue_from_ext(odp_queue_t handle);
-static int _queue_enq(queue_t handle, odp_buffer_hdr_t *buf_hdr);
-static odp_buffer_hdr_t *_queue_deq(queue_t handle);
-static int _queue_enq_multi(queue_t handle, odp_buffer_hdr_t *buf_hdr[],
+static void *queue_from_ext(odp_queue_t handle);
+static int _queue_enq(void *handle, odp_buffer_hdr_t *buf_hdr);
+static odp_buffer_hdr_t *_queue_deq(void *handle);
+static int _queue_enq_multi(void *handle, odp_buffer_hdr_t *buf_hdr[],
 			    int num);
-static int _queue_deq_multi(queue_t handle, odp_buffer_hdr_t *buf_hdr[],
+static int _queue_deq_multi(void *handle, odp_buffer_hdr_t *buf_hdr[],
 			    int num);
 
 static queue_entry_t *get_qentry(uint32_t queue_id)
@@ -612,7 +612,7 @@ int _odp_queue_enq_sp(sched_elem_t *q,
 	return actual;
 }
 
-static int _queue_enq_multi(queue_t handle, odp_buffer_hdr_t *buf_hdr[],
+static int _queue_enq_multi(void *handle, odp_buffer_hdr_t *buf_hdr[],
 			    int num)
 {
 	int actual;
@@ -648,7 +648,7 @@ static int _queue_enq_multi(queue_t handle, odp_buffer_hdr_t *buf_hdr[],
 	return actual;
 }
 
-static int _queue_enq(queue_t handle, odp_buffer_hdr_t *buf_hdr)
+static int _queue_enq(void *handle, odp_buffer_hdr_t *buf_hdr)
 {
 	return odp_likely(
 		_queue_enq_multi(handle, &buf_hdr, 1) == 1) ? 0 : -1;
@@ -811,7 +811,7 @@ inline int _odp_queue_deq_mc(sched_elem_t *q, odp_event_t *evp, int num)
 	return ret;
 }
 
-static int _queue_deq_multi(queue_t handle, odp_buffer_hdr_t *buf_hdr[],
+static int _queue_deq_multi(void *handle, odp_buffer_hdr_t *buf_hdr[],
 			    int num)
 {
 	sched_elem_t *q;
@@ -822,7 +822,7 @@ static int _queue_deq_multi(queue_t handle, odp_buffer_hdr_t *buf_hdr[],
 	return _odp_queue_deq(q, buf_hdr, num);
 }
 
-static odp_buffer_hdr_t *_queue_deq(queue_t handle)
+static odp_buffer_hdr_t *_queue_deq(void *handle)
 {
 	sched_elem_t *q;
 	odp_buffer_hdr_t *buf_hdr;
@@ -911,29 +911,29 @@ static uint64_t queue_to_u64(odp_queue_t hdl)
 	return _odp_pri(hdl);
 }
 
-static odp_pktout_queue_t queue_get_pktout(queue_t handle)
+static odp_pktout_queue_t queue_get_pktout(void *handle)
 {
 	return qentry_from_int(handle)->s.pktout;
 }
 
-static void queue_set_pktout(queue_t handle, odp_pktio_t pktio, int index)
+static void queue_set_pktout(void *handle, odp_pktio_t pktio, int index)
 {
 	qentry_from_int(handle)->s.pktout.pktio = pktio;
 	qentry_from_int(handle)->s.pktout.index = index;
 }
 
-static odp_pktin_queue_t queue_get_pktin(queue_t handle)
+static odp_pktin_queue_t queue_get_pktin(void *handle)
 {
 	return qentry_from_int(handle)->s.pktin;
 }
 
-static void queue_set_pktin(queue_t handle, odp_pktio_t pktio, int index)
+static void queue_set_pktin(void *handle, odp_pktio_t pktio, int index)
 {
 	qentry_from_int(handle)->s.pktin.pktio = pktio;
 	qentry_from_int(handle)->s.pktin.index = index;
 }
 
-static void queue_set_enq_deq_func(queue_t handle,
+static void queue_set_enq_deq_func(void *handle,
 				   queue_enq_fn_t enq,
 				   queue_enq_multi_fn_t enq_multi,
 				   queue_deq_fn_t deq,
@@ -952,7 +952,7 @@ static void queue_set_enq_deq_func(queue_t handle,
 		qentry_from_int(handle)->s.dequeue_multi = deq_multi;
 }
 
-static queue_t queue_from_ext(odp_queue_t handle)
+static void *queue_from_ext(odp_queue_t handle)
 {
 	uint32_t queue_id;
 
@@ -960,7 +960,7 @@ static queue_t queue_from_ext(odp_queue_t handle)
 	return qentry_to_int(get_qentry(queue_id));
 }
 
-static odp_queue_t queue_to_ext(queue_t handle)
+static odp_queue_t queue_to_ext(void *handle)
 {
 	return qentry_from_int(handle)->s.handle;
 }

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -798,7 +798,7 @@ static inline int poll_pktin(uint32_t qi, int stash)
 		return num;
 	}
 
-	q_int = queue_index_to_qint(qi);
+	q_int = qentry_from_index(qi);
 
 	ret = queue_fn->enq_multi(q_int, b_hdr, num);
 

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -638,8 +638,7 @@ static inline void ordered_stash_release(void)
 		buf_hdr = sched_local.ordered.stash[i].buf_hdr;
 		num = sched_local.ordered.stash[i].num;
 
-		num_enq = queue_fn->enq_multi(qentry_to_int(queue_entry),
-					      buf_hdr, num);
+		num_enq = queue_fn->enq_multi(queue_entry, buf_hdr, num);
 
 		/* Drop packets that were not enqueued */
 		if (odp_unlikely(num_enq < num)) {
@@ -719,7 +718,7 @@ static int schedule_ord_enq_multi(void *q_int, void *buf_hdr[],
 {
 	int i;
 	uint32_t stash_num = sched_local.ordered.stash_num;
-	queue_entry_t *dst_queue = qentry_from_int(q_int);
+	queue_entry_t *dst_queue = q_int;
 	uint32_t src_queue = sched_local.ordered.src_queue;
 
 	if ((src_queue == NULL_INDEX) || sched_local.ordered.in_order)

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -714,7 +714,7 @@ static inline int copy_from_stash(odp_event_t out_ev[], unsigned int max)
 	return i;
 }
 
-static int schedule_ord_enq_multi(queue_t q_int, void *buf_hdr[],
+static int schedule_ord_enq_multi(void *q_int, void *buf_hdr[],
 				  int num, int *ret)
 {
 	int i;
@@ -766,7 +766,7 @@ static inline int poll_pktin(uint32_t qi, int stash)
 	odp_buffer_hdr_t *b_hdr[MAX_DEQ];
 	int pktio_index, pktin_index, num, num_pktin, i;
 	int ret;
-	queue_t qint;
+	void *q_int;
 
 	pktio_index = sched->queue[qi].pktio_index;
 	pktin_index = sched->queue[qi].pktin_index;
@@ -799,9 +799,9 @@ static inline int poll_pktin(uint32_t qi, int stash)
 		return num;
 	}
 
-	qint = queue_index_to_qint(qi);
+	q_int = queue_index_to_qint(qi);
 
-	ret = queue_fn->enq_multi(qint, b_hdr, num);
+	ret = queue_fn->enq_multi(q_int, b_hdr, num);
 
 	/* Drop packets that were not enqueued */
 	if (odp_unlikely(ret < num)) {

--- a/platform/linux-generic/odp_schedule_iquery.c
+++ b/platform/linux-generic/odp_schedule_iquery.c
@@ -1142,8 +1142,7 @@ static inline void ordered_stash_release(void)
 		buf_hdr = thread_local.ordered.stash[i].buf_hdr;
 		num = thread_local.ordered.stash[i].num;
 
-		num_enq = queue_fn->enq_multi(qentry_to_int(queue_entry),
-					      buf_hdr, num);
+		num_enq = queue_fn->enq_multi(queue_entry, buf_hdr, num);
 
 		if (odp_unlikely(num_enq < num)) {
 			if (odp_unlikely(num_enq < 0))
@@ -1208,7 +1207,7 @@ static int schedule_ord_enq_multi(void *q_int, void *buf_hdr[],
 {
 	int i;
 	uint32_t stash_num = thread_local.ordered.stash_num;
-	queue_entry_t *dst_queue = qentry_from_int(q_int);
+	queue_entry_t *dst_queue = q_int;
 	uint32_t src_queue = thread_local.ordered.src_queue;
 
 	if ((src_queue == NULL_INDEX) || thread_local.ordered.in_order)

--- a/platform/linux-generic/odp_schedule_iquery.c
+++ b/platform/linux-generic/odp_schedule_iquery.c
@@ -1203,7 +1203,7 @@ static inline void schedule_release_context(void)
 		schedule_release_atomic();
 }
 
-static int schedule_ord_enq_multi(queue_t q_int, void *buf_hdr[],
+static int schedule_ord_enq_multi(void *q_int, void *buf_hdr[],
 				  int num, int *ret)
 {
 	int i;

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -2006,7 +2006,7 @@ static int sched_queue(uint32_t queue_index)
 	return 0;
 }
 
-static int ord_enq_multi(queue_t handle, void *buf_hdr[], int num,
+static int ord_enq_multi(void *handle, void *buf_hdr[], int num,
 			 int *ret)
 
 {

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -414,7 +414,7 @@ static int sched_queue(uint32_t qi)
 	return 0;
 }
 
-static int ord_enq_multi(queue_t q_int, void *buf_hdr[], int num,
+static int ord_enq_multi(void *q_int, void *buf_hdr[], int num,
 			 int *ret)
 {
 	(void)q_int;

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -108,7 +108,7 @@ static odp_bool_t tm_demote_pkt_desc(tm_system_t *tm_system,
 				     tm_shaper_obj_t *timer_shaper,
 				     pkt_desc_t *demoted_pkt_desc);
 
-static int queue_tm_reenq(queue_t queue, odp_buffer_hdr_t *buf_hdr)
+static int queue_tm_reenq(void *queue, odp_buffer_hdr_t *buf_hdr)
 {
 	odp_tm_queue_t tm_queue = MAKE_ODP_TM_QUEUE((uint8_t *)queue -
 						    offsetof(tm_queue_obj_t,
@@ -118,7 +118,7 @@ static int queue_tm_reenq(queue_t queue, odp_buffer_hdr_t *buf_hdr)
 	return odp_tm_enq(tm_queue, pkt);
 }
 
-static int queue_tm_reenq_multi(queue_t queue ODP_UNUSED,
+static int queue_tm_reenq_multi(void *queue ODP_UNUSED,
 				odp_buffer_hdr_t *buf[] ODP_UNUSED,
 				int num ODP_UNUSED)
 {

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -79,7 +79,7 @@ static int loopback_recv(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 {
 	int nbr, i;
 	odp_buffer_hdr_t *hdr_tbl[QUEUE_MULTI_MAX];
-	queue_t queue;
+	void *queue;
 	odp_packet_hdr_t *pkt_hdr;
 	odp_packet_t pkt;
 	odp_time_t ts_val;
@@ -260,7 +260,7 @@ static int loopback_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 			 const odp_packet_t pkt_tbl[], int num)
 {
 	odp_buffer_hdr_t *hdr_tbl[QUEUE_MULTI_MAX];
-	queue_t queue;
+	void *queue;
 	int i;
 	int ret;
 	int nb_tx = 0;


### PR DESCRIPTION
Clean up queue handle vs qentry pointer conversions. Change both basic and scalable queues to use qentry pointer as handle. Add common inline code for queue context function.