### PR TITLE
[PATCH v1] Tell Asciidoctor where to find the images for the IPsec documentation.

### DIFF
--- a/doc/users-guide/users-guide-ipsec.adoc
+++ b/doc/users-guide/users-guide-ipsec.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 == IPsec services
 
 In addition to general cryptographic services, ODP offers offload support for


### PR DESCRIPTION
The IPsec documentation doesn't specify a value for imagesdir, but the Makefile for the images is putting them into the images folder, which means that there are broken links to the images.

Setting imagesdir fixes that.
