### PR TITLE
[PATCH API-NEXT v4] api: timer: add timer pool capabilities

### DIFF
--- a/include/odp/api/spec/timer.h
+++ b/include/odp/api/spec/timer.h
@@ -135,6 +135,22 @@ typedef struct {
  * Timer capability
  */
 typedef struct {
+	/** Maximum number of timer pools over all clock sources
+	 *
+	 * The total number of timer pools that can be created combining
+	 * different clock sources.
+	 */
+	uint32_t max_pools_combined;
+
+	/** Maximum number of timer pools for the requested clock source */
+	uint32_t max_pools;
+
+	/** Maximum number of timers in a pool
+	 *
+	 * The value of zero means that limited only by the available
+	 * memory size for the pool. */
+	uint32_t max_timers;
+
 	/** Highest timer resolution in nanoseconds.
 	 *
 	 *  This defines the highest resolution supported by a timer.

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -1072,6 +1072,9 @@ int odp_timer_capability(odp_timer_clk_src_t clk_src,
 	int ret = 0;
 
 	if (clk_src == ODP_CLOCK_CPU) {
+		capa->max_pools_combined = MAX_TIMER_POOLS;
+		capa->max_pools = MAX_TIMER_POOLS;
+		capa->max_timers = 0;
 		capa->highest_res_ns = highest_res_ns;
 	} else {
 		ODP_ERR("ODP timer system doesn't support external clock source currently\n");


### PR DESCRIPTION
Fixes issue #659

V2:
- Changed `max_pools` from `unsigned int` to `uint32_t` (Barry & Bill)

V3:
- Renamed `common.max_pools` to `max_pools_combined` and improved related documentation

V4:
- Renamed `max_num` to `max_timers` (Petri)