### PR TITLE
[PATCH v1] Fix ordered queue sync

### DIFF
--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -489,12 +489,15 @@ static inline int _plain_queue_enq_multi(odp_queue_t handle,
 					 odp_buffer_hdr_t *buf_hdr[], int num)
 {
 	queue_entry_t *queue;
-	int num_enq;
+	int ret, num_enq;
 	ring_st_t *ring_st;
 	uint32_t buf_idx[num];
 
 	queue = qentry_from_handle(handle);
 	ring_st = &queue->s.ring_st;
+
+	if (sched_fn->ord_enq_multi(handle, (void **)buf_hdr, num, &ret))
+		return ret;
 
 	buffer_index_from_buf(buf_idx, buf_hdr, num);
 

--- a/test/performance/odp_queue_perf.c
+++ b/test/performance/odp_queue_perf.c
@@ -110,6 +110,7 @@ static int test_queue(test_options_t *test_options)
 	odp_pool_t pool;
 	odp_event_t ev;
 	uint32_t i, j, rounds;
+	uint32_t max_size;
 	uint64_t c1, c2, diff, ops, nsec;
 	odp_time_t t1, t2;
 	uint64_t num_retry = 0;
@@ -152,9 +153,9 @@ static int test_queue(test_options_t *test_options)
 			return -1;
 		}
 
-		if (num_event > queue_capa.plain.max_size) {
-			printf("Max queue size supported %u\n",
-			       queue_capa.plain.max_size);
+		max_size = queue_capa.plain.max_size;
+		if (max_size && num_event > max_size) {
+			printf("Max queue size supported %u\n", max_size);
 			return -1;
 		}
 	} else if (nonblock == ODP_NONBLOCKING_LF) {
@@ -169,9 +170,10 @@ static int test_queue(test_options_t *test_options)
 			return -1;
 		}
 
-		if (num_event > queue_capa.plain.lockfree.max_size) {
+		max_size = queue_capa.plain.lockfree.max_size;
+		if (max_size && num_event > max_size) {
 			printf("Max lockfree queue size supported %u\n",
-			       queue_capa.plain.lockfree.max_size);
+			       max_size);
 			return -1;
 		}
 	} else if (nonblock == ODP_NONBLOCKING_WF) {
@@ -186,9 +188,10 @@ static int test_queue(test_options_t *test_options)
 			return -1;
 		}
 
-		if (num_event > queue_capa.plain.waitfree.max_size) {
+		max_size = queue_capa.plain.waitfree.max_size;
+		if (max_size && num_event > max_size) {
 			printf("Max waitfree queue size supported %u\n",
-			       queue_capa.plain.waitfree.max_size);
+			       max_size);
 			return -1;
 		}
 	} else {


### PR DESCRIPTION
Add accidentally removed callback to scheduler ordered queue enq. It's needed for all queue types. Also fix queue performance test queue size capability check.