### PR TITLE
[PATCH v1] linux-gen: ishm: don't initialize anonymous mappings

### DIFF
--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -1508,7 +1508,6 @@ int _odp_ishm_init_global(const odp_init_t *init)
 		goto init_glob_err1;
 	}
 	ishm_tbl = addr;
-	memset(ishm_tbl, 0, sizeof(ishm_table_t));
 	ishm_tbl->dev_seq = 0;
 	ishm_tbl->odpthread_cnt = 0;
 	odp_spinlock_init(&ishm_tbl->lock);
@@ -1521,7 +1520,6 @@ int _odp_ishm_init_global(const odp_init_t *init)
 		goto init_glob_err2;
 	}
 	ishm_ftbl = addr;
-	memset(ishm_ftbl, 0, sizeof(ishm_ftable_t));
 
 	/*
 	 *reserve the address space for _ODP_ISHM_SINGLE_VA reserved blocks,


### PR DESCRIPTION
Anonymous mappings are automatically initalized to zero.
From the mmap manual: "MAP_ANONYMOUS: The mapping is not backed by any
file; its contents are initialized to zero."

Signed-off-by: Josep Puigdemont <josep.puigdemont@linaro.org>