### PR TITLE
[PATCH v3] IPsec perfomance improvements

### DIFF
--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -181,9 +181,6 @@ struct ipsec_sa_s {
 				odp_ipsec_ipv4_param_t param;
 				odp_u32be_t	src_ip;
 				odp_u32be_t	dst_ip;
-
-				/* 32-bit from which low 16 are used */
-				odp_atomic_u32_t hdr_id;
 			} tun_ipv4;
 			struct {
 				odp_ipsec_ipv6_param_t param;
@@ -273,6 +270,12 @@ int _odp_ipsec_sa_replay_precheck(ipsec_sa_t *ipsec_sa, uint32_t seq,
  */
 int _odp_ipsec_sa_replay_update(ipsec_sa_t *ipsec_sa, uint32_t seq,
 				odp_ipsec_op_status_t *status);
+
+/**
+  * Allocate an IPv4 ID for an outgoing packet.
+  */
+uint16_t _odp_ipsec_sa_alloc_ipv4_id(ipsec_sa_t *ipsec_sa);
+
 /**
  * Try inline IPsec processing of provided packet.
  *

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -109,8 +109,11 @@ struct ipsec_sa_s {
 			} in;
 
 			struct {
-				odp_atomic_u64_t counter; /* for CTR/GCM */
-				odp_atomic_u32_t seq;
+				/*
+				 * 64-bit sequence number that is also used as
+				 * CTR/GCM IV
+				 */
+				odp_atomic_u64_t seq;
 			} out;
 		};
 	} hot;

--- a/platform/linux-generic/include/odp_ipsec_internal.h
+++ b/platform/linux-generic/include/odp_ipsec_internal.h
@@ -207,6 +207,11 @@ uint32_t _odp_ipsec_cipher_iv_len(odp_cipher_alg_t cipher);
 /* Return digest length required for the cipher for IPsec use */
 uint32_t _odp_ipsec_auth_digest_len(odp_auth_alg_t auth);
 
+/*
+ * Get SA entry from handle without obtaining a reference
+ */
+ipsec_sa_t *_odp_ipsec_sa_entry_from_hdl(odp_ipsec_sa_t sa);
+
 /**
  * Obtain SA reference
  */

--- a/platform/linux-generic/odp_ipsec.c
+++ b/platform/linux-generic/odp_ipsec.c
@@ -813,7 +813,7 @@ err:
 static inline
 uint32_t ipsec_seq_no(ipsec_sa_t *ipsec_sa)
 {
-	return odp_atomic_fetch_add_u32(&ipsec_sa->out.seq, 1);
+	return odp_atomic_fetch_add_u32(&ipsec_sa->hot.out.seq, 1);
 }
 
 /* Helper for calculating encode length using data length and block size */
@@ -1010,7 +1010,7 @@ static int ipsec_out_iv(ipsec_state_t *state,
 		/* Both GCM and CTR use 8-bit counters */
 		ODP_ASSERT(sizeof(ctr) == ipsec_sa->esp_iv_len);
 
-		ctr = odp_atomic_fetch_add_u64(&ipsec_sa->out.counter,
+		ctr = odp_atomic_fetch_add_u64(&ipsec_sa->hot.out.counter,
 					       1);
 		/* Check for overrun */
 		if (ctr == 0)

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -320,7 +320,7 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 		odp_atomic_init_u64(&ipsec_sa->hot.in.antireplay, 0);
 	} else {
 		ipsec_sa->lookup_mode = ODP_IPSEC_LOOKUP_DISABLED;
-		odp_atomic_store_u32(&ipsec_sa->hot.out.seq, 1);
+		odp_atomic_store_u64(&ipsec_sa->hot.out.seq, 1);
 		ipsec_sa->out.frag_mode = param->outbound.frag_mode;
 		ipsec_sa->out.mtu = param->outbound.mtu;
 	}
@@ -468,10 +468,6 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 	default:
 		break;
 	}
