### PR TITLE
[PATCH API-NEXT v1] api: shm: remove unused ODP_SHM_NULL define

### DIFF
--- a/include/odp/api/abi-default/shared_memory.h
+++ b/include/odp/api/abi-default/shared_memory.h
@@ -21,7 +21,6 @@ typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_shm_t;
 typedef _odp_abi_shm_t *odp_shm_t;
 
 #define ODP_SHM_INVALID   ((odp_shm_t)0)
-#define ODP_SHM_NULL      ODP_SHM_INVALID
 #define ODP_SHM_NAME_LEN  32
 
 /**

--- a/include/odp/api/spec/shared_memory.h
+++ b/include/odp/api/spec/shared_memory.h
@@ -36,11 +36,6 @@ extern "C" {
  */
 
 /**
- * @def ODP_SHM_NULL
- * Synonym for buffer pool use
- */
-
-/**
  * @def ODP_SHM_NAME_LEN
  * Maximum shared memory block name length in chars including null char
  */

--- a/platform/linux-generic/include-abi/odp/api/abi/shared_memory.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/shared_memory.h
@@ -28,7 +28,6 @@ extern "C" {
 typedef ODP_HANDLE_T(odp_shm_t);
 
 #define ODP_SHM_INVALID _odp_cast_scalar(odp_shm_t, 0)
-#define ODP_SHM_NULL ODP_SHM_INVALID
 
 #define ODP_SHM_NAME_LEN 32
 


### PR DESCRIPTION
ODP_SHM_INVALID should be used instead.

Signed-off-by: Matias Elo <matias.elo@nokia.com>