### PR TITLE
[PATCH v1] abi: align ODP_CPUMASK_SIZE with kernel cpu_set_t

### DIFF
--- a/include/odp/api/abi-default/cpumask.h
+++ b/include/odp/api/abi-default/cpumask.h
@@ -23,8 +23,9 @@ extern "C" {
 
 #include <odp/api/std_types.h>
 #include <odp/api/align.h>
+#include <sched.h>
 
-#define ODP_CPUMASK_SIZE 1024
+#define ODP_CPUMASK_SIZE (sizeof(cpu_set_t) * 8)
 
 #define ODP_CPUMASK_STR_SIZE ((ODP_CPUMASK_SIZE + 3) / 4 + 3)
 


### PR DESCRIPTION
Depends on kernel compile configuration size of cpu
set may differ.
Fixes:
https://bugs.linaro.org/show_bug.cgi?id=3983

Reported-by: Robert Perper <rperper@litespeedtech.com>
Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>