### PR TITLE
linux-gen: shm: use single VA space for internal allocations in process mode

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -33,6 +33,10 @@ shm: {
 	# When using process mode threads, this value should be set to 0
 	# because the current implementation won't work properly otherwise.
 	num_cached_hp = 0
+
+	# Allocate internal shared memory using a single virtual address space.
+	# Set to 1 to enable using process mode.
+	single_va = 0
 }
 
 # DPDK pktio options

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -141,7 +141,7 @@ extern "C" {
  * all ODP threads (when the _ODP_ISHM_SINGLE_VA flag is used).
  * In bytes.
  */
-#define ODP_CONFIG_ISHM_VA_PREALLOC_SZ (536870912L)
+#define ODP_CONFIG_ISHM_VA_PREALLOC_SZ (1024 * 1024 * 1024L)
 
 /*
  * Maximum event burst size

--- a/platform/linux-generic/include/odp_global_data.h
+++ b/platform/linux-generic/include/odp_global_data.h
@@ -44,6 +44,7 @@ struct odp_global_data_s {
 	int   shm_dir_from_env;
 	uint64_t shm_max_memory;
 	uint64_t shm_max_size;
+	int shm_single_va;
 	pid_t main_pid;
 	char uid[UID_MAXLEN];
 	odp_log_func_t log_fn;

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -301,7 +301,14 @@ static void hp_init(void)
 	char filename[ISHM_FILENAME_MAXLEN];
 	char dir[ISHM_FILENAME_MAXLEN];
 	int count;
+	int single_va = 0;
 	void *addr;
+
+	if (_odp_libconfig_lookup_ext_int("shm", NULL, "single_va",
+					  &single_va)) {
+		odp_global_data.shm_single_va = single_va;
+		ODP_DBG("Shm single VA: %d\n", odp_global_data.shm_single_va);
+	}
 
 	if (!_odp_libconfig_lookup_ext_int("shm", NULL, "num_cached_hp",
 					   &count)) {

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -57,6 +57,7 @@
 #include <odp/api/timer.h>
 #include <odp_timer_internal.h>
 #include <odp/api/plat/queue_inlines.h>
+#include <odp_global_data.h>
 
 /* Inlined API functions */
 #include <odp/api/plat/event_inlines.h>
@@ -256,6 +257,10 @@ static odp_timer_pool_t timer_pool_new(const char *name,
 {
 	uint32_t i, tp_idx;
 	size_t sz0, sz1, sz2;
+	uint32_t flags = ODP_SHM_SW_ONLY;
+
+	if (odp_global_data.shm_single_va)
+		flags |= ODP_SHM_SINGLE_VA;
 
 	odp_ticketlock_lock(&timer_global.lock);
 
@@ -282,7 +287,7 @@ static odp_timer_pool_t timer_pool_new(const char *name,
 	sz2 = ROUNDUP_CACHE_LINE(sizeof(_odp_timer_t) *
 				 param->num_timers);
 	odp_shm_t shm = odp_shm_reserve(name, sz0 + sz1 + sz2,
-			ODP_CACHE_LINE_SIZE, ODP_SHM_SW_ONLY);
+			ODP_CACHE_LINE_SIZE, flags);
 	if (odp_unlikely(shm == ODP_SHM_INVALID))
 		ODP_ABORT("%s: timer pool shm-alloc(%zuKB) failed\n",
 			  name, (sz0 + sz1 + sz2) / 1024);

--- a/platform/linux-generic/pktio/ipc.c
+++ b/platform/linux-generic/pktio/ipc.c
@@ -423,7 +423,7 @@ static int ipc_pktio_open(odp_pktio_t id ODP_UNUSED,
 		snprintf(name, sizeof(name), "%s_info", dev);
 		shm = odp_shm_reserve(name, sizeof(struct pktio_info),
 				      ODP_CACHE_LINE_SIZE,
-				      _ODP_ISHM_EXPORT | _ODP_ISHM_LOCK);
+				      ODP_SHM_EXPORT | ODP_SHM_SINGLE_VA);
 		if (ODP_SHM_INVALID == shm) {
 			_ring_destroy("ipc_rx_cache");
 			ODP_ERR("can not create shm %s\n", name);

--- a/platform/linux-generic/pktio/ring.c
+++ b/platform/linux-generic/pktio/ring.c
@@ -79,6 +79,7 @@
 #include <inttypes.h>
 #include <odp_packet_io_ring_internal.h>
 #include <odp_errno_define.h>
+#include <odp_global_data.h>
 
 #include <odp/api/plat/cpu_inlines.h>
 
@@ -171,6 +172,8 @@ _ring_create(const char *name, unsigned count, unsigned flags)
 		shm_flag = ODP_SHM_PROC | ODP_SHM_EXPORT;
 	else
 		shm_flag = 0;
+	if (odp_global_data.shm_single_va)
+		shm_flag |= ODP_SHM_SINGLE_VA;
 
 	/* count must be a power of 2 */
 	if (!RING_VAL_IS_POWER_2(count) || (count > _RING_SZ_MASK)) {


### PR DESCRIPTION
V2:
- Made ODP_CONFIG_ISHM_VA_PREALLOC_SZ mode readable (Bill)