### PR TITLE
linux-gen: dpdk: prefetch pkt_hdr before packet init

### DIFF
--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -746,6 +746,14 @@ fail:
 	return i;
 }
 
+static inline void prefetch_pkt(struct rte_mbuf *mbuf)
+{
+	odp_packet_hdr_t *pkt_hdr = mbuf->userdata;
+
+	odp_prefetch(pkt_hdr);
+	odp_prefetch(&pkt_hdr->p);
+}
+
 static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 				   odp_packet_t pkt_table[],
 				   struct rte_mbuf *mbuf_table[],
@@ -756,15 +764,28 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 	uint16_t pkt_len;
 	struct rte_mbuf *mbuf;
 	void *data;
-	int i;
-	int nb_pkts = 0;
-	odp_pool_t pool = pkt_priv(pktio_entry)->pool;
-	odp_pktin_config_opt_t pktin_cfg = pktio_entry->s.config.pktin;
-	odp_proto_layer_t parse_layer = pktio_entry->s.config.parser.layer;
-	odp_pktio_t input = pktio_entry->s.handle;
+	int i, nb_pkts;
+	odp_pool_t pool;
+	odp_pktin_config_opt_t pktin_cfg;
+	odp_proto_layer_t parse_layer;
+	odp_pktio_t input;
+
+	prefetch_pkt(mbuf_table[0]);
+
+	nb_pkts = 0;
+	pool = pkt_priv(pktio_entry)->pool;
+	pktin_cfg = pktio_entry->s.config.pktin;
+	parse_layer = pktio_entry->s.config.parser.layer;
+	input = pktio_entry->s.handle;
+
+	if (odp_likely(mbuf_num > 1))
+		prefetch_pkt(mbuf_table[1]);
 
 	for (i = 0; i < mbuf_num; i++) {
 		odp_packet_hdr_t parsed_hdr;
+
+		if (odp_likely((i + 2) < mbuf_num))
+			prefetch_pkt(mbuf_table[i + 2]);
 
 		mbuf = mbuf_table[i];
 		if (odp_unlikely(mbuf->nb_segs != 1)) {

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -749,9 +749,11 @@ fail:
 static inline void prefetch_pkt(struct rte_mbuf *mbuf)
 {
 	odp_packet_hdr_t *pkt_hdr = mbuf->userdata;
+	void *data = rte_pktmbuf_mtod(mbuf, char *);
 
 	odp_prefetch(pkt_hdr);
 	odp_prefetch(&pkt_hdr->p);
+	odp_prefetch(data);
 }
 
 static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
@@ -795,8 +797,6 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 		}
 
 		data = rte_pktmbuf_mtod(mbuf, char *);
-		odp_prefetch(data);
-
 		pkt_len = rte_pktmbuf_pkt_len(mbuf);
 
 		pkt = (odp_packet_t)mbuf->userdata;


### PR DESCRIPTION
These prefetches improve performance with L2fwd 1 - 7.5% and with OFP fpm_burst about 9.5%.