### PR TITLE
[PATCH v2] Configurable scheduler burst size

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -55,4 +55,15 @@ sched_basic: {
 	# uneven service level for low thread counts. Typically, optimal
 	# value is the number of threads using the scheduler.
 	prio_spread = 4
+
+	# Default burst sizes for high and low priority queues. The default
+	# and higher priority levels are considered as high. Scheduler
+	# rounds up number of requested events up to these values. In general,
+	# larger requests are not round down. So, larger bursts than these may
+	# received when requested. A large burst size improves throughput,
+	# but decreases application responsiveness to high priority events
+	# due to head of line blocking cause by a burst of low priority
+	# events.
+	burst_size_hi  = 32
+	burst_size_low = 16
 }

--- a/platform/linux-generic/Makefile.am
+++ b/platform/linux-generic/Makefile.am
@@ -123,7 +123,7 @@ noinst_HEADERS = \
 		  include/odp_pool_internal.h \
 		  include/odp_posix_extensions.h \
 		  include/odp_queue_if.h \
-		  include/odp_queue_internal.h \
+		  include/odp_queue_basic_internal.h \
 		  include/odp_queue_lf.h \
 		  include/odp_queue_scalable_internal.h \
 		  include/odp_ring_internal.h \

--- a/platform/linux-generic/include/odp_queue_basic_internal.h
+++ b/platform/linux-generic/include/odp_queue_basic_internal.h
@@ -98,6 +98,13 @@ static inline odp_queue_t queue_from_index(uint32_t queue_id)
 
 void queue_spsc_init(queue_entry_t *queue, uint32_t queue_size);
 
