### PR TITLE
[PATCH v5] Single-producer/single-consumer queue

### DIFF
--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -182,6 +182,7 @@ __LIB__libodp_linux_la_SOURCES = \
 			   odp_queue_if.c \
 			   odp_queue_lf.c \
 			   odp_queue_scalable.c \
+			   odp_queue_spsc.c \
 			   odp_random.c \
 			   odp_rwlock.c \
 			   odp_rwlock_recursive.c \

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -127,6 +127,7 @@ noinst_HEADERS = \
 		  include/odp_queue_lf.h \
 		  include/odp_queue_scalable_internal.h \
 		  include/odp_ring_internal.h \
+		  include/odp_ring_spsc_internal.h \
 		  include/odp_ring_st_internal.h \
 		  include/odp_schedule_if.h \
 		  include/odp_schedule_scalable_config.h \

--- a/platform/linux-generic/include/odp_queue_internal.h
+++ b/platform/linux-generic/include/odp_queue_internal.h
@@ -23,6 +23,7 @@ extern "C" {
 #include <odp/api/ticketlock.h>
 #include <odp_config_internal.h>
 #include <odp_ring_st_internal.h>
+#include <odp_ring_spsc_internal.h>
 #include <odp_queue_lf.h>
 
 #define QUEUE_STATUS_FREE         0
@@ -33,7 +34,10 @@ extern "C" {
 
 struct queue_entry_s {
 	odp_ticketlock_t  ODP_ALIGNED_CACHE lock;
-	ring_st_t         ring_st;
+	union {
+		ring_st_t         ring_st;
+		ring_spsc_t       ring_spsc;
+	};
 	int               status;
 
 	queue_enq_fn_t       ODP_ALIGNED_CACHE enqueue;
@@ -48,6 +52,7 @@ struct queue_entry_s {
 	odp_pktin_queue_t pktin;
 	odp_pktout_queue_t pktout;
 	void             *queue_lf;
+	int               spsc;
 	char              name[ODP_QUEUE_NAME_LEN];
 };
 
@@ -90,6 +95,8 @@ static inline odp_queue_t queue_from_index(uint32_t queue_id)
 {
 	return (odp_queue_t)qentry_from_index(queue_id);
 }
+
+void queue_spsc_init(queue_entry_t *queue, uint32_t queue_size);
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/include/odp_ring_spsc_internal.h
+++ b/platform/linux-generic/include/odp_ring_spsc_internal.h
@@ -1,0 +1,124 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#ifndef ODP_RING_SPSC_INTERNAL_H_
+#define ODP_RING_SPSC_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#include <odp/api/atomic.h>
+#include <odp/api/plat/atomic_inlines.h>
+
+/* Lock-free ring for single-producer / single-consumer usage.
+ *
+ * Thread doing an operation may be different each time, but the same operation
+ * (enq- or dequeue) must not be called concurrently. The next thread may call
+ * the same operation only when it's sure that the previous thread have returned
+ * from the call, or will never return back to finish the call when interrupted
+ * during the call.
+ *
+ * Enqueue and dequeue operations can be done concurrently.
+ */
+typedef struct {
+	odp_atomic_u32_t head;
+	odp_atomic_u32_t tail;
+	uint32_t mask;
+	uint32_t *data;
+
+} ring_spsc_t;
+
+/* Initialize ring. Ring size must be a power of two. */
+static inline void ring_spsc_init(ring_spsc_t *ring, uint32_t *data,
+				  uint32_t size)
+{
+	odp_atomic_init_u32(&ring->head, 0);
+	odp_atomic_init_u32(&ring->tail, 0);
+	ring->mask = size - 1;
+	ring->data = data;
+}
+
+/* Dequeue data from the ring head. Max_num is smaller than ring size.*/
+static inline uint32_t ring_spsc_deq_multi(ring_spsc_t *ring, uint32_t data[],
+					   uint32_t max_num)
+{
+	uint32_t head, tail, mask, idx;
+	uint32_t num, i;
+
+	tail = odp_atomic_load_acq_u32(&ring->tail);
+	head = odp_atomic_load_u32(&ring->head);
+	mask = ring->mask;
+	num  = tail - head;
+
+	/* Empty */
+	if (num == 0)
+		return 0;
+
+	if (num > max_num)
+		num = max_num;
+
+	idx = head & mask;
+
+	for (i = 0; i < num; i++) {
+		data[i] = ring->data[idx];
+		idx = (idx + 1) & mask;
+	}
+
+	odp_atomic_store_rel_u32(&ring->head, head + num);
+
+	return num;
+}
+
+/* Enqueue data into the ring tail. Num_data is smaller than ring size. */
+static inline uint32_t ring_spsc_enq_multi(ring_spsc_t *ring,
+					   const uint32_t data[],
+					   uint32_t num_data)
+{
+	uint32_t head, tail, mask, size, idx;
+	uint32_t num, i;
+
+	head = odp_atomic_load_acq_u32(&ring->head);
+	tail = odp_atomic_load_u32(&ring->tail);
+	mask = ring->mask;
+	size = mask + 1;
+	num  = size - (tail - head);
+
+	/* Full */
+	if (num == 0)
+		return 0;
+
+	if (num > num_data)
+		num = num_data;
+
+	idx = tail & mask;
+
+	for (i = 0; i < num; i++) {
+		ring->data[idx] = data[i];
+		idx = (idx + 1) & mask;
+	}
+
+	odp_atomic_store_rel_u32(&ring->tail, tail + num);
+
+	return num;
+}
+
+/* Check if ring is empty */
+static inline int ring_spsc_is_empty(ring_spsc_t *ring)
+{
+	uint32_t head = odp_atomic_load_u32(&ring->head);
+	uint32_t tail = odp_atomic_load_u32(&ring->tail);
+
+	return head == tail;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/linux-generic/odp_queue_spsc.c
+++ b/platform/linux-generic/odp_queue_spsc.c
@@ -1,0 +1,131 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+#include <string.h>
+#include <stdio.h>
+
+#include <odp_queue_internal.h>
+#include <odp_pool_internal.h>
+
+#include "config.h"
+#include <odp_debug_internal.h>
+
+static inline void buffer_index_from_buf(uint32_t buffer_index[],
+					 odp_buffer_hdr_t *buf_hdr[], int num)
+{
+	int i;
+
+	for (i = 0; i < num; i++)
+		buffer_index[i] = buf_hdr[i]->index.u32;
+}
+
+static inline void buffer_index_to_buf(odp_buffer_hdr_t *buf_hdr[],
+				       uint32_t buffer_index[], int num)
+{
+	int i;
+
+	for (i = 0; i < num; i++) {
+		buf_hdr[i] = buf_hdr_from_index_u32(buffer_index[i]);
+		odp_prefetch(buf_hdr[i]);
+	}
+}
+
+static inline int spsc_enq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[],
+				 int num)
+{
+	queue_entry_t *queue;
+	ring_spsc_t *ring_spsc;
+	uint32_t buf_idx[num];
+
+	queue = q_int;
+	ring_spsc = &queue->s.ring_spsc;
+
+	buffer_index_from_buf(buf_idx, buf_hdr, num);
+
+	if (odp_unlikely(queue->s.status < QUEUE_STATUS_READY)) {
+		ODP_ERR("Bad queue status\n");
+		return -1;
+	}
+
+	return ring_spsc_enq_multi(ring_spsc, buf_idx, num);
+}
+
+static inline int spsc_deq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[],
+				 int num)
+{
+	queue_entry_t *queue;
+	int num_deq;
+	ring_spsc_t *ring_spsc;
+	uint32_t buf_idx[num];
+
+	queue = q_int;
+	ring_spsc = &queue->s.ring_spsc;
+
+	if (odp_unlikely(queue->s.status < QUEUE_STATUS_READY)) {
+		/* Bad queue, or queue has been destroyed. */
+		return -1;
+	}
+
+	num_deq = ring_spsc_deq_multi(ring_spsc, buf_idx, num);
+
+	if (num_deq == 0)
+		return 0;
+
+	buffer_index_to_buf(buf_hdr, buf_idx, num_deq);
+
+	return num_deq;
+}
+
+static int queue_spsc_enq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[],
+				int num)
+{
+	return spsc_enq_multi(q_int, buf_hdr, num);
+}
+
+static int queue_spsc_enq(void *q_int, odp_buffer_hdr_t *buf_hdr)
+{
+	int ret;
+
+	ret = spsc_enq_multi(q_int, &buf_hdr, 1);
+
+	if (ret == 1)
+		return 0;
+	else
+		return -1;
+}
+
+static int queue_spsc_deq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[],
+				int num)
+{
+	return spsc_deq_multi(q_int, buf_hdr, num);
+}
+
+static odp_buffer_hdr_t *queue_spsc_deq(void *q_int)
+{
+	odp_buffer_hdr_t *buf_hdr = NULL;
+	int ret;
+
+	ret = spsc_deq_multi(q_int, &buf_hdr, 1);
+
+	if (ret == 1)
+		return buf_hdr;
+	else
+		return NULL;
+}
+
+void queue_spsc_init(queue_entry_t *queue, uint32_t queue_size)
+{
+	uint64_t offset;
+
+	queue->s.enqueue = queue_spsc_enq;
+	queue->s.dequeue = queue_spsc_deq;
+	queue->s.enqueue_multi = queue_spsc_enq_multi;
+	queue->s.dequeue_multi = queue_spsc_deq_multi;
+
+	offset = queue->s.index * (uint64_t)queue_glb->config.max_queue_size;
+
+	ring_spsc_init(&queue->s.ring_spsc, &queue_glb->ring_data[offset],
+		       queue_size);
+}


### PR DESCRIPTION
Limitation to single thread per enq/deq operation, simplifies queue (and lock-free queue) implementation.