### PR TITLE
[PATCH API-NEXT v3] api: pktio: extend odp_pktin_queue_param_t to support per queue configuration

### DIFF
--- a/include/odp/api/spec/packet_io.h
+++ b/include/odp/api/spec/packet_io.h
@@ -149,6 +149,17 @@ typedef enum odp_pktio_op_mode_t {
 } odp_pktio_op_mode_t;
 
 /**
+ * Packet input queue parameters override
+ */
+typedef struct odp_pktin_queue_param_ovr_t {
+	/** Override for schedule group in odp_schedule_param_t
+	  *
+	  * This parameter is considered only when queue type is
+	  * ODP_QUEUE_TYPE_SCHED. */
+	odp_schedule_group_t group;
+} odp_pktin_queue_param_ovr_t;
+
+/**
  * Packet input queue parameters
  */
 typedef struct odp_pktin_queue_param_t {
@@ -203,6 +214,18 @@ typedef struct odp_pktin_queue_param_t {
 	  * value is ignored. */
 	odp_queue_param_t queue_param;
 
+	/** Queue parameters override
+	  *
+	  * When the override array is defined, the same parameter value
+	  * in 'queue_param' is ignored and these per queue parameter
+	  * values are used instead. Array elements are used in order
+	  * (i.e. the first queue gets parameters from the first array
+	  * element, etc).
+	  * Must point to an array of num_queues elements or NULL to
+	  * disable queue parameters override. The default value is
+	  * NULL.
+	  */
+	odp_pktin_queue_param_ovr_t *queue_param_ovr;
 } odp_pktin_queue_param_t;
 
 /**

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -1466,15 +1466,23 @@ int odp_pktin_queue_config(odp_pktio_t pktio,
 			odp_queue_param_t queue_param;
 			char name[ODP_QUEUE_NAME_LEN];
 			int pktio_id = odp_pktio_index(pktio);
+			odp_pktin_queue_param_ovr_t *queue_param_ovr = NULL;
+
+			if (param->queue_param_ovr)
+				queue_param_ovr = param->queue_param_ovr + i;
 
 			snprintf(name, sizeof(name), "odp-pktin-%i-%i",
 				 pktio_id, i);
 
-			if (param->classifier_enable)
+			if (param->classifier_enable) {
 				odp_queue_param_init(&queue_param);
-			else
+			} else {
 				memcpy(&queue_param, &param->queue_param,
 				       sizeof(odp_queue_param_t));
+				if (queue_param_ovr)
+					queue_param.sched.group =
+						queue_param_ovr->group;
+			}
 
 			queue_param.type = ODP_QUEUE_TYPE_PLAIN;
 


### PR DESCRIPTION
Per queue configuration enables advanced usecases where input queues of the same interface may belong to different scheduler groups or have different multithread safe modes.