### PR TITLE
Implement generic crc hash 

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -159,6 +159,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_fdserver.c \
 			   odp_hash_crc32.c \
 			   odp_hash_crc32c.c \
+			   odp_hash_crc_gen.c \
 			   odp_impl.c \
 			   odp_init.c \
 			   odp_ipsec.c \

--- a/platform/linux-generic/include/odp_init_internal.h
+++ b/platform/linux-generic/include/odp_init_internal.h
@@ -83,6 +83,8 @@ int _odp_ipsec_events_term_global(void);
 
 int _odp_cpu_cycles_init_global(void);
 
+int _odp_hash_init_global(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/odp_hash_crc_gen.c
+++ b/platform/linux-generic/odp_hash_crc_gen.c
@@ -1,0 +1,222 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <string.h>
+
+#include <odp/api/hash.h>
+#include <odp/api/hints.h>
+#include <odp/api/rwlock.h>
+
+#include <odp_debug_internal.h>
+#include <odp_init_internal.h>
+
+typedef struct crc_table_t {
+	uint32_t crc[256];
+	uint32_t width;
+	uint32_t poly;
+	int      reflect;
+	odp_rwlock_t rwlock;
+
+} crc_table_t;
+
+static crc_table_t crc_table;
+
+int _odp_hash_init_global(void)
+{
+	memset(&crc_table, 0, sizeof(crc_table_t));
+
+	odp_rwlock_init(&crc_table.rwlock);
+
+	return 0;
+}
+
+/* Reflect bits in a byte */
+static inline uint8_t reflect_u8(uint8_t byte)
+{
+	uint8_t u8[8];
+
+	u8[0] = (byte & (0x1 << 7)) >> 7;
+	u8[1] = (byte & (0x1 << 6)) >> 5;
+	u8[2] = (byte & (0x1 << 5)) >> 3;
+	u8[3] = (byte & (0x1 << 4)) >> 1;
+
+	u8[4] = (byte & (0x1 << 3)) << 1;
+	u8[5] = (byte & (0x1 << 2)) << 3;
+	u8[6] = (byte & (0x1 << 1)) << 5;
+	u8[7] = (byte & 0x1) << 7;
+
+	return u8[0] | u8[1] | u8[2] | u8[3] | u8[4] | u8[5] | u8[6] | u8[7];
+}
+
+/* Reflect 32 bits */
+static inline uint32_t reflect_u32(uint32_t u32)
+{
+	uint8_t u8[4];
+
+	u8[0] = reflect_u8((u32 & 0xff000000) >> 24);
+	u8[1] = reflect_u8((u32 & 0x00ff0000) >> 16);
+	u8[2] = reflect_u8((u32 & 0x0000ff00) >> 8);
+	u8[3] = reflect_u8(u32 & 0xff);
+
+	return (u8[3] << 24) | (u8[2] << 16) | (u8[1] << 8) | u8[0];
+}
+
+/* Reflect 24 bits */
+static inline uint32_t reflect_u24(uint32_t u32)
+{
+	uint8_t u8[4];
+
+	u8[0] = reflect_u8((u32 & 0xff0000) >> 16);
+	u8[1] = reflect_u8((u32 & 0x00ff00) >> 8);
+	u8[2] = reflect_u8(u32 & 0xff);
+
+	return (u8[2] << 16) | (u8[1] << 8) | u8[0];
+}
+
+/* Reflect 16 bits */
+static inline uint32_t reflect_u16(uint32_t u32)
+{
+	uint8_t u8[4];
+
+	u8[0] = reflect_u8((u32 & 0xff00) >> 8);
+	u8[1] = reflect_u8(u32 & 0xff);
+
+	return (u8[1] << 8) | u8[0];
+}
+
+/* Generate table for a 32/24/16 bit CRCs.
+ *
+ * Based on an example in RFC 1952.
+ */
+static inline void crc_table_gen(uint32_t poly, int reflect, int width)
+{
+	uint32_t i, crc, bit, shift, msb, mask;
+
+	crc_table.width   = width;
+	crc_table.poly    = poly;
+	crc_table.reflect = reflect;
+
+	shift = width - 8;
+	mask  = 0xffffffff >> (32 - width);
+	msb   = 0x1 << (width - 1);
+
+	if (reflect) {
+		if (width == 32)
+			poly = reflect_u32(poly);
+		else if (width == 24)
+			poly = reflect_u24(poly);
+		else
+			poly = reflect_u16(poly);
+	}
+
+	for (i = 0; i < 256; i++) {
+		if (reflect) {
+			crc = i;
+
+			for (bit = 0; bit < 8; bit++) {
+				if (crc & 0x1)
+					crc = poly ^ (crc >> 1);
+				else
+					crc = crc >> 1;
+			}
+		} else {
+			crc = i << shift;
+
+			for (bit = 0; bit < 8; bit++) {
+				if (crc & msb)
+					crc = poly ^ (crc << 1);
+				else
+					crc = crc << 1;
+			}
+		}
+
+		crc_table.crc[i] = crc & mask;
+	}
+}
+
+static inline uint32_t crc_calc(const uint8_t *data, uint32_t data_len,
+				uint32_t init_val, int reflect, int width)
+{
+	uint32_t i, crc, shift;
+	uint8_t byte;
+	uint32_t mask;
+
+	shift = width - 8;
+	mask  = 0xffffffff >> (32 - width);
+
+	crc = init_val;
+
+	for (i = 0; i < data_len; i++) {
+		byte = data[i];
+
+		if (reflect) {
+			crc = crc_table.crc[(crc ^ byte) & 0xff] ^ (crc >> 8);
+		} else {
+			crc = crc_table.crc[(crc >> shift) ^ byte] ^ (crc << 8);
+			crc = crc & mask;
+		}
+	}
+
+	return crc;
+}
+
+int odp_hash_crc_gen64(const void *data_ptr, uint32_t data_len,
+		       uint64_t init_val, odp_hash_crc_param_t *crc_param,
+		       uint64_t *crc_out)
+{
+	uint32_t crc;
+	int update_table;
+	uint32_t poly = crc_param->poly;
+	uint32_t width = crc_param->width;
+	int reflect = crc_param->reflect_in;
+
+	if (odp_unlikely(crc_param->reflect_in != crc_param->reflect_out)) {
+		ODP_ERR("Odd reflection setting not supported.\n");
+		return -1;
+	}
+
+	if (odp_unlikely(width != 32 && width != 24 && width != 16)) {
+		ODP_ERR("CRC width %" PRIu32 " bits not supported.\n", width);
+		return -1;
+	}
+
+	/* TODO: fix implementation of 24 bit CRC with reflection */
+	if (odp_unlikely(width == 24 && reflect)) {
+		ODP_ERR("24 bit CRC with reflection not supported.\n");
+		return -1;
+	}
+
+	odp_rwlock_read_lock(&crc_table.rwlock);
+
+	update_table = (crc_table.width != width) ||
+		       (crc_table.poly != poly) ||
+		       (crc_table.reflect != reflect);
+
+	/* Generate CRC table if not yet generated. */
+	if (odp_unlikely(update_table)) {
+		odp_rwlock_read_unlock(&crc_table.rwlock);
+		odp_rwlock_write_lock(&crc_table.rwlock);
+
+		crc_table_gen(poly, reflect, width);
+	}
+
+	crc = crc_calc(data_ptr, data_len, init_val, reflect, width);
+
+	if (odp_unlikely(update_table))
+		odp_rwlock_write_unlock(&crc_table.rwlock);
+	else
+		odp_rwlock_read_unlock(&crc_table.rwlock);
+
+	if (crc_param->xor_out)
+		crc = crc ^ (uint32_t)crc_param->xor_out;
+
+	*crc_out = crc;
+
+	return 0;
+}

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -22,6 +22,7 @@ enum init_stage {
 	LIBCONFIG_INIT,
 	CPUMASK_INIT,
 	CPU_CYCLES_INIT,
+	HASH_INIT,
 	TIME_INIT,
 	SYSINFO_INIT,
 	ISHM_INIT,
@@ -174,6 +175,8 @@ static int term_global(enum init_stage stage)
 		}
 		/* Fall through */
 
+	case HASH_INIT:
+		/* Fall through */
 	case CPU_CYCLES_INIT:
 		/* Fall through */
 	case CPUMASK_INIT:
@@ -232,6 +235,12 @@ int odp_init_global(odp_instance_t *instance,
 		goto init_failed;
 	}
 	stage = CPU_CYCLES_INIT;
+
+	if (_odp_hash_init_global()) {
+		ODP_ERR("ODP hash init failed.\n");
+		goto init_failed;
+	}
+	stage = HASH_INIT;
 
 	if (odp_time_init_global()) {
 		ODP_ERR("ODP time init failed.\n");

--- a/test/validation/api/hash/hash.c
+++ b/test/validation/api/hash/hash.c
@@ -90,118 +90,118 @@ static const uint8_t test_data_13[] = "123456789";
 static const hash_test_vector_t crc32c_test_vector[] = {
 	{ .data = test_data_0,
 	  .len = sizeof(test_data_0),
-	  .result.u8 = {0xaa, 0x36, 0x91, 0x8a}
+	  .result.u32 = 0x8a9136aa
 	},
 	{ .data = test_data_1,
 	  .len = sizeof(test_data_1),
-	  .result.u8 = {0x43, 0xab, 0xa8, 0x62}
+	  .result.u32 = 0x62a8ab43
 	},
 	{ .data = test_data_2,
 	  .len = sizeof(test_data_2),
-	  .result.u8 = {0x4e, 0x79, 0xdd, 0x46}
+	  .result.u32 = 0x46dd794e
 	},
 	{ .data = test_data_3,
 	  .len = sizeof(test_data_3),
-	  .result.u8 = {0x5c, 0xdb, 0x3f, 0x11}
+	  .result.u32 = 0x113fdb5c
 	},
 	{ .data = test_data_4,
 	  .len = sizeof(test_data_4),
-	  .result.u8 = {0x56, 0x3a, 0x96, 0xd9}
+	  .result.u32 = 0xd9963a56
 	},
 	{ .data = test_data_5,
 	  .len = sizeof(test_data_5) - 1,
-	  .result.u8 = {0x31, 0x0a, 0xc8, 0x92}
+	  .result.u32 = 0x92c80a31
 	},
 	{ .data = test_data_6,
 	  .len = sizeof(test_data_6) - 1,
-	  .result.u8 = {0xb7, 0x21, 0x94, 0x0a}
+	  .result.u32 = 0x0a9421b7
 	},
 	{ .data = test_data_7,
 	  .len = sizeof(test_data_7) - 1,
-	  .result.u8 = {0xb3, 0x97, 0x00, 0x19}
+	  .result.u32 = 0x190097b3
 	},
 	{ .data = test_data_8,
 	  .len = sizeof(test_data_8) - 1,
-	  .result.u8 = {0x30, 0x43, 0xd0, 0xc1}
+	  .result.u32 = 0xc1d04330
 	},
 	{ .data = test_data_9,
 	  .len = sizeof(test_data_9) - 1,
-	  .result.u8 = {0x36, 0x29, 0xa2, 0xe2}
+	  .result.u32 = 0xe2a22936
 	},
 	{ .data = test_data_10,
 	  .len = sizeof(test_data_10) - 1,
-	  .result.u8 = {0xb7, 0x3f, 0x4b, 0x36}
+	  .result.u32 = 0x364b3fb7
 	},
 	{ .data = test_data_11,
 	  .len = sizeof(test_data_11) - 1,
-	  .result.u8 = {0x41, 0xf4, 0x27, 0xe6}
+	  .result.u32 = 0xe627f441
 	},
 	{ .data = test_data_12,
 	  .len = sizeof(test_data_12) - 1,
-	  .result.u8 = {0x9a, 0x05, 0xd3, 0xde}
+	  .result.u32 = 0xded3059a
 	},
 	{ .data = test_data_13,
 	  .len = sizeof(test_data_13) - 1,
-	  .result.u8 = {0x83, 0x92, 0x06, 0xe3}
+	  .result.u32 = 0xe3069283
 	}
 };
 
 static const hash_test_vector_t crc32_test_vector[] = {
 	{ .data = test_data_0,
 	  .len = sizeof(test_data_0),
-	  .result.u8 = {0xad, 0x55, 0x0a, 0x19}
+	  .result.u32 = 0x190a55ad
 	},
 	{ .data = test_data_1,
 	  .len = sizeof(test_data_1),
-	  .result.u8 = {0x0b, 0xab, 0x6c, 0xff}
+	  .result.u32 = 0xff6cab0b
 	},
 	{ .data = test_data_2,
 	  .len = sizeof(test_data_2),
-	  .result.u8 = {0x8a, 0x7e, 0x26, 0x91}
+	  .result.u32 = 0x91267e8a
 	},
 	{ .data = test_data_3,
 	  .len = sizeof(test_data_3),
-	  .result.u8 = {0x72, 0xef, 0xb0, 0x9a}
+	  .result.u32 = 0x9ab0ef72
 	},
 	{ .data = test_data_4,
 	  .len = sizeof(test_data_4),
-	  .result.u8 = {0x12, 0x74, 0xe1, 0x51}
+	  .result.u32 = 0x51e17412
 	},
 	{ .data = test_data_5,
 	  .len = sizeof(test_data_5) - 1,
-	  .result.u8 = {0x11, 0xcd, 0x82, 0xed}
+	  .result.u32 = 0xed82cd11
 	},
 	{ .data = test_data_6,
 	  .len = sizeof(test_data_6) - 1,
-	  .result.u8 = {0x50, 0x2a, 0xef, 0xae}
+	  .result.u32 = 0xaeef2a50
 	},
 	{ .data = test_data_7,
 	  .len = sizeof(test_data_7) - 1,
-	  .result.u8 = {0xe9, 0x25, 0x90, 0x51}
+	  .result.u32 = 0x519025e9
 	},
 	{ .data = test_data_8,
 	  .len = sizeof(test_data_8) - 1,
-	  .result.u8 = {0x43, 0xbe, 0xb7, 0xe8}
+	  .result.u32 = 0xe8b7be43
 	},
 	{ .data = test_data_9,
 	  .len = sizeof(test_data_9) - 1,
-	  .result.u8 = {0x6d, 0x48, 0x83, 0x9e}
+	  .result.u32 = 0x9e83486d
 	},
 	{ .data = test_data_10,
 	  .len = sizeof(test_data_10) - 1,
-	  .result.u8 = {0xc2, 0x41, 0x24, 0x35}
+	  .result.u32 = 0x352441c2
 	},
 	{ .data = test_data_11,
 	  .len = sizeof(test_data_11) - 1,
-	  .result.u8 = {0xa6, 0x6a, 0x2a, 0x31}
+	  .result.u32 = 0x312a6aa6
 	},
 	{ .data = test_data_12,
 	  .len = sizeof(test_data_12) - 1,
-	  .result.u8 = {0xcd, 0x2a, 0x91, 0xde}
+	  .result.u32 = 0xde912acd
 	},
 	{ .data = test_data_13,
 	  .len = sizeof(test_data_13) - 1,
-	  .result.u8 = {0x26, 0x39, 0xf4, 0xcb}
+	  .result.u32 = 0xcbf43926
 	}
 };
 


### PR DESCRIPTION
Implemented 32, 24 and 16 bit CRCs. Everything works except 24 bit CRCs with reflection. It's marked unsupported for now. It seems that that configuration is not very popular, so implementation can be added/fixed later on.