-
-	if (1 == ipsec_sa->use_counter_iv &&
-	    ODP_IPSEC_DIR_OUTBOUND == param->dir)
-		odp_atomic_init_u64(&ipsec_sa->hot.out.counter, 1);
 
 	ipsec_sa->icv_len = crypto_param.auth_digest_len;
 

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -26,6 +26,9 @@
 
 typedef struct ipsec_sa_table_t {
 	ipsec_sa_t ipsec_sa[ODP_CONFIG_IPSEC_SAS];
+	struct ODP_ALIGNED_CACHE {
+		odp_atomic_u32_t ipv4_id;
+	} hot;
 	odp_shm_t shm;
 } ipsec_sa_table_t;
 
@@ -67,6 +70,7 @@ int _odp_ipsec_sad_init_global(void)
 
 	memset(ipsec_sa_tbl, 0, sizeof(ipsec_sa_table_t));
 	ipsec_sa_tbl->shm = shm;
+	odp_atomic_init_u32(&ipsec_sa_tbl->hot.ipv4_id, 0);
 
 	for (i = 0; i < ODP_CONFIG_IPSEC_SAS; i++) {
 		ipsec_sa_t *ipsec_sa = ipsec_sa_entry(i);
@@ -347,7 +351,6 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 			memcpy(&ipsec_sa->out.tun_ipv4.dst_ip,
 			       param->outbound.tunnel.ipv4.dst_addr,
 			       sizeof(ipsec_sa->out.tun_ipv4.dst_ip));
-			odp_atomic_init_u32(&ipsec_sa->out.tun_ipv4.hdr_id, 0);
 			ipsec_sa->out.tun_ipv4.param.src_addr =
 				&ipsec_sa->out.tun_ipv4.src_ip;
 			ipsec_sa->out.tun_ipv4.param.dst_addr =
@@ -728,4 +731,13 @@ int _odp_ipsec_sa_replay_update(ipsec_sa_t *ipsec_sa, uint32_t seq,
 	}
 
 	return 0;
+}
+
+uint16_t _odp_ipsec_sa_alloc_ipv4_id(ipsec_sa_t *ipsec_sa)
+{
+	(void) ipsec_sa;
+
+	/* No need to convert to BE: ID just should not be duplicated */
+	return odp_atomic_fetch_add_u32(&ipsec_sa_tbl->hot.ipv4_id, 1)
+		& 0xffff;
 }

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -46,6 +46,12 @@ static inline odp_ipsec_sa_t ipsec_sa_index_to_handle(uint32_t ipsec_sa_idx)
 	return _odp_cast_scalar(odp_ipsec_sa_t, ipsec_sa_idx + 1);
 }
 
+ipsec_sa_t *_odp_ipsec_sa_entry_from_hdl(odp_ipsec_sa_t sa)
+{
+	ODP_ASSERT(ODP_IPSEC_SA_INVALID != sa);
+	return ipsec_sa_entry_from_hdl(sa);
+}
+
 int _odp_ipsec_sad_init_global(void)
 {
 	odp_shm_t shm;


### PR DESCRIPTION
This set of patches improve the performance of outbound IPsec processing by making it scale better to multiple threads.

The patches reduce the amount of shared read-write data accessed for every packet. Many of the patches introduce some form of thread-local buffering. One of the patches simply removes per-packet SA refcount update and relies on the application for synchronization as required by the ODP API. See the individual commit messages for more details.

Biggest speedup can be seen with small packets and outbound processing only. The SA lookup in inbound IPsec processing still has a scalability bottleneck that this patch series does not address.

A few test results about forwarding to an IPsec tunnel using OFP in x86:

kpps before / kpps after / case
417 / 941 / AES-CBC, SHA-1, 2 threads
597 / 4495 / AES-CBC, SHA-1, 10 threads
1558 / 1864 / AES-GCM, 2 threads
2444 / 9020 / AES-GCM, 10 threads

One of the patches contains a fix for an IP ID bug (PR 4013).
