### PR TITLE
[PATCH API-NEXT v1] Add packet subtype API call

### DIFF
--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -224,6 +224,19 @@ typedef enum odp_packet_chksum_status_t {
 
 } odp_packet_chksum_status_t;
 
+/**
+ * Event subtype of a packet
+ *
+ * Returns the subtype of a packet event. Subtype tells if the packet contains
+ * only basic metadata (ODP_EVENT_PACKET_BASIC) or in addition to that some
+ * specific metadata (e.g. ODP_EVENT_PACKET_CRYPTO or ODP_EVENT_PACKET_IPSEC).
+ *
+ * @param      packet   Packet handle
+ *
+ * @return Packet subtype
+ */
+odp_event_subtype_t odp_packet_subtype(odp_packet_t packet);
+
 /*
  *
  * Alloc and free

--- a/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inline_types.h
@@ -45,6 +45,7 @@ typedef struct _odp_packet_inline_offset_t {
 	uint16_t timestamp;
 	uint16_t input_flags;
 	uint16_t flags;
+	uint16_t subtype;
 
 } _odp_packet_inline_offset_t;
 

--- a/platform/linux-generic/include/odp/api/plat/packet_inlines.h
+++ b/platform/linux-generic/include/odp/api/plat/packet_inlines.h
@@ -19,6 +19,7 @@
 #include <odp/api/hints.h>
 #include <odp/api/time.h>
 #include <odp/api/abi/buffer.h>
+#include <odp/api/abi/event.h>
 
 #include <odp/api/plat/packet_inline_types.h>
 #include <odp/api/plat/pool_inline_types.h>
@@ -64,6 +65,7 @@
 	#define odp_packet_to_event __odp_packet_to_event
 	#define odp_packet_from_event_multi __odp_packet_from_event_multi
 	#define odp_packet_to_event_multi __odp_packet_to_event_multi
+	#define odp_packet_subtype __odp_packet_subtype
 #else
 	#undef _ODP_INLINE
 	#define _ODP_INLINE
@@ -353,6 +355,11 @@ _ODP_INLINE void odp_packet_to_event_multi(const odp_packet_t pkt[],
 
 	for (i = 0; i < num; i++)
 		ev[i] = odp_packet_to_event(pkt[i]);
+}
+
+_ODP_INLINE odp_event_subtype_t odp_packet_subtype(odp_packet_t pkt)
+{
+	return (odp_event_subtype_t)_odp_pkt_get(pkt, int8_t, subtype);
 }
 
 /** @endcond */

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -155,11 +155,6 @@ static inline seg_entry_t *seg_entry_last(odp_packet_hdr_t *hdr)
 	return &last->buf_hdr.seg[last_seg];
 }
 
