### PR TITLE
[PATCH v4] configure: add warning about --without-openssl implications

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -381,6 +381,7 @@ AC_MSG_RESULT([
 	includedir:		${includedir}
 	testdir:		${testdir}
 	WITH_ARCH:              ${WITH_ARCH}
+	with_openssl:           ${with_openssl}
 
 	cc:			${CC}
 	cc version:             ${CC_VERSION}
@@ -405,3 +406,7 @@ AC_MSG_RESULT([
 	user_guides:		${user_guides}
 	pcapng:			${have_pcapng}
 ])
+
+AS_IF([test "${with_openssl}" = "no"],
+      [AC_MSG_WARN([Strong cryptography is not available without OpenSSL])]
+      )

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -2487,7 +2487,7 @@ sub process {
 # Check the patch for a signoff:
 		if ($line =~ /^\s*signed-off-by:/i) {
 			$signoff++;
-			$in_commit_log = 0;
+			#$in_commit_log = 0;
 		}
 
 # Check if MAINTAINERS is being updated.  If so, there's probably no need to
@@ -2497,7 +2497,7 @@ sub process {
 		}
 
 # Check signature styles
-		if (!$in_header_lines &&
+		if (!$in_header_lines && $in_commit_log &&
 		    $line =~ /^(\s*)([a-z0-9_-]+by:|$signature_tags)(\s*)(.*)/i) {
 			my $space_before = $1;
 			my $sign_off = $2;


### PR DESCRIPTION
ODP now supports the --without-openssl configure option to not
use OpenSSL as part of building odp-linux. However, omitting
OpenSSL will make strong cryptographic support unavailable.

Display the OpenSSL inclusion status as part of configure
output and include a warning to be sure the user understands
this implication of omitting this support.

Signed-off-by: Bill Fischofer <bill.fischofer@linaro.org>