### PR TITLE
[PATCH v1] travis: export CI for first distcheck

### DIFF
--- a/scripts/ci/distcheck.sh
+++ b/scripts/ci/distcheck.sh
@@ -10,12 +10,12 @@ cd "$(dirname "$0")"/../..
 ./configure \
 	--enable-user-guides
 
-make distcheck
-
-make clean
-
 # Ignore possible failures there because these tests depends on measurements
 # and systems might differ in performance.
 export CI="true"
+
+make distcheck
+
+make clean
 
 make distcheck DISTCHECK__CONFIGURE_FLAGS=--disable-abi-compat


### PR DESCRIPTION
scripts runs 2 distchecks but only for second one CI
was exported.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>