### PR TITLE
[PATCH v1] linux-gen: do not use huge pages for internal allocations

### DIFF
--- a/platform/linux-generic/include/odp_shm_internal.h
+++ b/platform/linux-generic/include/odp_shm_internal.h
@@ -16,8 +16,9 @@ extern "C" {
 #define SHM_DEVNAME_MAXLEN (ODP_SHM_NAME_LEN + 16)
 #define SHM_DEVNAME_FORMAT "/odp-%d-%s" /* /dev/shm/odp-<pid>-<name> */
 
-#define _ODP_SHM_PROC_NOCREAT 0x40  /**< Do not create shm if not exist */
-#define _ODP_SHM_O_EXCL	      0x80  /**< Do not create shm if exist */
+#define _ODP_SHM_PROC_NOCREAT (1 << 6)  /**< Do not create shm if not exist */
+#define _ODP_SHM_O_EXCL	      (1 << 7)  /**< Do not create shm if exist */
+#define _ODP_SHM_NO_HP	      (1 << 8)  /**< Do not use huge pages */
 
 #ifdef __cplusplus
 }

--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -11,6 +11,7 @@
 #include <odp/api/queue.h>
 #include <odp/api/debug.h>
 #include <odp_init_internal.h>
+#include <odp_shm_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_packet_internal.h>
 #include <odp/api/packet_io.h>
@@ -84,9 +85,10 @@ int odp_classification_init_global(void)
 	odp_shm_t queue_grp_shm;
 	int i;
 
-	cos_shm = odp_shm_reserve("shm_odp_cos_tbl",
+	cos_shm = odp_shm_reserve("_odp_shm_odp_cos_tbl",
 				  sizeof(cos_tbl_t),
-				  sizeof(cos_t), 0);
+				  sizeof(cos_t),
+				  _ODP_SHM_NO_HP);
 
 	if (cos_shm == ODP_SHM_INVALID) {
 		ODP_ERR("shm allocation failed for shm_odp_cos_tbl");
@@ -104,9 +106,10 @@ int odp_classification_init_global(void)
 		LOCK_INIT(&cos->s.lock);
 	}
 
-	pmr_shm = odp_shm_reserve("shm_odp_pmr_tbl",
+	pmr_shm = odp_shm_reserve("_odp_shm_odp_pmr_tbl",
 				  sizeof(pmr_tbl_t),
-				  sizeof(pmr_t), 0);
+				  sizeof(pmr_t),
+				  _ODP_SHM_NO_HP);
 
 	if (pmr_shm == ODP_SHM_INVALID) {
 		ODP_ERR("shm allocation failed for shm_odp_pmr_tbl");
@@ -124,9 +127,10 @@ int odp_classification_init_global(void)
 		LOCK_INIT(&pmr->s.lock);
 	}
 