-static inline odp_event_subtype_t packet_subtype(odp_packet_t pkt)
-{
-	return packet_hdr(pkt)->subtype;
-}
-
 static inline void packet_subtype_set(odp_packet_t pkt, int ev)
 {
 	packet_hdr(pkt)->subtype = ev;

--- a/platform/linux-generic/odp_event.c
+++ b/platform/linux-generic/odp_event.c
@@ -19,6 +19,7 @@
 
 /* Inlined API functions */
 #include <odp/api/plat/event_inlines.h>
+#include <odp/api/plat/packet_inlines.h>
 
 odp_event_subtype_t odp_event_subtype(odp_event_t event)
 {
@@ -26,7 +27,7 @@ odp_event_subtype_t odp_event_subtype(odp_event_t event)
 			ODP_EVENT_PACKET)
 		return ODP_EVENT_NO_SUBTYPE;
 
-	return packet_subtype(odp_packet_from_event(event));
+	return odp_packet_subtype(odp_packet_from_event(event));
 }
 
 odp_event_type_t odp_event_types(odp_event_t event,
@@ -36,7 +37,7 @@ odp_event_type_t odp_event_types(odp_event_t event,
 	odp_event_type_t event_type = _odp_buffer_event_type(buf);
 
 	*subtype = event_type == ODP_EVENT_PACKET ?
-			packet_subtype(odp_packet_from_event(event)) :
+			odp_packet_subtype(odp_packet_from_event(event)) :
 			ODP_EVENT_NO_SUBTYPE;
 
 	return event_type;

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -50,7 +50,8 @@ const _odp_packet_inline_offset_t ODP_ALIGNED_CACHE _odp_packet_inline = {
 	.flow_hash      = offsetof(odp_packet_hdr_t, flow_hash),
 	.timestamp      = offsetof(odp_packet_hdr_t, timestamp),
 	.input_flags    = offsetof(odp_packet_hdr_t, p.input_flags),
-	.flags          = offsetof(odp_packet_hdr_t, p.flags)
+	.flags          = offsetof(odp_packet_hdr_t, p.flags),
+	.subtype        = offsetof(odp_packet_hdr_t, subtype)
 
 };
 

--- a/platform/linux-generic/pktio/loop.c
+++ b/platform/linux-generic/pktio/loop.c
@@ -18,6 +18,7 @@
 #include <odp/api/hints.h>
 #include <odp/api/plat/byteorder_inlines.h>
 #include <odp_queue_if.h>
+#include <odp/api/plat/packet_inlines.h>
 
 #include <protocols/eth.h>
 #include <protocols/ip.h>
@@ -309,7 +310,7 @@ static int loopback_send(pktio_entry_t *pktio_entry, int index ODP_UNUSED,
 	for (i = 0; i < nb_tx; ++i) {
 		odp_ipsec_packet_result_t result;
 
-		if (packet_subtype(pkt_tbl[i]) ==
+		if (odp_packet_subtype(pkt_tbl[i]) ==
 				ODP_EVENT_PACKET_IPSEC &&
 		    pktio_entry->s.config.outbound_ipsec) {
 

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -225,6 +225,7 @@ static int alg_packet_op(odp_packet_t pkt,
 	CU_ASSERT(ODP_EVENT_PACKET ==
 		  odp_event_types(odp_packet_to_event(pkt), &subtype));
 	CU_ASSERT(ODP_EVENT_PACKET_CRYPTO == subtype);
+	CU_ASSERT(odp_packet_subtype(pkt) == ODP_EVENT_PACKET_CRYPTO);
 
 	rc = odp_crypto_result(&result, pkt);
 	if (rc < 0) {
@@ -298,6 +299,7 @@ static int alg_packet_op_enq(odp_packet_t pkt,
 	CU_ASSERT(ODP_EVENT_PACKET ==
 		  odp_event_types(odp_packet_to_event(pkt), &subtype));
 	CU_ASSERT(ODP_EVENT_PACKET_CRYPTO == subtype);
+	CU_ASSERT(odp_packet_subtype(pkt) == ODP_EVENT_PACKET_CRYPTO);
 
 	rc = odp_crypto_result(&result, pkt);
 	if (rc < 0) {

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -502,6 +502,7 @@ static int ipsec_send_in_one(const ipsec_test_part *part,
 							    pkto, &num_out,
 							    &param));
 		CU_ASSERT_EQUAL(num_out, part->out_pkt);
+		CU_ASSERT(odp_packet_subtype(*pkto) == ODP_EVENT_PACKET_IPSEC);
 	} else if (ODP_IPSEC_OP_MODE_ASYNC == suite_context.inbound_op_mode) {
 		CU_ASSERT_EQUAL(1, odp_ipsec_in_enq(&pkt, 1, &param));
 
@@ -517,6 +518,8 @@ static int ipsec_send_in_one(const ipsec_test_part *part,
 					odp_event_types(event, &subtype));
 			CU_ASSERT_EQUAL(ODP_EVENT_PACKET_IPSEC, subtype);
 			pkto[i] = odp_ipsec_packet_from_event(event);
+			CU_ASSERT(odp_packet_subtype(pkto[i]) ==
+				  ODP_EVENT_PACKET_IPSEC);
 		}
 	} else {
 		odp_queue_t queue;
@@ -555,7 +558,10 @@ static int ipsec_send_in_one(const ipsec_test_part *part,
 						subtype);
 				CU_ASSERT(!part->out[i].status.error.sa_lookup);
 
-				pkto[i++] = odp_ipsec_packet_from_event(ev);
+				pkto[i] = odp_ipsec_packet_from_event(ev);
+				CU_ASSERT(odp_packet_subtype(pkto[i]) ==
+					  ODP_EVENT_PACKET_IPSEC);
+				i++;
 				continue;
 			}
 		}
@@ -586,6 +592,8 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 							     pkto, &num_out,
 							     &param));
 		CU_ASSERT_EQUAL(num_out, part->out_pkt);
+		CU_ASSERT(odp_packet_subtype(*pkto) ==
+			  ODP_EVENT_PACKET_IPSEC);
 	} else if (ODP_IPSEC_OP_MODE_ASYNC == suite_context.outbound_op_mode) {
 		CU_ASSERT_EQUAL(1, odp_ipsec_out_enq(&pkt, 1, &param));
 
@@ -601,6 +609,8 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 					odp_event_types(event, &subtype));
 			CU_ASSERT_EQUAL(ODP_EVENT_PACKET_IPSEC, subtype);
 			pkto[i] = odp_ipsec_packet_from_event(event);
+			CU_ASSERT(odp_packet_subtype(pkto[i]) ==
+				  ODP_EVENT_PACKET_IPSEC);
 		}
 	} else {
 		struct odp_ipsec_out_inline_param_t inline_param;
@@ -657,7 +667,10 @@ static int ipsec_send_out_one(const ipsec_test_part *part,
 						subtype);
 				CU_ASSERT(part->out[i].status.error.all);
 
-				pkto[i++] = odp_ipsec_packet_from_event(ev);
+				pkto[i] = odp_ipsec_packet_from_event(ev);
+				CU_ASSERT(odp_packet_subtype(pkto[i]) ==
+					  ODP_EVENT_PACKET_IPSEC);
+				i++;
 				continue;
 			}
 		}

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -319,6 +319,7 @@ static void packet_test_alloc_free(void)
 	CU_ASSERT(odp_event_types(odp_packet_to_event(packet), &subtype) ==
 		  ODP_EVENT_PACKET);
 	CU_ASSERT(subtype == ODP_EVENT_PACKET_BASIC);
+	CU_ASSERT(odp_packet_subtype(packet) == ODP_EVENT_PACKET_BASIC);
 	CU_ASSERT(odp_packet_to_u64(packet) !=
 		  odp_packet_to_u64(ODP_PACKET_INVALID));
 
@@ -402,6 +403,8 @@ static void packet_test_alloc_free_multi(void)
 					  &subtype) ==
 			  ODP_EVENT_PACKET);
 		CU_ASSERT(subtype == ODP_EVENT_PACKET_BASIC);
+		CU_ASSERT(odp_packet_subtype(packet[i]) ==
+			  ODP_EVENT_PACKET_BASIC);
 		CU_ASSERT(odp_packet_to_u64(packet[i]) !=
 			  odp_packet_to_u64(ODP_PACKET_INVALID));
 


### PR DESCRIPTION
Enables checking packet subtype with packet handle. Useful when event handle is not available any more.