### PR TITLE
linux-gen: netmap: remove minimum frame len check

### DIFF
--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -606,11 +606,6 @@ static inline int netmap_pkt_to_odp(pktio_entry_t *pktio_entry,
 		return -1;
 	}
 
-	if (odp_unlikely(len < _ODP_ETH_LEN_MIN)) {
-		ODP_ERR("RX: Frame truncated: %" PRIu16 "\n", len);
-		return -1;
-	}
-
 	if (pktio_cls_enabled(pktio_entry)) {
 		if (cls_classify_packet(pktio_entry, (const uint8_t *)buf, len,
 					len, &pool, &parsed_hdr))


### PR DESCRIPTION
(Note: this pull request is for monarch_lts)

Checking the minimum frame length is unnecessary as netmap drops truncated frames internally.

This also helps when using netmap+ODP with veth interfaces. They don't enlarge frames to 60 bytes + CRC like real Ethernet devices do. Such veth interfaces have smaller than 60 byte packets for ARP, for example. Checking the minimum frame length unnecessarily drops such packets, causing ARP to not work.

The change was taken from tigermoth_lts branch. My opinion is that although monarch_lts is starting to be a bit outdated, the change could be backported to monarch_lts as there still may be people using monarch_lts.