### PR TITLE
[PATCH v1] abi: unify *_INVALID define values

### DIFF
--- a/include/odp/api/abi-default/classification.h
+++ b/include/odp/api/abi-default/classification.h
@@ -25,7 +25,7 @@ typedef _odp_abi_cos_t *odp_cos_t;
 typedef _odp_abi_pmr_t *odp_pmr_t;
 
 #define ODP_COS_INVALID   ((odp_cos_t)0)
-#define ODP_PMR_INVAL     ((odp_pmr_t)~0)
+#define ODP_PMR_INVAL     ((odp_pmr_t)0)
 
 #define ODP_COS_NAME_LEN  32
 

--- a/include/odp/api/abi-default/classification.h
+++ b/include/odp/api/abi-default/classification.h
@@ -24,7 +24,7 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_pmr_t;
 typedef _odp_abi_cos_t *odp_cos_t;
 typedef _odp_abi_pmr_t *odp_pmr_t;
 
-#define ODP_COS_INVALID   ((odp_cos_t)~0)
+#define ODP_COS_INVALID   ((odp_cos_t)0)
 #define ODP_PMR_INVAL     ((odp_pmr_t)~0)
 
 #define ODP_COS_NAME_LEN  32

--- a/include/odp/api/abi-default/ipsec.h
+++ b/include/odp/api/abi-default/ipsec.h
@@ -28,7 +28,7 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_ipsec_sa_t;
 
 typedef _odp_abi_ipsec_sa_t *odp_ipsec_sa_t;
 
-#define ODP_IPSEC_SA_INVALID ((odp_ipsec_sa_t)0xffffffff)
+#define ODP_IPSEC_SA_INVALID ((odp_ipsec_sa_t)0)
 
 /**
  * @}

--- a/include/odp/api/abi-default/packet.h
+++ b/include/odp/api/abi-default/packet.h
@@ -27,7 +27,7 @@ typedef _odp_abi_packet_t *odp_packet_t;
 typedef _odp_abi_packet_seg_t *odp_packet_seg_t;
 
 #define ODP_PACKET_INVALID        ((odp_packet_t)0)
-#define ODP_PACKET_SEG_INVALID    ((odp_packet_seg_t)0xffffffff)
+#define ODP_PACKET_SEG_INVALID    ((odp_packet_seg_t)0)
 #define ODP_PACKET_OFFSET_INVALID 0xffff
 
 typedef uint8_t odp_proto_l2_type_t;

--- a/include/odp/api/abi-default/pool.h
+++ b/include/odp/api/abi-default/pool.h
@@ -22,7 +22,7 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_pool_t;
 
 typedef _odp_abi_pool_t *odp_pool_t;
 
-#define ODP_POOL_INVALID   ((odp_pool_t)0xffffffff)
+#define ODP_POOL_INVALID   ((odp_pool_t)0)
 
 #define ODP_POOL_NAME_LEN  32
 

--- a/include/odp/api/abi-default/timer.h
+++ b/include/odp/api/abi-default/timer.h
@@ -41,7 +41,7 @@ typedef _odp_abi_timer_t *odp_timer_t;
 
 typedef _odp_abi_timeout_t *odp_timeout_t;
 
-#define ODP_TIMEOUT_INVALID  ((odp_timeout_t)NULL)
+#define ODP_TIMEOUT_INVALID  ((odp_timeout_t)0)
 
 /**
  * @}

--- a/include/odp/api/abi-default/timer.h
+++ b/include/odp/api/abi-default/timer.h
@@ -31,7 +31,7 @@ struct timer_pool_s; /**< Forward declaration */
 
 typedef struct timer_pool_s *odp_timer_pool_t;
 
-#define ODP_TIMER_POOL_INVALID NULL
+#define ODP_TIMER_POOL_INVALID  ((odp_timer_pool_t)0)
 
 #define ODP_TIMER_POOL_NAME_LEN  32
 

--- a/include/odp/api/abi-default/timer.h
+++ b/include/odp/api/abi-default/timer.h
@@ -37,7 +37,7 @@ typedef struct timer_pool_s *odp_timer_pool_t;
 
 typedef _odp_abi_timer_t *odp_timer_t;
 
