### PR TITLE
[PATCH v2] example/l2fw_simple: increase wait time

### DIFF
--- a/example/l2fwd_simple/l2fwd_simple_run.sh
+++ b/example/l2fwd_simple/l2fwd_simple_run.sh
@@ -12,7 +12,7 @@ echo "using PCAP_IN = ${PCAP_IN}"
 ./odp_l2fwd_simple${EXEEXT} pcap:in=${PCAP_IN} pcap:out=pcapout.pcap \
 	02:00:00:00:00:01 02:00:00:00:00:02 &
 
-sleep 1
+sleep 2
 kill -s SIGINT $!
 wait $!
 STATUS=$?
@@ -32,7 +32,7 @@ rm -f pcapout.pcap
 ./odp_l2fwd_simple${EXEEXT} null:0 null:1 \
 	02:00:00:00:00:01 02:00:00:00:00:02 &
 
-sleep 1
+sleep 2
 kill -s SIGINT $!
 wait $!
 STATUS=$?


### PR DESCRIPTION
When using huge pages, the wrapper script that's used to run this test
will send a SIGINT signal too early to the signal, causing it to be
ignored by the application. This in turn causes the application to never
exit its main loop, which depends on handling this signal to set the
variable that terminates the loop.

Increasing the delay between starting the application and sending the
SIGINT signal fixes this issue.

This fixes https://bugs.linaro.org/show_bug.cgi?id=3879

Signed-off-by: Josep Puigdemont <josep.puigdemont@linaro.org>