### PR TITLE
test: ipc: reduce interface start poll frequency

### DIFF
--- a/platform/linux-generic/test/pktio_ipc/pktio_ipc1.c
+++ b/platform/linux-generic/test/pktio_ipc/pktio_ipc1.c
@@ -96,6 +96,9 @@ static int pktio_run_loop(odp_pool_t pool)
 		ret = odp_pktio_start(ipc_pktio);
 		if (!ret)
 			break;
+
+		/* Reduce polling frequency to once per 50ms */
+		odp_time_wait_ns(50 * ODP_TIME_MSEC_IN_NS);
 	}
 
 	/* packets loop */

--- a/platform/linux-generic/test/pktio_ipc/pktio_ipc2.c
+++ b/platform/linux-generic/test/pktio_ipc/pktio_ipc2.c
@@ -97,6 +97,9 @@ static int ipc_second_process(int master_pid)
 		ret = odp_pktio_start(ipc_pktio);
 		if (!ret)
 			break;
+
+		/* Reduce polling frequency to once per 50ms */
+		odp_time_wait_ns(50 * ODP_TIME_MSEC_IN_NS);
 	}
 
 	for (;;) {


### PR DESCRIPTION
This test fails frequently in Travis since log get filled with
debug prints from odp_pktio_start(). Reduce polling frequency to
once per 50ms. This gives both process time to start up, before
log is filled with unnecessary error messages.

Signed-off-by: Petri Savolainen <petri.savolainen@linaro.org>