### PR TITLE
[PATCH API-NEXT v3] Packet parse result API

### DIFF
--- a/include/odp/api/abi-default/packet.h
+++ b/include/odp/api/abi-default/packet.h
@@ -72,6 +72,70 @@ typedef enum {
 
 #define ODP_NUM_PACKET_COLORS 3
 
+/** Parse result flags */
+typedef struct odp_packet_parse_result_flag_t {
+	/** Flags union */
+	union {
+		/** All flags as a 64 bit word */
+		uint64_t all;
+
+		/** Flags as a bitfield struct */
+		struct {
+			/** @see odp_packet_has_error() */
+			uint64_t has_error    : 1;
+			/** @see odp_packet_has_l2_error() */
+			uint64_t has_l2_error : 1;
+			/** @see odp_packet_has_l3_error() */
+			uint64_t has_l3_error : 1;
+			/** @see odp_packet_has_l4_error() */
+			uint64_t has_l4_error : 1;
+			/** @see odp_packet_has_l2() */
+			uint64_t has_l2 : 1;
+			/** @see odp_packet_has_l3() */
+			uint64_t has_l3 : 1;
+			/** @see odp_packet_has_l4() */
+			uint64_t has_l4 : 1;
+			/** @see odp_packet_has_eth() */
+			uint64_t has_eth : 1;
+			/** @see odp_packet_has_eth_bcast() */
+			uint64_t has_eth_bcast : 1;
+			/** @see odp_packet_has_eth_mcast() */
+			uint64_t has_eth_mcast : 1;
+			/** @see odp_packet_has_jumbo() */
+			uint64_t has_jumbo : 1;
+			/** @see odp_packet_has_vlan() */
+			uint64_t has_vlan : 1;
+			/** @see odp_packet_has_vlan_qinq() */
+			uint64_t has_vlan_qinq : 1;
+			/** @see odp_packet_has_arp() */
+			uint64_t has_arp : 1;
+			/** @see odp_packet_has_ipv4() */
+			uint64_t has_ipv4 : 1;
+			/** @see odp_packet_has_ipv6() */
+			uint64_t has_ipv6 : 1;
+			/** @see odp_packet_has_ip_bcast() */
+			uint64_t has_ip_bcast : 1;
+			/** @see odp_packet_has_ip_mcast() */
+			uint64_t has_ip_mcast : 1;
+			/** @see odp_packet_has_ipfrag() */
+			uint64_t has_ipfrag : 1;
+			/** @see odp_packet_has_ipopt() */
+			uint64_t has_ipopt : 1;
+			/** @see odp_packet_has_ipsec() */
+			uint64_t has_ipsec : 1;
+			/** @see odp_packet_has_udp() */
+			uint64_t has_udp : 1;
+			/** @see odp_packet_has_tcp() */
+			uint64_t has_tcp : 1;
+			/** @see odp_packet_has_sctp() */
+			uint64_t has_sctp : 1;
+			/** @see odp_packet_has_icmp() */
+			uint64_t has_icmp : 1;
+		};
+	};
+
+} odp_packet_parse_result_flag_t;
+
 /**
  * @}
  */

--- a/include/odp/api/spec/packet.h
+++ b/include/odp/api/spec/packet.h
@@ -1428,6 +1428,62 @@ int odp_packet_parse(odp_packet_t pkt, uint32_t offset,
 int odp_packet_parse_multi(const odp_packet_t pkt[], const uint32_t offset[],
 			   int num, const odp_packet_parse_param_t *param);
 
+/** Packet parse results */
+typedef struct odp_packet_parse_result_t {
+	/** Parse result flags */
+	odp_packet_parse_result_flag_t flag;
+
+	/** @see odp_packet_len() */
+	uint32_t packet_len;
+
+	/** @see odp_packet_l2_offset() */
+	uint32_t l2_offset;
+	/** @see odp_packet_l3_offset() */
+	uint32_t l3_offset;
+	/** @see odp_packet_l4_offset() */
+	uint32_t l4_offset;
+
+	/** @see odp_packet_l3_chksum_status() */
+	odp_packet_chksum_status_t l3_chksum_status;
+	/** @see odp_packet_l4_chksum_status() */
+	odp_packet_chksum_status_t l4_chksum_status;
+
+	/** @see odp_packet_l2_type() */
+	odp_proto_l2_type_t l2_type;
+	/** @see odp_packet_l3_type() */
+	odp_proto_l3_type_t l3_type;
+	/** @see odp_packet_l4_type() */
+	odp_proto_l4_type_t l4_type;
+
+} odp_packet_parse_result_t;
+
+/**
+ * Read parse results
+ *
+ * Read out the most commonly used packet parse results. The same information is
+ * available through individual function calls, but this call may be more
+ * efficient when reading multiple results from a packet.
+ *
+ * @param      pkt     Packet handle
+ * @param[out] result  Pointer for parse result output
+ */
+void odp_packet_parse_result(odp_packet_t pkt,
+			     odp_packet_parse_result_t *result);
+
+/**
+ * Read parse results from multiple packets
+ *
+ * Otherwise same functionality as odp_packet_parse_result() but handles
+ * multiple packets.
+ *
+ * @param      pkt     Packet handle array
+ * @param[out] result  Parse result array for output
+ * @param      num     Number of packets and results
+ */
+void odp_packet_parse_result_multi(const odp_packet_t pkt[],
+				   odp_packet_parse_result_t *result[],
+				   int num);
+
 /**
  * Packet pool
  *

--- a/platform/linux-generic/include-abi/odp/api/abi/packet.h
+++ b/platform/linux-generic/include-abi/odp/api/abi/packet.h
@@ -89,6 +89,41 @@ typedef enum {
 
 #define ODP_NUM_PACKET_COLORS 3
 
+typedef struct odp_packet_parse_result_flag_t {
+	union {
+		uint64_t all;
+
+		struct {
+			uint64_t has_error    : 1;
+			uint64_t has_l2_error : 1;
+			uint64_t has_l3_error : 1;
+			uint64_t has_l4_error : 1;
+			uint64_t has_l2 : 1;
+			uint64_t has_l3 : 1;
+			uint64_t has_l4 : 1;
+			uint64_t has_eth : 1;
+			uint64_t has_eth_bcast : 1;
+			uint64_t has_eth_mcast : 1;
+			uint64_t has_jumbo : 1;
+			uint64_t has_vlan : 1;
+			uint64_t has_vlan_qinq : 1;
+			uint64_t has_arp : 1;
+			uint64_t has_ipv4 : 1;
+			uint64_t has_ipv6 : 1;
+			uint64_t has_ip_bcast : 1;
+			uint64_t has_ip_mcast : 1;
+			uint64_t has_ipfrag : 1;
+			uint64_t has_ipopt : 1;
+			uint64_t has_ipsec : 1;
+			uint64_t has_udp : 1;
+			uint64_t has_tcp : 1;
+			uint64_t has_sctp : 1;
+			uint64_t has_icmp : 1;
+		};
+	};
+
+} odp_packet_parse_result_flag_t;
+
 #include <odp/api/plat/packet_inlines.h>
 
 /**

--- a/platform/linux-generic/odp_packet.c
+++ b/platform/linux-generic/odp_packet.c
@@ -2732,6 +2732,59 @@ int odp_packet_parse_multi(const odp_packet_t pkt[], const uint32_t offset[],
 	return num;
 }
 
+void odp_packet_parse_result(odp_packet_t pkt,
+			     odp_packet_parse_result_t *result)
+{
+	/* TODO: optimize to single word copy when packet header stores bits
+	 * directly into odp_packet_parse_result_flag_t */
+	result->flag.all           = 0;
+	result->flag.has_error     = odp_packet_has_error(pkt);
+	result->flag.has_l2_error  = odp_packet_has_l2_error(pkt);
+	result->flag.has_l3_error  = odp_packet_has_l3_error(pkt);
+	result->flag.has_l4_error  = odp_packet_has_l4_error(pkt);
+	result->flag.has_l2        = odp_packet_has_l2(pkt);
+	result->flag.has_l3        = odp_packet_has_l3(pkt);
+	result->flag.has_l4        = odp_packet_has_l4(pkt);
+	result->flag.has_eth       = odp_packet_has_eth(pkt);
+	result->flag.has_eth_bcast = odp_packet_has_eth_bcast(pkt);
+	result->flag.has_eth_mcast = odp_packet_has_eth_mcast(pkt);
+	result->flag.has_jumbo     = odp_packet_has_jumbo(pkt);
+	result->flag.has_vlan      = odp_packet_has_vlan(pkt);
+	result->flag.has_vlan_qinq = odp_packet_has_vlan_qinq(pkt);
+	result->flag.has_arp       = odp_packet_has_arp(pkt);
+	result->flag.has_ipv4      = odp_packet_has_ipv4(pkt);
+	result->flag.has_ipv6      = odp_packet_has_ipv6(pkt);
+	result->flag.has_ip_bcast  = odp_packet_has_ip_bcast(pkt);
+	result->flag.has_ip_mcast  = odp_packet_has_ip_mcast(pkt);
+	result->flag.has_ipfrag    = odp_packet_has_ipfrag(pkt);
+	result->flag.has_ipopt     = odp_packet_has_ipopt(pkt);
+	result->flag.has_ipsec     = odp_packet_has_ipsec(pkt);
+	result->flag.has_udp       = odp_packet_has_udp(pkt);
+	result->flag.has_tcp       = odp_packet_has_tcp(pkt);
+	result->flag.has_sctp      = odp_packet_has_sctp(pkt);
+	result->flag.has_icmp      = odp_packet_has_icmp(pkt);
+
+	result->packet_len       = odp_packet_len(pkt);
+	result->l2_offset        = odp_packet_l2_offset(pkt);
+	result->l3_offset        = odp_packet_l3_offset(pkt);
+	result->l4_offset        = odp_packet_l4_offset(pkt);
+	result->l3_chksum_status = odp_packet_l3_chksum_status(pkt);
+	result->l4_chksum_status = odp_packet_l4_chksum_status(pkt);
+	result->l2_type          = odp_packet_l2_type(pkt);
+	result->l3_type          = odp_packet_l3_type(pkt);
+	result->l4_type          = odp_packet_l4_type(pkt);
+}
+
+void odp_packet_parse_result_multi(const odp_packet_t pkt[],
+				   odp_packet_parse_result_t *result[],
+				   int num)
+{
+	int i;
+
+	for (i = 0; i < num; i++)
+		odp_packet_parse_result(pkt[i], result[i]);
+}
+
 uint64_t odp_packet_to_u64(odp_packet_t hdl)
 {
 	return _odp_pri(hdl);

--- a/test/validation/api/packet/packet.c
+++ b/test/validation/api/packet/packet.c
@@ -2561,10 +2561,9 @@ static int packet_parse_suite_term(void)
 }
 
 static void parse_test_alloc(odp_packet_t pkt[], const uint8_t test_packet[],
-			     uint32_t len)
+			     uint32_t len, int num_pkt)
 {
 	int ret, i;
-	int num_pkt = PARSE_TEST_NUM_PKT;
 
 	ret = odp_packet_alloc_multi(parse_test.pool, len, pkt, num_pkt);
 	CU_ASSERT_FATAL(ret == num_pkt);
@@ -2585,7 +2584,7 @@ static void parse_eth_ipv4_udp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv4_udp,
-			 sizeof(test_packet_ipv4_udp));
+			 sizeof(test_packet_ipv4_udp), num_pkt);
 
 	for (i = 0; i < num_pkt; i++) {
 		chksum_status = odp_packet_l3_chksum_status(pkt[i]);
@@ -2629,7 +2628,7 @@ static void parse_ipv4_udp(void)
 	uint32_t offset[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv4_udp,
-			 sizeof(test_packet_ipv4_udp));
+			 sizeof(test_packet_ipv4_udp), num_pkt);
 
 	for (i = 0; i < num_pkt; i++)
 		offset[i] = 14;
