### PR TITLE
[PATCH v1] Scheduler optimizations and clean ups

### DIFF
--- a/platform/linux-generic/include/odp_queue_basic_internal.h
+++ b/platform/linux-generic/include/odp_queue_basic_internal.h
@@ -113,7 +113,6 @@ static inline queue_entry_t *qentry_from_handle(odp_queue_t handle)
 void queue_spsc_init(queue_entry_t *queue, uint32_t queue_size);
 
 /* Functions for schedulers */
-void sched_queue_destroy_finalize(uint32_t queue_index);
 void sched_queue_set_status(uint32_t queue_index, int status);
 int sched_queue_deq(uint32_t queue_index, odp_event_t ev[], int num,
 		    int update_status);

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -402,11 +402,6 @@ static int schedule_init_global(void)
 	return 0;
 }
 
-static inline void queue_destroy_finalize(uint32_t qi)
-{
-	sched_queue_destroy_finalize(qi);
-}
-
 static int schedule_term_global(void)
 {
 	int ret = 0;
@@ -426,9 +421,6 @@ static int schedule_term_global(void)
 					int num;
 
 					num = sched_queue_deq(qi, events, 1, 1);
-
-					if (num < 0)
-						queue_destroy_finalize(qi);
 
 					if (num > 0)
 						ODP_ERR("Queue not empty\n");
@@ -944,10 +936,9 @@ static inline int do_schedule_grp(odp_queue_t *out_queue, odp_event_t out_ev[],
 
 			num = sched_queue_deq(qi, ev_tbl, max_deq, !pktin);
 
-			if (num < 0) {
+			if (odp_unlikely(num < 0)) {
 				/* Destroyed queue. Continue scheduling the same
 				 * priority queue. */
-				sched_queue_destroy_finalize(qi);
 				continue;
 			}
 

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -416,8 +416,7 @@ static int schedule_term_global(void)
 				ring_t *ring = &sched->prio_q[grp][i][j].ring;
 				uint32_t qi;
 
-				while ((qi = ring_deq(ring, ring_mask)) !=
-				       RING_EMPTY) {
+				while (ring_deq(ring, ring_mask, &qi)) {
 					odp_event_t events[1];
 					int num;
 
@@ -907,10 +906,9 @@ static inline int do_schedule_grp(odp_queue_t *out_queue, odp_event_t out_ev[],
 
 			/* Get queue index from the priority queue */
 			ring = &sched->prio_q[grp][prio][id].ring;
-			qi   = ring_deq(ring, ring_mask);
 
-			/* Priority queue empty */
-			if (qi == RING_EMPTY) {
+			if (ring_deq(ring, ring_mask, &qi) == 0) {
+				/* Priority queue empty */
 				i++;
 				id++;
 				continue;

--- a/platform/linux-generic/odp_schedule_iquery.c
+++ b/platform/linux-generic/odp_schedule_iquery.c
@@ -209,6 +209,7 @@ struct sched_thread_local {
 	 * in the same priority level.
 	 */
 	odp_rwlock_t lock;
+	int r_locked;
 	queue_index_sparse_t indexes[NUM_SCHED_PRIO];
 	sparse_bitmap_iterator_t iterators[NUM_SCHED_PRIO];
 
@@ -292,9 +293,7 @@ static int schedule_term_global(void)
 		if (sched->availables[i])
 			count = sched_queue_deq(i, events, 1, 1);
 
-		if (count < 0)
-			sched_queue_destroy_finalize(i);
-		else if (count > 0)
+		if (count > 0)
 			ODP_ERR("Queue (%d) not empty\n", i);
 	}
 
@@ -526,7 +525,14 @@ static void destroy_sched_queue(uint32_t queue_index)
 		return;
 	}
 
+	if (thread_local.r_locked)
+		odp_rwlock_read_unlock(&thread_local.lock);
+
 	__destroy_sched_queue(G, queue_index);
+
+	if (thread_local.r_locked)
+		odp_rwlock_read_lock(&thread_local.lock);
+
 	odp_rwlock_write_unlock(&G->lock);
 
 	if (sched->queues[queue_index].sync == ODP_SCHED_SYNC_ORDERED &&
@@ -613,9 +619,6 @@ static int schedule_pktio_stop(int pktio, int pktin ODP_UNUSED)
 	odp_rwlock_write_unlock(&sched->pktio_poll.lock);
 	return remains;
 }
-
-#define DO_SCHED_LOCK() odp_rwlock_read_lock(&thread_local.lock)
-#define DO_SCHED_UNLOCK() odp_rwlock_read_unlock(&thread_local.lock)
 
 static inline bool do_schedule_prio(int prio);
 
@@ -720,7 +723,9 @@ static int do_schedule(odp_queue_t *out_queue,
 	if (odp_unlikely(thread_local.pause))
 		return count;
 
-	DO_SCHED_LOCK();
+	odp_rwlock_read_lock(&thread_local.lock);
+	thread_local.r_locked = 1;
+
 	/* Schedule events */
 	for (prio = 0; prio < NUM_SCHED_PRIO; prio++) {
 		/* Round robin iterate the interested queue
@@ -732,11 +737,14 @@ static int do_schedule(odp_queue_t *out_queue,
 
 		count = pop_cache_events(out_ev, max_num);
 		assign_queue_handle(out_queue);
-		DO_SCHED_UNLOCK();
+
+		odp_rwlock_read_unlock(&thread_local.lock);
+		thread_local.r_locked = 0;
 		return count;
 	}
 
-	DO_SCHED_UNLOCK();
+	odp_rwlock_read_unlock(&thread_local.lock);
+	thread_local.r_locked = 0;
 
 	/* Poll packet input when there are no events */
 	pktio_poll_input();
@@ -1536,14 +1544,7 @@ static inline int consume_queue(int prio, unsigned int queue_index)
 
 	count = sched_queue_deq(queue_index, cache->stash, max, 1);
 
-	if (count < 0) {
-		DO_SCHED_UNLOCK();
-		sched_queue_destroy_finalize(queue_index);
-		DO_SCHED_LOCK();
-		return 0;
-	}
-
-	if (count == 0)
+	if (count <= 0)
 		return 0;
 
 	cache->top = &cache->stash[0];

--- a/platform/linux-generic/odp_schedule_iquery.c
+++ b/platform/linux-generic/odp_schedule_iquery.c
@@ -271,7 +271,7 @@ static int schedule_init_global(void)
 		ring_init(&queue->ring);
 
 		for (k = 0; k < PKTIO_RING_SIZE; k++)
-			queue->cmd_index[k] = RING_EMPTY;
+			queue->cmd_index[k] = -1;
 	}
 
 	for (i = 0; i < NUM_PKTIO_CMD; i++)
@@ -668,9 +668,8 @@ static inline void pktio_poll_input(void)
 	for (i = 0; i < PKTIO_CMD_QUEUES; i++,
 	     hash = (hash + 1) % PKTIO_CMD_QUEUES) {
 		ring = &sched->pktio_poll.queues[hash].ring;
-		index = ring_deq(ring, PKTIO_RING_MASK);
 
-		if (odp_unlikely(index == RING_EMPTY))
+		if (odp_unlikely(ring_deq(ring, PKTIO_RING_MASK, &index) == 0))
 			continue;
 
 		cmd = &sched->pktio_poll.commands[index];

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -401,9 +401,8 @@ static inline sched_cmd_t *rem_head(int group, int prio)
 	int pktio;
 
 	prio_queue = &sched_global->prio_queue[group][prio];
-	ring_idx = ring_deq(&prio_queue->ring, RING_MASK);
 
-	if (ring_idx == RING_EMPTY)
+	if (ring_deq(&prio_queue->ring, RING_MASK, &ring_idx) == 0)
 		return NULL;
 
 	pktio = index_from_ring_idx(&index, ring_idx);


### PR DESCRIPTION
Incremental optimizations and clean ups. Sched_perf test shows 4-20% improvement on some test cases, 0% on others. Improvement not visible with L2fwd as majority of cycles are on packet IO side.
 