-#define ODP_TIMER_INVALID ((odp_timer_t)0xffffffff)
+#define ODP_TIMER_INVALID ((odp_timer_t)0)
 
 typedef _odp_abi_timeout_t *odp_timeout_t;
 

--- a/platform/linux-generic/include-abi/odp/api/abi/classification.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/classification.h
@@ -27,7 +27,7 @@ typedef ODP_HANDLE_T(odp_cos_t);
 #define ODP_COS_INVALID   _odp_cast_scalar(odp_cos_t, 0)
 
 typedef ODP_HANDLE_T(odp_pmr_t);
-#define ODP_PMR_INVAL     _odp_cast_scalar(odp_pmr_t, ~0)
+#define ODP_PMR_INVAL     _odp_cast_scalar(odp_pmr_t, 0)
 
 #define ODP_COS_NAME_LEN  32
 

--- a/platform/linux-generic/include-abi/odp/api/abi/classification.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/classification.h
@@ -24,7 +24,7 @@ extern "C" {
  */
 
 typedef ODP_HANDLE_T(odp_cos_t);
-#define ODP_COS_INVALID   _odp_cast_scalar(odp_cos_t, ~0)
+#define ODP_COS_INVALID   _odp_cast_scalar(odp_cos_t, 0)
 
 typedef ODP_HANDLE_T(odp_pmr_t);
 #define ODP_PMR_INVAL     _odp_cast_scalar(odp_pmr_t, ~0)

--- a/platform/linux-generic/include-abi/odp/api/abi/ipsec.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/ipsec.h
@@ -26,7 +26,7 @@ extern "C" {
 
 typedef ODP_HANDLE_T(odp_ipsec_sa_t);
 
-#define ODP_IPSEC_SA_INVALID _odp_cast_scalar(odp_ipsec_sa_t, 0xffffffff)
+#define ODP_IPSEC_SA_INVALID _odp_cast_scalar(odp_ipsec_sa_t, 0)
 
 /**
  * @}

--- a/platform/linux-generic/include-abi/odp/api/abi/pool.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/pool.h
@@ -27,7 +27,7 @@ extern "C" {
 
 typedef ODP_HANDLE_T(odp_pool_t);
 
-#define ODP_POOL_INVALID _odp_cast_scalar(odp_pool_t, 0xffffffff)
+#define ODP_POOL_INVALID _odp_cast_scalar(odp_pool_t, 0)
 
 #define ODP_POOL_NAME_LEN  32
 

--- a/platform/linux-generic/include-abi/odp/api/abi/timer.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/timer.h
@@ -34,7 +34,7 @@ typedef struct timer_pool_s *odp_timer_pool_t;
 
 typedef ODP_HANDLE_T(odp_timer_t);
 
-#define ODP_TIMER_INVALID _odp_cast_scalar(odp_timer_t, 0xffffffff)
+#define ODP_TIMER_INVALID _odp_cast_scalar(odp_timer_t, 0)
 
 typedef ODP_HANDLE_T(odp_timeout_t);
 

--- a/platform/linux-generic/include-abi/odp/api/abi/timer.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/timer.h
@@ -38,7 +38,7 @@ typedef ODP_HANDLE_T(odp_timer_t);
 
 typedef ODP_HANDLE_T(odp_timeout_t);
 
-#define ODP_TIMEOUT_INVALID  _odp_cast_scalar(odp_timeout_t, NULL)
+#define ODP_TIMEOUT_INVALID  _odp_cast_scalar(odp_timeout_t, 0)
 
 /**
  * @}

--- a/platform/linux-generic/include-abi/odp/api/abi/timer.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/timer.h
@@ -28,7 +28,7 @@ struct timer_pool_s; /**< Forward declaration */
 
 typedef struct timer_pool_s *odp_timer_pool_t;
 
-#define ODP_TIMER_POOL_INVALID NULL
+#define ODP_TIMER_POOL_INVALID _odp_cast_scalar(odp_timer_pool_t, 0)
 
 #define ODP_TIMER_POOL_NAME_LEN  32
 

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -85,12 +85,12 @@ extern const _odp_pool_inline_offset_t   _odp_pool_inline;
 #include <odp/api/plat/strong_types.h>
 static inline uint32_t _odp_packet_seg_to_ndx(odp_packet_seg_t seg)
 {
-	return _odp_typeval(seg);
+	return _odp_typeval(seg) - 1;
 }
 
 static inline odp_packet_seg_t _odp_packet_seg_from_ndx(uint32_t ndx)
 {
-	return _odp_cast_scalar(odp_packet_seg_t, ndx);
+	return _odp_cast_scalar(odp_packet_seg_t, ndx + 1);
 }
 #endif
 

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -96,7 +96,7 @@ static inline pool_t *pool_entry(uint32_t pool_idx)
 
 static inline pool_t *pool_entry_from_hdl(odp_pool_t pool_hdl)
 {
-	return &pool_tbl->pool[_odp_typeval(pool_hdl)];
+	return &pool_tbl->pool[_odp_typeval(pool_hdl) - 1];
 }
 
 static inline odp_buffer_hdr_t *buf_hdl_to_hdr(odp_buffer_t buf)

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -38,12 +38,12 @@ static inline ipsec_sa_t *ipsec_sa_entry(uint32_t ipsec_sa_idx)
 
 static inline ipsec_sa_t *ipsec_sa_entry_from_hdl(odp_ipsec_sa_t ipsec_sa_hdl)
 {
-	return ipsec_sa_entry(_odp_typeval(ipsec_sa_hdl));
+	return ipsec_sa_entry(_odp_typeval(ipsec_sa_hdl) - 1);
 }
 
 static inline odp_ipsec_sa_t ipsec_sa_index_to_handle(uint32_t ipsec_sa_idx)
 {
-	return _odp_cast_scalar(odp_ipsec_sa_t, ipsec_sa_idx);
+	return _odp_cast_scalar(odp_ipsec_sa_t, ipsec_sa_idx + 1);
 }
 
 int _odp_ipsec_sad_init_global(void)

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -70,7 +70,7 @@ const _odp_pool_inline_offset_t ODP_ALIGNED_CACHE _odp_pool_inline = {
 
 static inline odp_pool_t pool_index_to_handle(uint32_t pool_idx)
 {
-	return _odp_cast_scalar(odp_pool_t, pool_idx);
+	return _odp_cast_scalar(odp_pool_t, pool_idx + 1);
 }
 
 static inline pool_t *pool_from_buf(odp_buffer_t buf)

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -231,7 +231,7 @@ static inline timer_pool_t *handle_to_tp(odp_timer_t hdl)
 static inline uint32_t handle_to_idx(odp_timer_t hdl,
 				     timer_pool_t *tp)
 {
-	uint32_t idx = _odp_typeval(hdl) & ((1U << INDEX_BITS) - 1U);
+	uint32_t idx = (_odp_typeval(hdl) & ((1U << INDEX_BITS) - 1U)) - 1;
 	__builtin_prefetch(&tp->tick_buf[idx], 0, 0);
 	if (odp_likely(idx < odp_atomic_load_u32(&tp->high_wm)))
 		return idx;
@@ -241,8 +241,9 @@ static inline uint32_t handle_to_idx(odp_timer_t hdl,
 static inline odp_timer_t tp_idx_to_handle(timer_pool_t *tp,
 					   uint32_t idx)
 {
-	ODP_ASSERT(idx < (1U << INDEX_BITS));
-	return _odp_cast_scalar(odp_timer_t, (tp->tp_idx << INDEX_BITS) | idx);
+	ODP_ASSERT((idx + 1) < (1U << INDEX_BITS));
+	return _odp_cast_scalar(odp_timer_t, (tp->tp_idx << INDEX_BITS) |
+				(idx + 1));
 }
 
 /* Forward declarations */


### PR DESCRIPTION
Always use zero as invalid value when base data type is defined as a pointer.