### PR TITLE
linux-gen: ipsec: fix sliding window shifts

### DIFF
--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -701,18 +701,17 @@ int _odp_ipsec_sa_replay_update(ipsec_sa_t *ipsec_sa, uint32_t seq,
 		if (seq + IPSEC_ANTIREPLAY_WS <= max_seq) {
 			status->error.antireplay = 1;
 			return -1;
-		}
-
-		if (seq > max_seq) {
+		} else if (seq >= max_seq + IPSEC_ANTIREPLAY_WS) {
+			mask = 1;
+			max_seq = seq;
+		} else if (seq > max_seq) {
 			mask <<= seq - max_seq;
 			mask |= 1;
 			max_seq = seq;
+		} else if (mask & (1U << (max_seq - seq))) {
+			status->error.antireplay = 1;
+			return -1;
 		} else {
-			if (mask & (1U << (max_seq - seq))) {
-				status->error.antireplay = 1;
-				return -1;
-			}
-
 			mask |= (1U << (max_seq - seq));
 		}
 


### PR DESCRIPTION
If shift is greater than window bit-width, bit shift results in
undefined behaviour. Rewrite code to excplicitly set the mask in such
cases.

Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>
Fixes: https://bugs.linaro.org/show_bug.cgi?id=3999