-	queue_grp_shm = odp_shm_reserve("shm_odp_cls_queue_grp_tbl",
+	queue_grp_shm = odp_shm_reserve("_odp_shm_cls_queue_grp_tbl",
 					sizeof(_cls_queue_grp_tbl_t),
-					sizeof(queue_entry_t *), 0);
+					sizeof(queue_entry_t *),
+					_ODP_SHM_NO_HP);
 
 	if (queue_grp_shm == ODP_SHM_INVALID) {
 		ODP_ERR("shm allocation failed for queue_grp_tbl");
@@ -153,19 +157,19 @@ int odp_classification_term_global(void)
 	int ret = 0;
 	int rc = 0;
 
-	ret = odp_shm_free(odp_shm_lookup("shm_odp_cos_tbl"));
+	ret = odp_shm_free(odp_shm_lookup("_odp_shm_odp_cos_tbl"));
 	if (ret < 0) {
 		ODP_ERR("shm free failed for shm_odp_cos_tbl");
 		rc = -1;
 	}
 
-	ret = odp_shm_free(odp_shm_lookup("shm_odp_pmr_tbl"));
+	ret = odp_shm_free(odp_shm_lookup("_odp_shm_odp_pmr_tbl"));
 	if (ret < 0) {
 		ODP_ERR("shm free failed for shm_odp_pmr_tbl");
 		rc = -1;
 	}
 
-	ret = odp_shm_free(odp_shm_lookup("shm_odp_cls_queue_grp_tbl"));
+	ret = odp_shm_free(odp_shm_lookup("_odp_shm_cls_queue_grp_tbl"));
 	if (ret < 0) {
 		ODP_ERR("shm free failed for shm_odp_cls_queue_grp_tbl");
 		rc = -1;

--- a/platform/linux-generic/odp_crypto_null.c
+++ b/platform/linux-generic/odp_crypto_null.c
@@ -21,6 +21,7 @@
 #include <odp/api/plat/thread_inlines.h>
 #include <odp_packet_internal.h>
 #include <odp/api/plat/queue_inlines.h>
+#include <odp_shm_internal.h>
 
 /* Inlined API functions */
 #include <odp/api/plat/event_inlines.h>
@@ -316,8 +317,9 @@ odp_crypto_init_global(void)
 	mem_size  = sizeof(odp_crypto_global_t);
 
 	/* Allocate our globally shared memory */
-	shm = odp_shm_reserve("crypto_pool", mem_size,
-			      ODP_CACHE_LINE_SIZE, 0);
+	shm = odp_shm_reserve("_odp_crypto_pool_null", mem_size,
+			      ODP_CACHE_LINE_SIZE,
+			      _ODP_SHM_NO_HP);
 	if (ODP_SHM_INVALID == shm) {
 		ODP_ERR("unable to allocate crypto pool\n");
 		return -1;
@@ -352,9 +354,9 @@ int odp_crypto_term_global(void)
 		rc = -1;
 	}
 
-	ret = odp_shm_free(odp_shm_lookup("crypto_pool"));
+	ret = odp_shm_free(odp_shm_lookup("_odp_crypto_pool_null"));
 	if (ret < 0) {
-		ODP_ERR("shm free failed for crypto_pool\n");
+		ODP_ERR("shm free failed for _odp_crypto_pool_null\n");
 		rc = -1;
 	}
 

--- a/platform/linux-generic/odp_crypto_openssl.c
+++ b/platform/linux-generic/odp_crypto_openssl.c
@@ -21,6 +21,7 @@
 #include <odp/api/plat/thread_inlines.h>
 #include <odp_packet_internal.h>
 #include <odp/api/plat/queue_inlines.h>
+#include <odp_shm_internal.h>
 
 /* Inlined API functions */
 #include <odp/api/plat/event_inlines.h>
@@ -1856,8 +1857,9 @@ odp_crypto_init_global(void)
 	mem_size += nlocks * sizeof(odp_ticketlock_t);
 
 	/* Allocate our globally shared memory */
-	shm = odp_shm_reserve("crypto_pool", mem_size,
-			      ODP_CACHE_LINE_SIZE, 0);
+	shm = odp_shm_reserve("_odp_crypto_pool_ssl", mem_size,
+			      ODP_CACHE_LINE_SIZE,
+			      _ODP_SHM_NO_HP);
 	if (ODP_SHM_INVALID == shm) {
 		ODP_ERR("unable to allocate crypto pool\n");
 		return -1;
@@ -1903,7 +1905,7 @@ int odp_crypto_term_global(void)
 	CRYPTO_set_locking_callback(NULL);
 	CRYPTO_set_id_callback(NULL);
 
-	ret = odp_shm_free(odp_shm_lookup("crypto_pool"));
+	ret = odp_shm_free(odp_shm_lookup("_odp_crypto_pool_ssl"));
 	if (ret < 0) {
 		ODP_ERR("shm free failed for crypto_pool\n");
 		rc = -1;

--- a/platform/linux-generic/odp_ipsec_events.c
+++ b/platform/linux-generic/odp_ipsec_events.c
@@ -41,7 +41,7 @@ int _odp_ipsec_events_init_global(void)
 	param.buf.num   = IPSEC_EVENTS_POOL_BUF_COUNT;
 	param.type      = ODP_POOL_BUFFER;
 
-	ipsec_status_pool = odp_pool_create("ipsec_status_pool", &param);
+	ipsec_status_pool = odp_pool_create("_odp_ipsec_status_pool", &param);
 	if (ODP_POOL_INVALID == ipsec_status_pool) {
 		ODP_ERR("Error: status pool create failed.\n");
 		goto err_status;
@@ -55,16 +55,15 @@ err_status:
 
 int _odp_ipsec_events_term_global(void)
 {
-	int ret = 0;
-	int rc = 0;
+	int ret;
 
 	ret = odp_pool_destroy(ipsec_status_pool);
 	if (ret < 0) {
 		ODP_ERR("status pool destroy failed");
-		rc = -1;
+		return -1;
 	}
 
-	return rc;
+	return 0;
 }
 
 ipsec_status_t _odp_ipsec_status_from_event(odp_event_t ev)

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -14,6 +14,7 @@
 #include <odp_init_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_ipsec_internal.h>
+#include <odp_shm_internal.h>
 
 #include <odp/api/plat/atomic_inlines.h>
 #include <odp/api/plat/cpu_inlines.h>
@@ -51,14 +52,14 @@ int _odp_ipsec_sad_init_global(void)
 	odp_shm_t shm;
 	unsigned i;
 
-	shm = odp_shm_reserve("ipsec_sa_table",
+	shm = odp_shm_reserve("_odp_ipsec_sa_table",
 			      sizeof(ipsec_sa_table_t),
-			      ODP_CACHE_LINE_SIZE, 0);
-
-	ipsec_sa_tbl = odp_shm_addr(shm);
-	if (ipsec_sa_tbl == NULL)
+			      ODP_CACHE_LINE_SIZE,
+			      _ODP_SHM_NO_HP);
+	if (shm == ODP_SHM_INVALID)
 		return -1;
 
+	ipsec_sa_tbl = odp_shm_addr(shm);
 	memset(ipsec_sa_tbl, 0, sizeof(ipsec_sa_table_t));
 	ipsec_sa_tbl->shm = shm;
 

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -1036,7 +1036,8 @@ int _odp_ishm_reserve(const char *name, uint64_t size, int fd,
 
 	/* Get system page sizes: page_hp_size is 0 if no huge page available*/
 	page_sz      = odp_sys_page_size();
-	page_hp_size = odp_sys_huge_page_size();
+	page_hp_size = user_flags & _ODP_SHM_NO_HP ?
+		       0 : odp_sys_huge_page_size();
 
 	/* grab a new entry: */
 	for (new_index = 0; new_index < ISHM_MAX_NB_BLOCKS; new_index++) {

--- a/platform/linux-generic/odp_ishmphy.c
+++ b/platform/linux-generic/odp_ishmphy.c
@@ -147,10 +147,8 @@ void *_odp_ishmphy_map(int fd, void *start, uint64_t size,
 		}
 	}
 
-	if (mapped_addr == MAP_FAILED) {
-		ODP_ERR("mmap failed:%s\n", strerror(errno));
+	if (mapped_addr == MAP_FAILED)
 		return NULL;
-	}
 
 	/* if locking is requested, lock it...*/
 	if (flags & _ODP_ISHM_LOCK) {

--- a/platform/linux-generic/odp_packet_io.c
+++ b/platform/linux-generic/odp_packet_io.c
@@ -29,6 +29,7 @@
 #include <odp/api/plat/time_inlines.h>
 #include <odp_pcapng.h>
 #include <odp/api/plat/queue_inlines.h>
+#include <odp_shm_internal.h>
 
 #include <string.h>
 #include <inttypes.h>
@@ -65,9 +66,10 @@ int odp_pktio_init_global(void)
 	odp_shm_t shm;
 	int pktio_if;
 
-	shm = odp_shm_reserve("odp_pktio_entries",
+	shm = odp_shm_reserve("_odp_pktio_entries",
 			      sizeof(pktio_table_t),
-			      sizeof(pktio_entry_t), 0);
+			      sizeof(pktio_entry_t),
+			      _ODP_SHM_NO_HP);
 	if (shm == ODP_SHM_INVALID)
 		return -1;
 
@@ -1326,9 +1328,9 @@ int odp_pktio_term_global(void)
 					  pktio_if);
 	}
 
-	ret = odp_shm_free(odp_shm_lookup("odp_pktio_entries"));
+	ret = odp_shm_free(odp_shm_lookup("_odp_pktio_entries"));
 	if (ret != 0)
-		ODP_ERR("shm free failed for odp_pktio_entries");
+		ODP_ERR("shm free failed for _odp_pktio_entries");
 
 	return ret;
 }

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -19,6 +19,7 @@
 #include <odp_config_internal.h>
 #include <odp_debug_internal.h>
 #include <odp_ring_internal.h>
+#include <odp_shm_internal.h>
 #include <odp_global_data.h>
 
 #include <string.h>
@@ -88,7 +89,8 @@ int odp_pool_init_global(void)
 
 	shm = odp_shm_reserve("_odp_pool_table",
 			      sizeof(pool_table_t),
-			      ODP_CACHE_LINE_SIZE, 0);
+			      ODP_CACHE_LINE_SIZE,
+			      _ODP_SHM_NO_HP);
 
 	pool_tbl = odp_shm_addr(shm);
 
@@ -200,7 +202,7 @@ static pool_t *reserve_pool(uint32_t shmflags)
 		if (pool->reserved == 0) {
 			pool->reserved = 1;
 			UNLOCK(&pool->lock);
-			sprintf(ring_name, "pool_ring_%d", i);
+			sprintf(ring_name, "_odp_pool_ring_%d", i);
 			pool->ring_shm =
 				odp_shm_reserve(ring_name,
 						sizeof(pool_ring_t),

--- a/platform/linux-generic/odp_queue_basic.c
+++ b/platform/linux-generic/odp_queue_basic.c
@@ -15,6 +15,7 @@
 #include <odp_buffer_internal.h>
 #include <odp_pool_internal.h>
 #include <odp_init_internal.h>
+#include <odp_shm_internal.h>
 #include <odp/api/shared_memory.h>
 #include <odp/api/schedule.h>
 #include <odp_schedule_if.h>
@@ -134,12 +135,12 @@ static int queue_init_global(void)
 
 	shm = odp_shm_reserve("_odp_queue_gbl",
 			      sizeof(queue_global_t),
-			      sizeof(queue_entry_t), 0);
+			      sizeof(queue_entry_t),
+			      _ODP_SHM_NO_HP);
+	if (shm == ODP_SHM_INVALID)
+		return -1;
 
 	queue_glb = odp_shm_addr(shm);
-
-	if (queue_glb == NULL)
-		return -1;
 
 	memset(queue_glb, 0, sizeof(queue_global_t));
 
@@ -161,7 +162,8 @@ static int queue_init_global(void)
 		   (uint64_t)queue_glb->config.max_queue_size;
 
 	shm = odp_shm_reserve("_odp_queue_rings", mem_size,
-			      ODP_CACHE_LINE_SIZE, 0);
+			      ODP_CACHE_LINE_SIZE,
+			      _ODP_SHM_NO_HP);
 
 	if (shm == ODP_SHM_INVALID) {
 		odp_shm_free(queue_glb->queue_gbl_shm);

--- a/platform/linux-generic/odp_queue_lf.c
+++ b/platform/linux-generic/odp_queue_lf.c
@@ -9,6 +9,7 @@
 #include <odp/api/plat/atomic_inlines.h>
 #include <odp/api/shared_memory.h>
 #include <odp_queue_basic_internal.h>
+#include <odp_shm_internal.h>
 #include <string.h>
 #include <stdio.h>
 
@@ -318,8 +319,11 @@ uint32_t queue_lf_init_global(uint32_t *queue_lf_size,
 	if (!lockfree)
 		return 0;
 
-	shm = odp_shm_reserve("odp_queues_lf", sizeof(queue_lf_global_t),
-			      ODP_CACHE_LINE_SIZE, 0);
+	shm = odp_shm_reserve("_odp_queues_lf", sizeof(queue_lf_global_t),
+			      ODP_CACHE_LINE_SIZE,
+			      _ODP_SHM_NO_HP);
+	if (shm == ODP_SHM_INVALID)
+		return 0;
 
 	queue_lf_glb = odp_shm_addr(shm);
 	memset(queue_lf_glb, 0, sizeof(queue_lf_global_t));

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -29,6 +29,7 @@
 #include <odp_queue_basic_internal.h>
 #include <odp_libconfig_internal.h>
 #include <odp/api/plat/queue_inlines.h>
+#include <odp_shm_internal.h>
 
 /* No synchronization context */
 #define NO_SYNC_CONTEXT ODP_SCHED_SYNC_PARALLEL
@@ -353,17 +354,16 @@ static int schedule_init_global(void)
 
 	ODP_DBG("Schedule init ... ");
 
-	shm = odp_shm_reserve("odp_scheduler",
+	shm = odp_shm_reserve("_odp_scheduler",
 			      sizeof(sched_global_t),
-			      ODP_CACHE_LINE_SIZE, 0);
-
-	sched = odp_shm_addr(shm);
-
-	if (sched == NULL) {
+			      ODP_CACHE_LINE_SIZE,
+			      _ODP_SHM_NO_HP);
+	if (shm == ODP_SHM_INVALID) {
 		ODP_ERR("Schedule init: Shm reserve failed.\n");
 		return -1;
 	}
 
+	sched = odp_shm_addr(shm);
 	memset(sched, 0, sizeof(sched_global_t));
 
 	if (read_config_file(sched)) {

--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -59,7 +59,7 @@ odp_shm_t odp_shm_reserve(const char *name, uint64_t size, uint64_t align,
 			  uint32_t flags)
 {
 	int block_index;
-	int flgs = 0; /* internal ishm flags */
+	uint32_t flgs = 0; /* internal ishm flags */
 
 	flgs = get_ishm_flags(flags);
 

--- a/platform/linux-generic/odp_thread.c
+++ b/platform/linux-generic/odp_thread.c
@@ -54,7 +54,7 @@ int odp_thread_init_global(void)
 {
 	odp_shm_t shm;
 
-	shm = odp_shm_reserve("odp_thread_globals",
+	shm = odp_shm_reserve("_odp_thread_globals",
 			      sizeof(thread_globals_t),
 			      ODP_CACHE_LINE_SIZE, 0);
 
@@ -73,9 +73,9 @@ int odp_thread_term_global(void)
 {
 	int ret;
 
-	ret = odp_shm_free(odp_shm_lookup("odp_thread_globals"));
+	ret = odp_shm_free(odp_shm_lookup("_odp_thread_globals"));
 	if (ret < 0)
-		ODP_ERR("shm free failed for odp_thread_globals");
+		ODP_ERR("shm free failed for _odp_thread_globals");
 
 	return ret;
 }


### PR DESCRIPTION
Some linux-generic internal shared memory allocations have
to be in normal pages due to small required data. Relaying
on odp_sys_huge_page_size() is not really correct, because
call returns default huge page size. But default huge page
size is definned in kernel boot parameter as:
default_hugepagesz=1G hugepagesz=1G hugepages=2
So in that case for small allocation linux-gen will create 1GB
huge page. This patch introduces internal flag to shm funtion
to allocate hp.
This patch remains allowing changes on top of it:
For now pools are in huge page. And for apps with small pool it's
big overhead of unused memory. We should take into account
odp_sys_huge_page_size_all() call and found best sized huge pages.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>
---
v2: - rebase
       - use internal shm flags then ishm flags
