### PR TITLE
[PATCH v1] linux-gen: use common posix extensions header

### DIFF
--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -7,10 +7,8 @@
  */
 
 #include "config.h"
+#include <odp_posix_extensions.h>
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
 #include <stdint.h>
 #include <string.h>
 #include <malloc.h>

--- a/platform/linux-generic/pktio/ethtool_rss.c
+++ b/platform/linux-generic/pktio/ethtool_rss.c
@@ -5,10 +5,7 @@
  */
 
 #include "config.h"
-
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
+#include <odp_posix_extensions.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/platform/linux-generic/pktio/socket_common.c
+++ b/platform/linux-generic/pktio/socket_common.c
@@ -4,10 +4,7 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 #include "config.h"
-
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
+#include <odp_posix_extensions.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/platform/linux-generic/pktio/stats/ethtool_stats.c
+++ b/platform/linux-generic/pktio/stats/ethtool_stats.c
@@ -5,10 +5,8 @@
  */
 
 #include "config.h"
+#include <odp_posix_extensions.h>
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
 #include <sys/ioctl.h>
 #include <netinet/in.h>
 #include <linux/sockios.h>


### PR DESCRIPTION
odp_posix_extensions.h should be the only file to define POSIX extension levels