@@ -2665,7 +2664,7 @@ static void parse_eth_ipv4_tcp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv4_tcp,
-			 sizeof(test_packet_ipv4_tcp));
+			 sizeof(test_packet_ipv4_tcp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -2701,7 +2700,7 @@ static void parse_eth_ipv6_udp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv6_udp,
-			 sizeof(test_packet_ipv6_udp));
+			 sizeof(test_packet_ipv6_udp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -2731,7 +2730,7 @@ static void parse_eth_ipv6_tcp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv6_tcp,
-			 sizeof(test_packet_ipv6_tcp));
+			 sizeof(test_packet_ipv6_tcp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_ALL;
@@ -2761,7 +2760,7 @@ static void parse_eth_vlan_ipv4_udp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_vlan_ipv4_udp,
-			 sizeof(test_packet_vlan_ipv4_udp));
+			 sizeof(test_packet_vlan_ipv4_udp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -2792,7 +2791,7 @@ static void parse_eth_vlan_ipv6_udp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_vlan_ipv6_udp,
-			 sizeof(test_packet_vlan_ipv6_udp));
+			 sizeof(test_packet_vlan_ipv6_udp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -2829,7 +2828,7 @@ static void parse_eth_vlan_qinq_ipv4_udp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_vlan_qinq_ipv4_udp,
-			 sizeof(test_packet_vlan_qinq_ipv4_udp));
+			 sizeof(test_packet_vlan_qinq_ipv4_udp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -2861,7 +2860,7 @@ static void parse_eth_arp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_arp,
-			 sizeof(test_packet_arp));
+			 sizeof(test_packet_arp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -2893,7 +2892,7 @@ static void parse_eth_ipv4_icmp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv4_icmp,
-			 sizeof(test_packet_ipv4_icmp));
+			 sizeof(test_packet_ipv4_icmp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -2924,7 +2923,7 @@ static void parse_eth_ipv6_icmp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv6_icmp,
-			 sizeof(test_packet_ipv6_icmp));
+			 sizeof(test_packet_ipv6_icmp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -2955,7 +2954,7 @@ static void parse_eth_ipv4_sctp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv4_sctp,
-			 sizeof(test_packet_ipv4_sctp));
+			 sizeof(test_packet_ipv4_sctp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -2986,7 +2985,7 @@ static void parse_eth_ipv4_ipsec_ah(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv4_ipsec_ah,
-			 sizeof(test_packet_ipv4_ipsec_ah));
+			 sizeof(test_packet_ipv4_ipsec_ah), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -3017,7 +3016,7 @@ static void parse_eth_ipv4_ipsec_esp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv4_ipsec_esp,
-			 sizeof(test_packet_ipv4_ipsec_esp));
+			 sizeof(test_packet_ipv4_ipsec_esp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -3048,7 +3047,7 @@ static void parse_eth_ipv6_ipsec_ah(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv6_ipsec_ah,
-			 sizeof(test_packet_ipv6_ipsec_ah));
+			 sizeof(test_packet_ipv6_ipsec_ah), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -3085,7 +3084,7 @@ static void parse_eth_ipv6_ipsec_esp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv6_ipsec_esp,
-			 sizeof(test_packet_ipv6_ipsec_esp));
+			 sizeof(test_packet_ipv6_ipsec_esp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -3116,7 +3115,7 @@ static void parse_mcast_eth_ipv4_udp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_mcast_eth_ipv4_udp,
-			 sizeof(test_packet_mcast_eth_ipv4_udp));
+			 sizeof(test_packet_mcast_eth_ipv4_udp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -3150,7 +3149,7 @@ static void parse_bcast_eth_ipv4_udp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_bcast_eth_ipv4_udp,
-			 sizeof(test_packet_bcast_eth_ipv4_udp));
+			 sizeof(test_packet_bcast_eth_ipv4_udp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -3185,7 +3184,7 @@ static void parse_mcast_eth_ipv6_udp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_mcast_eth_ipv6_udp,
-			 sizeof(test_packet_mcast_eth_ipv6_udp));
+			 sizeof(test_packet_mcast_eth_ipv6_udp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -3219,7 +3218,7 @@ static void parse_eth_ipv4_udp_first_frag(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv4_udp_first_frag,
-			 sizeof(test_packet_ipv4_udp_first_frag));
+			 sizeof(test_packet_ipv4_udp_first_frag), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -3251,7 +3250,7 @@ static void parse_eth_ipv4_udp_last_frag(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv4_udp_last_frag,
-			 sizeof(test_packet_ipv4_udp_last_frag));
+			 sizeof(test_packet_ipv4_udp_last_frag), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;
@@ -3283,7 +3282,7 @@ static void parse_eth_ipv4_rr_nop_icmp(void)
 	odp_packet_t pkt[num_pkt];
 
 	parse_test_alloc(pkt, test_packet_ipv4_rr_nop_icmp,
-			 sizeof(test_packet_ipv4_rr_nop_icmp));
+			 sizeof(test_packet_ipv4_rr_nop_icmp), num_pkt);
 
 	parse.proto = ODP_PROTO_ETH;
 	parse.last_layer = ODP_PROTO_LAYER_L4;


### PR DESCRIPTION
Get most commonly used packet parse results with a single function call. May improve performance when multiple metadata fields are read, especially in ABI compat mode.