### PR TITLE
[PATCH v1] do not use Travis deprecated image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -382,14 +382,14 @@ jobs:
                           - ./bootstrap
                           - ./configure --enable-helper-linux $CROSS
                           - make -j $(nproc)
-                - stage: "build only"
-                  env: CROSS_ARCH="arm64"
-                  compiler: gcc
-                  install: true
-                  script:
-                          - ./bootstrap
-                          - ./configure --enable-helper-linux $CROSS
-                          - make -j $(nproc)
+                #- stage: "build only"
+                #  env: CROSS_ARCH="arm64"
+                #  compiler: gcc
+                #  install: true
+                #  script:
+                #          - ./bootstrap
+                #          - ./configure --enable-helper-linux $CROSS
+                #          - make -j $(nproc)
                 - stage: test
                   compiler: gcc
                   env: CROSS_ARCH="arm64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@
 language: c
 sudo: required
 dist: trusty
-group: deprecated-2017Q2
 stages:
   - "build only"
   - test
@@ -249,6 +248,9 @@ install:
             sudo insmod ./netmap/LINUX/netmap.ko
             EXTRA_CONF="$EXTRA_CONF --with-netmap-path=`pwd`/netmap"
           fi
+
+#	Allow forwaring on virtual interfaces used for testing
+        - sudo iptables --policy FORWARD ACCEPT
 
 script:
         - ./bootstrap


### PR DESCRIPTION
I updated ubuntu locally and see  bug where tap pktio test fails. Problem with test is that Ubuntu switched default policy for forwarding rule. That leads traffic to not go thought 2 bridged tap devices.

After removing deprecated image tap test passes but I see some conflicts with arm64 toolchain installations with apt-get. I don't know if it's temporary problem with apt servers or not.  Arm64 is commented out for not and this patch is not intended to be merged. 