+/* Functions for schedulers */
+void sched_queue_destroy_finalize(uint32_t queue_index);
+void sched_queue_set_status(uint32_t queue_index, int status);
+int sched_queue_deq(uint32_t queue_index, odp_event_t ev[], int num,
+		    int update_status);
+int sched_queue_empty(uint32_t queue_index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/linux-generic/include/odp_queue_basic_internal.h
+++ b/platform/linux-generic/include/odp_queue_basic_internal.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  */
 
-#ifndef ODP_QUEUE_INTERNAL_H_
-#define ODP_QUEUE_INTERNAL_H_
+#ifndef ODP_QUEUE_BASIC_INTERNAL_H_
+#define ODP_QUEUE_BASIC_INTERNAL_H_
 
 #ifdef __cplusplus
 extern "C" {

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -82,12 +82,6 @@ int sched_cb_pktin_poll(int pktio_index, int pktin_index,
 int sched_cb_pktin_poll_old(int pktio_index, int num_queue, int index[]);
 int sched_cb_pktin_poll_one(int pktio_index, int rx_queue, odp_event_t evts[]);
 void sched_cb_pktio_stop_finalize(int pktio_index);
-odp_queue_t sched_cb_queue_handle(uint32_t queue_index);
-void sched_cb_queue_destroy_finalize(uint32_t queue_index);
-void sched_cb_queue_set_status(uint32_t queue_index, int status);
-int sched_cb_queue_deq_multi(uint32_t queue_index, odp_event_t ev[], int num,
-			     int update_status);
-int sched_cb_queue_empty(uint32_t queue_index);
 
 /* API functions */
 typedef struct {

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -357,7 +357,7 @@ static odp_queue_t queue_create(const char *name,
 	return handle;
 }
 
-void sched_cb_queue_destroy_finalize(uint32_t queue_index)
+void sched_queue_destroy_finalize(uint32_t queue_index)
 {
 	queue_entry_t *queue = qentry_from_index(queue_index);
 
@@ -370,7 +370,7 @@ void sched_cb_queue_destroy_finalize(uint32_t queue_index)
 	UNLOCK(queue);
 }
 
-void sched_cb_queue_set_status(uint32_t queue_index, int status)
+void sched_queue_set_status(uint32_t queue_index, int status)
 {
 	queue_entry_t *queue = qentry_from_index(queue_index);
 
@@ -761,8 +761,8 @@ static int queue_info(odp_queue_t handle, odp_queue_info_t *info)
 	return 0;
 }
 
-int sched_cb_queue_deq_multi(uint32_t queue_index, odp_event_t ev[],
-			     int max_num, int update_status)
+int sched_queue_deq(uint32_t queue_index, odp_event_t ev[], int max_num,
+		    int update_status)
 {
 	int num_deq;
 	ring_st_t *ring_st;
@@ -807,7 +807,7 @@ int sched_cb_queue_deq_multi(uint32_t queue_index, odp_event_t ev[],
 	return num_deq;
 }
 
-int sched_cb_queue_empty(uint32_t queue_index)
+int sched_queue_empty(uint32_t queue_index)
 {
 	queue_entry_t *queue = qentry_from_index(queue_index);
 	int ret = 0;

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -7,7 +7,7 @@
 #include "config.h"
 
 #include <odp/api/queue.h>
-#include <odp_queue_internal.h>
+#include <odp_queue_basic_internal.h>
 #include <odp_queue_if.h>
 #include <odp/api/std_types.h>
 #include <odp/api/align.h>

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -576,10 +576,9 @@ static int queue_enq(odp_queue_t handle, odp_event_t ev)
 				(odp_buffer_hdr_t *)(uintptr_t)ev);
 }
 
-static inline int deq_multi(queue_entry_t *queue, odp_buffer_hdr_t *buf_hdr[],
-			    int num, int update_status)
+static inline int plain_queue_deq(queue_entry_t *queue,
+				  odp_buffer_hdr_t *buf_hdr[], int num)
 {
-	int status_sync = sched_fn->status_sync;
 	int num_deq;
 	ring_st_t *ring_st;
 	uint32_t buf_idx[num];
@@ -589,32 +588,17 @@ static inline int deq_multi(queue_entry_t *queue, odp_buffer_hdr_t *buf_hdr[],
 	LOCK(queue);
 
 	if (odp_unlikely(queue->s.status < QUEUE_STATUS_READY)) {
-		/* Bad queue, or queue has been destroyed.
-		 * Scheduler finalizes queue destroy after this. */
+		/* Bad queue, or queue has been destroyed. */
 		UNLOCK(queue);
 		return -1;
 	}
 
 	num_deq = ring_st_deq_multi(ring_st, buf_idx, num);
 
-	if (num_deq == 0) {
-		/* Already empty queue */
-		if (update_status && queue->s.status == QUEUE_STATUS_SCHED) {
-			queue->s.status = QUEUE_STATUS_NOTSCHED;
-
-			if (status_sync)
-				sched_fn->unsched_queue(queue->s.index);
-		}
-
-		UNLOCK(queue);
-
-		return 0;
-	}
-
-	if (status_sync && queue->s.type == ODP_QUEUE_TYPE_SCHED)
-		sched_fn->save_context(queue->s.index);
-
 	UNLOCK(queue);
+
+	if (num_deq == 0)
+		return 0;
 
 	buffer_index_to_buf(buf_hdr, buf_idx, num_deq);
 
@@ -626,7 +610,7 @@ static int queue_int_deq_multi(void *q_int, odp_buffer_hdr_t *buf_hdr[],
 {
 	queue_entry_t *queue = q_int;
 
-	return deq_multi(queue, buf_hdr, num, 0);
+	return plain_queue_deq(queue, buf_hdr, num);
 }
 
 static odp_buffer_hdr_t *queue_int_deq(void *q_int)
@@ -635,7 +619,7 @@ static odp_buffer_hdr_t *queue_int_deq(void *q_int)
 	odp_buffer_hdr_t *buf_hdr = NULL;
 	int ret;
 
-	ret = deq_multi(queue, &buf_hdr, 1, 0);
+	ret = plain_queue_deq(queue, &buf_hdr, 1);
 
 	if (ret == 1)
 		return buf_hdr;
@@ -777,12 +761,50 @@ static int queue_info(odp_queue_t handle, odp_queue_info_t *info)
 	return 0;
 }
 
-int sched_cb_queue_deq_multi(uint32_t queue_index, odp_event_t ev[], int num,
-			     int update_status)
+int sched_cb_queue_deq_multi(uint32_t queue_index, odp_event_t ev[],
+			     int max_num, int update_status)
 {
-	queue_entry_t *qe = qentry_from_index(queue_index);
+	int num_deq;
+	ring_st_t *ring_st;
+	queue_entry_t *queue = qentry_from_index(queue_index);
+	int status_sync = sched_fn->status_sync;
+	uint32_t buf_idx[max_num];
 
-	return deq_multi(qe, (odp_buffer_hdr_t **)ev, num, update_status);
+	ring_st = &queue->s.ring_st;
+
+	LOCK(queue);
+
+	if (odp_unlikely(queue->s.status < QUEUE_STATUS_READY)) {
+		/* Bad queue, or queue has been destroyed.
+		 * Scheduler finalizes queue destroy after this. */
+		UNLOCK(queue);
+		return -1;
+	}
+
+	num_deq = ring_st_deq_multi(ring_st, buf_idx, max_num);
+
+	if (num_deq == 0) {
+		/* Already empty queue */
+		if (update_status && queue->s.status == QUEUE_STATUS_SCHED) {
+			queue->s.status = QUEUE_STATUS_NOTSCHED;
+
+			if (status_sync)
+				sched_fn->unsched_queue(queue->s.index);
+		}
+
+		UNLOCK(queue);
+
+		return 0;
+	}
+
+	if (status_sync && queue->s.type == ODP_QUEUE_TYPE_SCHED)
+		sched_fn->save_context(queue->s.index);
+
+	UNLOCK(queue);
+
+	buffer_index_to_buf((odp_buffer_hdr_t **)ev, buf_idx, num_deq);
+
+	return num_deq;
 }
 
 int sched_cb_queue_empty(uint32_t queue_index)

--- a/platform/linux-generic/odp_queue_lf.c
+++ b/platform/linux-generic/odp_queue_lf.c
@@ -8,7 +8,7 @@
 #include <odp/api/atomic.h>
 #include <odp/api/plat/atomic_inlines.h>
 #include <odp/api/shared_memory.h>
-#include <odp_queue_internal.h>
+#include <odp_queue_basic_internal.h>
 #include <string.h>
 #include <stdio.h>
 

--- a/platform/linux-generic/odp_queue_spsc.c
+++ b/platform/linux-generic/odp_queue_spsc.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#include <odp_queue_internal.h>
+#include <odp_queue_basic_internal.h>
 #include <odp_pool_internal.h>
 
 #include "config.h"

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -26,7 +26,7 @@
 #include <odp/api/packet_io.h>
 #include <odp_ring_internal.h>
 #include <odp_timer_internal.h>
-#include <odp_queue_internal.h>
+#include <odp_queue_basic_internal.h>
 #include <odp_libconfig_internal.h>
 
 /* Number of priority levels  */

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -363,7 +363,7 @@ static int schedule_init_global(void)
 
 static inline void queue_destroy_finalize(uint32_t qi)
 {
-	sched_cb_queue_destroy_finalize(qi);
+	sched_queue_destroy_finalize(qi);
 }
 
 static int schedule_term_global(void)
@@ -384,9 +384,7 @@ static int schedule_term_global(void)
 					odp_event_t events[1];
 					int num;
 
-					num = sched_cb_queue_deq_multi(qi,
-								       events,
-								       1, 1);
+					num = sched_queue_deq(qi, events, 1, 1);
 
 					if (num < 0)
 						queue_destroy_finalize(qi);
@@ -581,7 +579,7 @@ static void schedule_pktio_start(int pktio_index, int num_pktin,
 		ODP_ASSERT(pktin_idx[i] <= MAX_PKTIN_INDEX);
 
 		/* Start polling */
-		sched_cb_queue_set_status(qi, QUEUE_STATUS_SCHED);
+		sched_queue_set_status(qi, QUEUE_STATUS_SCHED);
 		schedule_sched_queue(qi);
 	}
 }
@@ -797,7 +795,7 @@ static inline int poll_pktin(uint32_t qi, int direct_recv,
 		num_pktin = sched->pktio[pktio_index].num_pktin;
 		odp_spinlock_unlock(&sched->pktio_lock);
 
-		sched_cb_queue_set_status(qi, QUEUE_STATUS_NOTSCHED);
+		sched_queue_set_status(qi, QUEUE_STATUS_NOTSCHED);
 
 		if (num_pktin == 0)
 			sched_cb_pktio_stop_finalize(pktio_index);
@@ -899,13 +897,12 @@ static inline int do_schedule_grp(odp_queue_t *out_queue, odp_event_t out_ev[],
 
 			pktin = queue_is_pktin(qi);
 
-			num = sched_cb_queue_deq_multi(qi, ev_tbl, max_deq,
-						       !pktin);
+			num = sched_queue_deq(qi, ev_tbl, max_deq, !pktin);
 
 			if (num < 0) {
 				/* Destroyed queue. Continue scheduling the same
 				 * priority queue. */
-				sched_cb_queue_destroy_finalize(qi);
+				sched_queue_destroy_finalize(qi);
 				continue;
 			}
 

--- a/platform/linux-generic/odp_schedule_iquery.c
+++ b/platform/linux-generic/odp_schedule_iquery.c
@@ -289,10 +289,10 @@ static int schedule_term_global(void)
 		odp_event_t events[1];
 
 		if (sched->availables[i])
-			count = sched_cb_queue_deq_multi(i, events, 1, 1);
+			count = sched_queue_deq(i, events, 1, 1);
 
 		if (count < 0)
-			sched_cb_queue_destroy_finalize(i);
+			sched_queue_destroy_finalize(i);
 		else if (count > 0)
 			ODP_ERR("Queue (%d) not empty\n", i);
 	}
@@ -1532,12 +1532,11 @@ static inline int consume_queue(int prio, unsigned int queue_index)
 	if (is_ordered_queue(queue_index))
 		max = 1;
 
-	count = sched_cb_queue_deq_multi(
-		queue_index, cache->stash, max, 1);
+	count = sched_queue_deq(queue_index, cache->stash, max, 1);
 
 	if (count < 0) {
 		DO_SCHED_UNLOCK();
-		sched_cb_queue_destroy_finalize(queue_index);
+		sched_queue_destroy_finalize(queue_index);
 		DO_SCHED_LOCK();
 		return 0;
 	}

--- a/platform/linux-generic/odp_schedule_iquery.c
+++ b/platform/linux-generic/odp_schedule_iquery.c
@@ -25,9 +25,7 @@
 #include <odp/api/packet_io.h>
 #include <odp_config_internal.h>
 #include <odp_timer_internal.h>
-
-/* Should remove this dependency */
-#include <odp_queue_internal.h>
+#include <odp_queue_basic_internal.h>
 
 /* Number of priority levels */
 #define NUM_SCHED_PRIO 8

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -228,7 +228,7 @@ static int term_global(void)
 	for (qi = 0; qi < NUM_QUEUE; qi++) {
 		if (sched_global->queue_cmd[qi].s.init) {
 			/* todo: dequeue until empty ? */
-			sched_cb_queue_destroy_finalize(qi);
+			sched_queue_destroy_finalize(qi);
 		}
 	}
 
@@ -507,7 +507,7 @@ static int schedule_multi(odp_queue_t *from, uint64_t wait,
 
 	if (sched_local.cmd) {
 		/* Continue scheduling if queue is not empty */
-		if (sched_cb_queue_empty(sched_local.cmd->s.index) == 0)
+		if (sched_queue_empty(sched_local.cmd->s.index) == 0)
 			add_tail(sched_local.cmd);
 
 		sched_local.cmd = NULL;
@@ -562,7 +562,7 @@ static int schedule_multi(odp_queue_t *from, uint64_t wait,
 		}
 
 		qi  = cmd->s.index;
-		num = sched_cb_queue_deq_multi(qi, events, 1, 1);
+		num = sched_queue_deq(qi, events, 1, 1);
 
 		if (num > 0) {
 			sched_local.cmd = cmd;
@@ -575,7 +575,7 @@ static int schedule_multi(odp_queue_t *from, uint64_t wait,
 
 		if (num < 0) {
 			/* Destroyed queue */
-			sched_cb_queue_destroy_finalize(qi);
+			sched_queue_destroy_finalize(qi);
 			continue;
 		}
 

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -20,7 +20,7 @@
 #include <odp_config_internal.h>
 #include <odp_ring_internal.h>
 #include <odp_timer_internal.h>
-#include <odp_queue_internal.h>
+#include <odp_queue_basic_internal.h>
 
 #define NUM_THREAD        ODP_THREAD_COUNT_MAX
 #define NUM_QUEUE         ODP_CONFIG_QUEUES


### PR DESCRIPTION
Add burst size configuration options for scheduler. This enables tuning application throughput vs real-time responsiveness. Patch set also enables large (larger than burst size) event requests, which improves throughput when application is prepared to receive for large number of events. In this case, event handle copy to stash is avoided, which improves performance. So, an application that calls scheduler with large max_num events can benefit from small burst size config. However, didn't change default burst sizes yet. Patch set has been tested also with burst sizes being 1.

	# Default burst sizes for high and low priority queues. The default
	# and higher priority levels are considered as high. Scheduler
	# rounds up number of requested events up to these values. In general,
	# larger requests are not round down. So, larger bursts than these may
	# received when requested. A large burst size improves throughput,
	# but decreases application responsiveness to high priority events
	# due to head of line blocking cause by a burst of low priority
	# events.
	burst_size_hi  = 32
	burst_size_low = 16