### PR TITLE
[PATCH API-NEXT v2] api: classifier: rename ODP_PMR_INVAL to ODP_PMR_INVALID

### DIFF
--- a/example/classifier/odp_classifier.c
+++ b/example/classifier/odp_classifier.c
@@ -454,7 +454,7 @@ static void configure_cos(odp_cos_t default_cos, appl_args_t *args)
 
 		stats->pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos,
 						stats->cos);
-		if (stats->pmr == ODP_PMR_INVAL) {
+		if (stats->pmr == ODP_PMR_INVALID) {
 			EXAMPLE_ERR("odp_pktio_pmr_cos failed");
 			exit(EXIT_FAILURE);
 		}

--- a/include/odp/api/abi-default/classification.h
+++ b/include/odp/api/abi-default/classification.h
@@ -11,6 +11,8 @@
 extern "C" {
 #endif
 
+#include <odp/api/deprecated.h>
+
 /** @internal Dummy type for strong typing */
 typedef struct { char dummy; /**< @internal Dummy */ } _odp_abi_cos_t;
 
@@ -25,7 +27,15 @@ typedef _odp_abi_cos_t *odp_cos_t;
 typedef _odp_abi_pmr_t *odp_pmr_t;
 
 #define ODP_COS_INVALID   ((odp_cos_t)~0)
-#define ODP_PMR_INVAL     ((odp_pmr_t)~0)
+#define ODP_PMR_INVALID   ((odp_pmr_t)~0)
+
+#if ODP_DEPRECATED_API
+#define ODP_PMR_INVAL     ODP_PMR_INVALID
+#else
+/* Required to prevent Doxygen warning */
+#define ODP_PMR_INVAL
+#undef ODP_PMR_INVAL
+#endif
 
 #define ODP_COS_NAME_LEN  32
 

--- a/include/odp/api/spec/classification.h
+++ b/include/odp/api/spec/classification.h
@@ -44,10 +44,15 @@ extern "C" {
  */
 
 /**
- * @def ODP_PMR_INVAL
+ * @def ODP_PMR_INVALID
  * Invalid odp_pmr_t value.
  * This value is returned from odp_cls_pmr_create()
  * function on failure.
+ */
+
+/**
+ * @def ODP_PMR_INVAL
+ * @deprecated Use ODP_PMR_INVALID instead
  */
 
 /**
@@ -558,7 +563,7 @@ void odp_cls_pmr_param_init(odp_pmr_param_t *param);
  * @param dst_cos      destination CoS handle
  *
  * @return Handle to the Packet Match Rule.
- * @retval ODP_PMR_INVAL on failure
+ * @retval ODP_PMR_INVALID on failure
  */
 odp_pmr_t odp_cls_pmr_create(const odp_pmr_param_t *terms, int num_terms,
 			     odp_cos_t src_cos, odp_cos_t dst_cos);

--- a/platform/linux-generic/include-abi/odp/api/abi/classification.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/classification.h
@@ -18,6 +18,7 @@ extern "C" {
 #endif
 
 #include <odp/api/plat/strong_types.h>
+#include <odp/api/deprecated.h>
 
 /** @ingroup odp_classification
  *  @{
@@ -27,7 +28,15 @@ typedef ODP_HANDLE_T(odp_cos_t);
 #define ODP_COS_INVALID   _odp_cast_scalar(odp_cos_t, ~0)
 
 typedef ODP_HANDLE_T(odp_pmr_t);
-#define ODP_PMR_INVAL     _odp_cast_scalar(odp_pmr_t, ~0)
+#define ODP_PMR_INVALID   _odp_cast_scalar(odp_pmr_t, ~0)
+
+#if ODP_DEPRECATED_API
+#define ODP_PMR_INVAL     ODP_PMR_INVALID
+#else
+/* Required to prevent Doxygen warning */
+#define ODP_PMR_INVAL
+#undef ODP_PMR_INVAL
+#endif
 
 #define ODP_COS_NAME_LEN  32
 

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -313,7 +313,7 @@ odp_pmr_t alloc_pmr(pmr_t **pmr)
 		UNLOCK(&pmr_tbl->pmr[i].s.lock);
 	}
 	ODP_ERR("CLS_PMR_MAX_ENTRY reached");
-	return ODP_PMR_INVAL;
+	return ODP_PMR_INVALID;
 }
 
 static
@@ -331,7 +331,7 @@ static
 pmr_t *get_pmr_entry(odp_pmr_t pmr_id)
 {
 	if (_odp_typeval(pmr_id) >= CLS_PMR_MAX_ENTRY ||
-	    pmr_id == ODP_PMR_INVAL)
+	    pmr_id == ODP_PMR_INVALID)
 		return NULL;
 	if (pmr_tbl->pmr[_odp_typeval(pmr_id)].s.valid == 0)
 		return NULL;
@@ -676,20 +676,20 @@ odp_pmr_t odp_cls_pmr_create(const odp_pmr_param_t *terms, int num_terms,
 
 	if (NULL == cos_src || NULL == cos_dst) {
 		ODP_ERR("Invalid input handle");
-		return ODP_PMR_INVAL;
+		return ODP_PMR_INVALID;
 	}
 
 	if (num_terms > CLS_PMRTERM_MAX) {
 		ODP_ERR("no of terms greater than supported CLS_PMRTERM_MAX");
-		return ODP_PMR_INVAL;
+		return ODP_PMR_INVALID;
 	}
 
 	if (CLS_PMR_PER_COS_MAX == odp_atomic_load_u32(&cos_src->s.num_rule))
-		return ODP_PMR_INVAL;
+		return ODP_PMR_INVALID;
 
 	id = alloc_pmr(&pmr);
 	/*if alloc_pmr is successful it returns with the acquired lock*/
-	if (id == ODP_PMR_INVAL)
+	if (id == ODP_PMR_INVALID)
 		return id;
 
 	pmr->s.num_pmr = num_terms;
@@ -697,12 +697,12 @@ odp_pmr_t odp_cls_pmr_create(const odp_pmr_param_t *terms, int num_terms,
 		val_sz = terms[i].val_sz;
 		if (val_sz > CLS_PMR_TERM_BYTES_MAX) {
 			pmr->s.valid = 0;
-			return ODP_PMR_INVAL;
+			return ODP_PMR_INVALID;
 		}
 		if (0 > odp_pmr_create_term(&pmr->s.pmr_term_value[i],
 					    &terms[i])) {
 			UNLOCK(&pmr->s.lock);
-			return ODP_PMR_INVAL;
+			return ODP_PMR_INVALID;
 		}
 	}
 

--- a/test/validation/api/classification/odp_classification_basic.c
+++ b/test/validation/api/classification/odp_classification_basic.c
@@ -119,14 +119,14 @@ static void classification_test_create_pmr_match(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
-	CU_ASSERT(odp_pmr_to_u64(pmr) != odp_pmr_to_u64(ODP_PMR_INVAL));
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
+	CU_ASSERT(odp_pmr_to_u64(pmr) != odp_pmr_to_u64(ODP_PMR_INVALID));
 	/* destroy the created PMR */
 	retval = odp_cls_pmr_destroy(pmr);
 	CU_ASSERT(retval == 0);
 
 	/* destroy an INVALID PMR */
-	retval = odp_cls_pmr_destroy(ODP_PMR_INVAL);
+	retval = odp_cls_pmr_destroy(ODP_PMR_INVALID);
 	CU_ASSERT(retval < 0);
 
 	odp_queue_destroy(queue);
@@ -309,7 +309,7 @@ static void classification_test_pmr_composite_create(void)
 	pmr_composite = odp_cls_pmr_create(pmr_terms, PMR_SET_NUM,
 					   default_cos, cos);
 	CU_ASSERT(odp_pmr_to_u64(pmr_composite) !=
-		  odp_pmr_to_u64(ODP_PMR_INVAL));
+		  odp_pmr_to_u64(ODP_PMR_INVALID));
 
 	retval = odp_cls_pmr_destroy(pmr_composite);
 	CU_ASSERT(retval == 0);

--- a/test/validation/api/classification/odp_classification_test_pmr.c
+++ b/test/validation/api/classification/odp_classification_test_pmr.c
@@ -146,7 +146,7 @@ static void classification_test_pktin_classifier_flag(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	pkt = create_packet(default_pkt_info);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
@@ -241,7 +241,7 @@ static void classification_test_pmr_term_tcp_dport(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	pkt = create_packet(default_pkt_info);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
@@ -355,7 +355,7 @@ static void classification_test_pmr_term_tcp_sport(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	pkt = create_packet(default_pkt_info);
 	CU_ASSERT_FATAL(pkt != ODP_PACKET_INVALID);
@@ -468,7 +468,7 @@ static void classification_test_pmr_term_udp_dport(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	pkt_info = default_pkt_info;
 	pkt_info.udp = true;
@@ -584,7 +584,7 @@ static void classification_test_pmr_term_udp_sport(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	pkt_info = default_pkt_info;
 	pkt_info.udp = true;
@@ -698,7 +698,7 @@ static void classification_test_pmr_term_ipproto(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	pkt_info = default_pkt_info;
 	pkt_info.udp = true;
@@ -807,7 +807,7 @@ static void classification_test_pmr_term_dmac(void)
 	pmr_param.val_sz = ODPH_ETHADDR_LEN;
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	pkt_info = default_pkt_info;
 	pkt_info.udp = true;
@@ -914,7 +914,7 @@ static void classification_test_pmr_term_packet_len(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	/* create packet of payload length 1024 */
 	pkt_info = default_pkt_info;
@@ -1026,7 +1026,7 @@ static void classification_test_pmr_term_vlan_id_0(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	/* create packet of payload length 1024 */
 	pkt_info = default_pkt_info;
@@ -1139,7 +1139,7 @@ static void classification_test_pmr_term_vlan_id_x(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	/* create packet of payload length 1024 */
 	pkt_info = default_pkt_info;
@@ -1252,7 +1252,7 @@ static void classification_test_pmr_term_eth_type_0(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	pkt_info = default_pkt_info;
 	pkt_info.vlan = true;
@@ -1362,7 +1362,7 @@ static void classification_test_pmr_term_eth_type_x(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	/* create packet of payload length 1024 */
 	pkt_info = default_pkt_info;
@@ -1482,7 +1482,7 @@ static void classification_test_pmr_pool_set(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 
 	pkt_info = default_pkt_info;
 	pkt_info.udp = true;
@@ -1581,7 +1581,7 @@ static void classification_test_pmr_queue_set(void)
 	pmr_param.val_sz = sizeof(val);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT(pmr != ODP_PMR_INVAL);
+	CU_ASSERT(pmr != ODP_PMR_INVALID);
 	pkt_info = default_pkt_info;
 	pkt_info.udp = true;
 	pkt = create_packet(pkt_info);
@@ -1667,7 +1667,7 @@ static void classification_test_pmr_term_daddr(void)
 	pmr_param.val_sz = sizeof(addr);
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT_FATAL(pmr != ODP_PMR_INVAL);
+	CU_ASSERT_FATAL(pmr != ODP_PMR_INVALID);
 
 	/* packet with dst ip address matching PMR rule to be
 	received in the CoS queue*/
@@ -1777,7 +1777,7 @@ static void classification_test_pmr_term_ipv6daddr(void)
 	pmr_param.val_sz = ODPH_IPV6ADDR_LEN;
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT_FATAL(pmr != ODP_PMR_INVAL);
+	CU_ASSERT_FATAL(pmr != ODP_PMR_INVALID);
 
 	/* packet with dst ip address matching PMR rule to be
 	received in the CoS queue*/
@@ -1887,7 +1887,7 @@ static void classification_test_pmr_term_ipv6saddr(void)
 	pmr_param.val_sz = ODPH_IPV6ADDR_LEN;
 
 	pmr = odp_cls_pmr_create(&pmr_param, 1, default_cos, cos);
-	CU_ASSERT_FATAL(pmr != ODP_PMR_INVAL);
+	CU_ASSERT_FATAL(pmr != ODP_PMR_INVALID);
 
 	/* packet with dst ip address matching PMR rule to be
 	received in the CoS queue*/

--- a/test/validation/api/classification/odp_classification_tests.c
+++ b/test/validation/api/classification/odp_classification_tests.c
@@ -79,7 +79,7 @@ int classification_suite_init(void)
 		cos_list[i] = ODP_COS_INVALID;
 
 	for (i = 0; i < CLS_ENTRIES; i++)
-		pmr_list[i] = ODP_PMR_INVAL;
+		pmr_list[i] = ODP_PMR_INVALID;
 
 	for (i = 0; i < CLS_ENTRIES; i++)
 		queue_list[i] = ODP_QUEUE_INVALID;
@@ -211,7 +211,7 @@ void configure_cls_pmr_chain(void)
 	pmr_list[CLS_PMR_CHAIN_SRC] =
 	odp_cls_pmr_create(&pmr_param, 1, cos_list[CLS_DEFAULT],
 			   cos_list[CLS_PMR_CHAIN_SRC]);
-	CU_ASSERT_FATAL(pmr_list[CLS_PMR_CHAIN_SRC] != ODP_PMR_INVAL);
+	CU_ASSERT_FATAL(pmr_list[CLS_PMR_CHAIN_SRC] != ODP_PMR_INVALID);
 
 	val = CLS_PMR_CHAIN_PORT;
 	maskport = 0xffff;
@@ -223,7 +223,7 @@ void configure_cls_pmr_chain(void)
 	pmr_list[CLS_PMR_CHAIN_DST] =
 	odp_cls_pmr_create(&pmr_param, 1, cos_list[CLS_PMR_CHAIN_SRC],
 			   cos_list[CLS_PMR_CHAIN_DST]);
-	CU_ASSERT_FATAL(pmr_list[CLS_PMR_CHAIN_DST] != ODP_PMR_INVAL);
+	CU_ASSERT_FATAL(pmr_list[CLS_PMR_CHAIN_DST] != ODP_PMR_INVALID);
 }
 
 void test_cls_pmr_chain(void)
@@ -569,7 +569,7 @@ void configure_pmr_cos(void)
 	pmr_list[CLS_PMR] = odp_cls_pmr_create(&pmr_param, 1,
 					       cos_list[CLS_DEFAULT],
 					       cos_list[CLS_PMR]);
-	CU_ASSERT_FATAL(pmr_list[CLS_PMR] != ODP_PMR_INVAL);
+	CU_ASSERT_FATAL(pmr_list[CLS_PMR] != ODP_PMR_INVALID);
 }
 
 void test_pmr_cos(void)
@@ -652,7 +652,7 @@ void configure_pktio_pmr_composite(void)
 	pmr_list[CLS_PMR_SET] = odp_cls_pmr_create(pmr_params, num_terms,
 						   cos_list[CLS_DEFAULT],
 						   cos_list[CLS_PMR_SET]);
-	CU_ASSERT_FATAL(pmr_list[CLS_PMR_SET] != ODP_PMR_INVAL);
+	CU_ASSERT_FATAL(pmr_list[CLS_PMR_SET] != ODP_PMR_INVALID);
 }
 
 void test_pktio_pmr_composite_cos(void)


### PR DESCRIPTION
Deprecates ODP_PMR_INVAL.

V2:
- Removed comments from deprecated ODP_PMR_INVAL define (Petri)