### PR TITLE
[PATCH v1] RFC: abi: change atomic flag type from char to int for dpdk compatibi…

### DIFF
--- a/include/odp/api/abi-default/atomic.h
+++ b/include/odp/api/abi-default/atomic.h
@@ -54,7 +54,7 @@ struct odp_atomic_u64_s {
 	uint64_t v; /**< Actual storage for the atomic variable */
 	/* Some architectures do not support lock-free operations on 64-bit
 	 * data types. We use a spin lock to ensure atomicity. */
-	char lock; /**< Spin lock (if needed) used to ensure atomic access */
+	int lock; /**< Spin lock (if needed) used to ensure atomic access */
 } ODP_ALIGNED(sizeof(uint64_t)); /* Enforce alignment! */
 
 #endif

--- a/include/odp/api/abi-default/spinlock.h
+++ b/include/odp/api/abi-default/spinlock.h
@@ -19,7 +19,7 @@ extern "C" {
 
 /** @internal */
 typedef struct odp_spinlock_s {
-	char lock;  /**< lock flag, should match odp_atomic_flag_t */
+	int lock;  /**< lock flag, should match odp_atomic_flag_t */
 } odp_spinlock_t;
 
 #ifdef __cplusplus

--- a/platform/linux-generic/include-abi/odp/api/abi/atomic.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/atomic.h
@@ -50,7 +50,7 @@ struct odp_atomic_u64_s {
 	uint64_t v; /**< Actual storage for the atomic variable */
 	/* Some architectures do not support lock-free operations on 64-bit
 	 * data types. We use a spin lock to ensure atomicity. */
-	char lock; /**< Spin lock (if needed) used to ensure atomic access */
+	int lock; /**< Spin lock (if needed) used to ensure atomic access */
 } ODP_ALIGNED(sizeof(uint64_t)); /* Enforce alignment! */
 
 #endif

--- a/platform/linux-generic/include/odp_atomic_internal.h
+++ b/platform/linux-generic/include/odp_atomic_internal.h
@@ -38,7 +38,7 @@ typedef struct ODP_ALIGNED(sizeof(void *)) {
  * @Note this is not the same as a plain boolean type.
  * _odp_atomic_flag_t is guaranteed to be able to operate on atomically.
  */
-typedef char _odp_atomic_flag_t;
+typedef int _odp_atomic_flag_t;
 
 /**
  * Memory orderings supported by ODP.
@@ -642,6 +642,7 @@ static inline int _odp_atomic_ptr_cmp_xchg_strong(
 static inline void _odp_atomic_flag_init(_odp_atomic_flag_t *flag,
 		odp_bool_t val)
 {
+	*flag = 0;
 	__atomic_clear(flag, __ATOMIC_RELAXED);
 	if (val)
 		__atomic_test_and_set(flag, __ATOMIC_RELAXED);


### PR DESCRIPTION
…lity

Change the default type definitions for _odp_atomic_flag_t and
odp_spinlock_t to be ABI compatible with those uses by DPDK.

This is an RFC for discussion purposes for now.

Signed-off-by: Bill Fischofer <bill.fischofer@linaro.org>