### PR TITLE
Scheduler burst size configuration options

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.0.1"
+config_file_version = "0.1.0"
 
 # Shared memory options
 shm: {
@@ -73,14 +73,17 @@ sched_basic: {
 	# value is the number of threads using the scheduler.
 	prio_spread = 4
 
-	# Default burst sizes for high and low priority queues. The default
-	# and higher priority levels are considered as high. Scheduler
-	# rounds up number of requested events up to these values. In general,
-	# larger requests are not round down. So, larger bursts than these may
-	# received when requested. A large burst size improves throughput,
-	# but decreases application responsiveness to high priority events
-	# due to head of line blocking cause by a burst of low priority
-	# events.
-	burst_size_hi  = 32
-	burst_size_low = 16
+	# Burst size configuration per priority. The first array element
+	# represents the highest queue priority. The scheduler tries to get
+	# burst_size_default[prio] events from a queue and stashes those that
+	# cannot be passed to the application immediately. More events than the
+	# default burst size may be returned from application request, but no
+	# more than burst_size_max[prio].
+	#
+	# Large burst sizes improve throughput, but decrease application
+	# responsiveness to higher priority events due to head of line blocking
+	# caused by a burst of lower priority events.
+	burst_size_default = [ 32,  32,  32,  32,  32, 16,  8, 4]
+	burst_size_max     = [255, 255, 255, 255, 255, 16, 16, 8]
+
 }

--- a/platform/linux-generic/include/odp_libconfig_internal.h
+++ b/platform/linux-generic/include/odp_libconfig_internal.h
@@ -21,6 +21,7 @@ int _odp_libconfig_init_global(void);
 int _odp_libconfig_term_global(void);
 
 int _odp_libconfig_lookup_int(const char *path, int *value);
+int _odp_libconfig_lookup_array(const char *path, int value[], int max_num);
 
 int _odp_libconfig_lookup_ext_int(const char *base_path,
 				  const char *local_path,

--- a/platform/linux-generic/odp_libconfig.c
+++ b/platform/linux-generic/odp_libconfig.c
@@ -96,6 +96,45 @@ int _odp_libconfig_lookup_int(const char *path, int *value)
 	return  (ret_def == CONFIG_TRUE || ret_rt == CONFIG_TRUE) ? 1 : 0;
 }
 
+int _odp_libconfig_lookup_array(const char *path, int value[], int max_num)
+{
+	const config_t *config;
+	config_setting_t *setting;
+	int num, i, j;
+	int num_out = 0;
+
+	for (j = 0; j < 2; j++) {
+		if (j == 0)
+			config = &odp_global_data.libconfig_default;
+		else
+			config = &odp_global_data.libconfig_runtime;
+
+		setting = config_lookup(config, path);
+
+		/* Runtime config may not define the array, whereas
+		 * the default config has it always defined. When the array
+		 * is defined, it must be correctly formatted. */
+		if (setting == NULL)
+			continue;
+
+		if (config_setting_is_array(setting) == CONFIG_FALSE)
+			return 0;
+
+		num = config_setting_length(setting);
+
+		if (num <= 0 || num > max_num)
+			return 0;
+
+		for (i = 0; i < num; i++)
+			value[i] = config_setting_get_int_elem(setting, i);
+
+		num_out = num;
+	}
+
+	/* Number of elements copied */
+	return num_out;
+}
+
 static int lookup_int(config_t *cfg,
 		      const char *base_path,
 		      const char *local_path,

--- a/platform/linux-generic/odp_libconfig.c
+++ b/platform/linux-generic/odp_libconfig.c
@@ -40,6 +40,8 @@ int _odp_libconfig_init_global(void)
 	if (filename == NULL)
 		return 0;
 
+	ODP_PRINT("CONFIG FILE: %s\n", filename);
+
 	if (!config_read_file(config_rt, filename)) {
 		ODP_ERR("Failed to read config file: %s(%d): %s\n",
 			config_error_file(config_rt),

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -100,10 +100,9 @@ ODP_STATIC_ASSERT((8 * sizeof(pri_mask_t)) >= MAX_SPREAD,
 /* Start of named groups in group mask arrays */
 #define SCHED_GROUP_NAMED (ODP_SCHED_GROUP_CONTROL + 1)
 
-/* Default burst size. Scheduler rounds up number of requested events up to
- * this value. */
-#define BURST_SIZE_MAX  CONFIG_BURST_SIZE
-#define BURST_SIZE_MIN  1
+/* Limits for burst size configuration */
+#define BURST_MAX  255
+#define STASH_SIZE CONFIG_BURST_SIZE
 
 /* Ordered stash size */
 #define MAX_ORDERED_STASH 512
@@ -138,7 +137,7 @@ typedef struct ODP_ALIGNED_CACHE {
 		uint32_t    qi;
 		odp_queue_t queue;
 		ring_t      *ring;
-		odp_event_t ev[BURST_SIZE_MAX];
+		odp_event_t ev[STASH_SIZE];
 	} stash;
 
 	uint32_t grp_epoch;
@@ -193,8 +192,8 @@ typedef struct {
 
 	struct {
 		uint8_t num_spread;
-		uint8_t burst_hi;
-		uint8_t burst_low;
+		uint8_t burst_default[NUM_PRIO];
+		uint8_t burst_max[NUM_PRIO];
 	} config;
 
 	uint32_t       pri_count[NUM_PRIO][MAX_SPREAD];
@@ -249,6 +248,8 @@ static __thread sched_local_t sched_local;
 static int read_config_file(sched_global_t *sched)
 {
 	const char *str;
+	int i;
+	int burst_val[NUM_PRIO];
 	int val = 0;
 
 	ODP_PRINT("Scheduler config:\n");
@@ -267,33 +268,45 @@ static int read_config_file(sched_global_t *sched)
 	sched->config.num_spread = val;
 	ODP_PRINT("  %s: %i\n", str, val);
 
-	str = "sched_basic.burst_size_hi";
-	if (!_odp_libconfig_lookup_int(str, &val)) {
+	str = "sched_basic.burst_size_default";
+	if (_odp_libconfig_lookup_array(str, burst_val, NUM_PRIO) !=
+	    NUM_PRIO) {
 		ODP_ERR("Config option '%s' not found.\n", str);
 		return -1;
 	}
 
-	if (val > BURST_SIZE_MAX || val < BURST_SIZE_MIN) {
-		ODP_ERR("Bad value %s = %u\n", str, val);
-		return -1;
+	ODP_PRINT("  %s[] =", str);
+	for (i = 0; i < NUM_PRIO; i++) {
+		val = burst_val[i];
+		sched->config.burst_default[i] = val;
+		ODP_PRINT(" %3i", val);
+
+		if (val > STASH_SIZE || val < 1) {
+			ODP_ERR("Bad value %i\n", val);
+			return -1;
+		}
 	}
+	ODP_PRINT("\n");
 
-	sched->config.burst_hi = val;
-	ODP_PRINT("  %s: %i\n", str, val);
-
-	str = "sched_basic.burst_size_low";
-	if (!_odp_libconfig_lookup_int(str, &val)) {
+	str = "sched_basic.burst_size_max";
+	if (_odp_libconfig_lookup_array(str, burst_val, NUM_PRIO) !=
+	    NUM_PRIO) {
 		ODP_ERR("Config option '%s' not found.\n", str);
 		return -1;
 	}
 
-	if (val > BURST_SIZE_MAX || val < BURST_SIZE_MIN) {
-		ODP_ERR("Bad value %s = %u\n", str, val);
-		return -1;
-	}
+	ODP_PRINT("  %s[] =    ", str);
+	for (i = 0; i < NUM_PRIO; i++) {
+		val = burst_val[i];
+		sched->config.burst_max[i] = val;
+		ODP_PRINT(" %3i", val);
 
-	sched->config.burst_low = val;
-	ODP_PRINT("  %s: %i\n\n", str, val);
+		if (val > BURST_MAX || val < 1) {
+			ODP_ERR("Bad value %i\n", val);
+			return -1;
+		}
+	}
+	ODP_PRINT("\n\n");
 
 	return 0;
 }
@@ -802,7 +815,7 @@ static inline int poll_pktin(uint32_t qi, int direct_recv,
 	odp_buffer_hdr_t **hdr_tbl;
 	int ret;
 	void *q_int;
-	odp_buffer_hdr_t *b_hdr[BURST_SIZE_MAX];
+	odp_buffer_hdr_t *b_hdr[CONFIG_BURST_SIZE];
 
 	hdr_tbl = (odp_buffer_hdr_t **)ev_tbl;
 
@@ -810,8 +823,8 @@ static inline int poll_pktin(uint32_t qi, int direct_recv,
 		hdr_tbl = b_hdr;
 
 		/* Limit burst to max queue enqueue size */
-		if (max_num > BURST_SIZE_MAX)
-			max_num = BURST_SIZE_MAX;
+		if (max_num > CONFIG_BURST_SIZE)
+			max_num = CONFIG_BURST_SIZE;
 	}
 
 	pktio_index = sched->queue[qi].pktio_index;
@@ -866,7 +879,7 @@ static inline int do_schedule_grp(odp_queue_t *out_queue, odp_event_t out_ev[],
 	int ret;
 	int id;
 	uint32_t qi;
-	unsigned int max_burst;
+	uint16_t burst_def;
 	int num_spread = sched->config.num_spread;
 	uint32_t ring_mask = sched->ring_mask;
 
@@ -876,9 +889,7 @@ static inline int do_schedule_grp(odp_queue_t *out_queue, odp_event_t out_ev[],
 		if (sched->pri_mask[prio] == 0)
 			continue;
 
-		max_burst = sched->config.burst_hi;
-		if (prio > ODP_SCHED_PRIO_DEFAULT)
-			max_burst = sched->config.burst_low;
+		burst_def = sched->config.burst_default[prio];
 
 		/* Select the first ring based on weights */
 		id = first;
@@ -889,7 +900,7 @@ static inline int do_schedule_grp(odp_queue_t *out_queue, odp_event_t out_ev[],
 			odp_queue_t handle;
 			ring_t *ring;
 			int pktin;
-			unsigned int max_deq = max_burst;
+			uint16_t max_deq = burst_def;
 			int stashed = 1;
 			odp_event_t *ev_tbl = sched_local.stash.ev;
 
@@ -917,15 +928,20 @@ static inline int do_schedule_grp(odp_queue_t *out_queue, odp_event_t out_ev[],
 			sync_ctx = sched_sync_type(qi);
 			ordered  = (sync_ctx == ODP_SCHED_SYNC_ORDERED);
 
-			/* When application's array is larger than max burst
+			/* When application's array is larger than default burst
 			 * size, output all events directly there. Also, ordered
 			 * queues are not stashed locally to improve
 			 * parallelism. Ordered context can only be released
 			 * when the local cache is empty. */
-			if (max_num > max_burst || ordered) {
+			if (max_num > burst_def || ordered) {
+				uint16_t burst_max;
+
+				burst_max = sched->config.burst_max[prio];
 				stashed = 0;
 				ev_tbl  = out_ev;
 				max_deq = max_num;
+				if (max_num > burst_max)
+					max_deq = burst_max;
 			}
 
 			pktin = queue_is_pktin(qi);

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -183,32 +183,18 @@ typedef struct ODP_ALIGNED_CACHE {
 } order_context_t;
 
 typedef struct {
-	pri_mask_t     pri_mask[NUM_PRIO];
-	odp_spinlock_t mask_lock;
-
-	prio_queue_t   prio_q[NUM_SCHED_GRPS][NUM_PRIO][MAX_SPREAD];
-
-	odp_shm_t      shm;
-
 	struct {
-		uint8_t num_spread;
 		uint8_t burst_default[NUM_PRIO];
 		uint8_t burst_max[NUM_PRIO];
+		uint8_t num_spread;
 	} config;
 
-	uint32_t       pri_count[NUM_PRIO][MAX_SPREAD];
-
-	odp_thrmask_t    mask_all;
-	odp_spinlock_t   grp_lock;
-	odp_atomic_u32_t grp_epoch;
-	uint32_t         ring_mask;
 	uint16_t         max_spread;
-
-	struct {
-		char           name[ODP_SCHED_GROUP_NAME_LEN];
-		odp_thrmask_t  mask;
-		int	       allocated;
-	} sched_grp[NUM_SCHED_GRPS];
+	uint32_t         ring_mask;
+	pri_mask_t       pri_mask[NUM_PRIO];
+	odp_spinlock_t   mask_lock;
+	odp_atomic_u32_t grp_epoch;
+	odp_shm_t        shm;
 
 	struct {
 		uint8_t grp;
@@ -220,6 +206,20 @@ typedef struct {
 		uint8_t pktio_index;
 		uint8_t pktin_index;
 	} queue[ODP_CONFIG_QUEUES];
+
+	/* Scheduler priority queues */
+	prio_queue_t prio_q[NUM_SCHED_GRPS][NUM_PRIO][MAX_SPREAD];
+
+	uint32_t pri_count[NUM_PRIO][MAX_SPREAD];
+
+	odp_thrmask_t  mask_all;
+	odp_spinlock_t grp_lock;
+
+	struct {
+		char           name[ODP_SCHED_GROUP_NAME_LEN];
+		odp_thrmask_t  mask;
+		int	       allocated;
+	} sched_grp[NUM_SCHED_GRPS];
 
 	struct {
 		int num_pktin;


### PR DESCRIPTION
Changed configuration file options to control burst sizes per queue priority. Max burst size is needed to guarantee that low priority queues cannot cause large head of line blocking, when application uses schedule_multi() with large max burst size. 