### PR TITLE
[PATCH v1] Improved zero-copy DPDK pktio implementation

### DIFF
--- a/platform/linux-generic/include/odp_packet_dpdk.h
+++ b/platform/linux-generic/include/odp_packet_dpdk.h
@@ -13,23 +13,24 @@ struct rte_mbuf;
 
 /** Cache for storing packets */
 /** Packet parser using DPDK interface */
-int dpdk_packet_parse_common(packet_parser_t *pkt_hdr,
-			     const uint8_t *ptr,
-			     uint32_t pkt_len,
-			     uint32_t seg_len,
-			     struct rte_mbuf *mbuf,
-			     int layer,
-			     odp_pktin_config_opt_t pktin_cfg);
+int _odp_dpdk_packet_parse_common(packet_parser_t *pkt_hdr,
+				  const uint8_t *ptr,
+				  uint32_t pkt_len,
+				  uint32_t seg_len,
+				  struct rte_mbuf *mbuf,
+				  int layer,
+				  odp_pktin_config_opt_t pktin_cfg);
 
-static inline int dpdk_packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
-					  struct rte_mbuf *mbuf,
-					  odp_pktio_parser_layer_t layer,
-					  odp_pktin_config_opt_t pktin_cfg)
+static inline int _odp_dpdk_packet_parse_layer(odp_packet_hdr_t *pkt_hdr,
+					       struct rte_mbuf *mbuf,
+					       odp_pktio_parser_layer_t layer,
+					       odp_pktin_config_opt_t pktin_cfg)
 {
 	uint32_t seg_len = pkt_hdr->buf_hdr.seg[0].len;
 	void *base = pkt_hdr->buf_hdr.seg[0].data;
 
-	return dpdk_packet_parse_common(&pkt_hdr->p, base, pkt_hdr->frame_len,
-					seg_len, mbuf, layer, pktin_cfg);
+	return _odp_dpdk_packet_parse_common(&pkt_hdr->p, base,
+					     pkt_hdr->frame_len, seg_len, mbuf,
+					     layer, pktin_cfg);
 }
 #endif

--- a/platform/linux-generic/include/odp_packet_dpdk.h
+++ b/platform/linux-generic/include/odp_packet_dpdk.h
@@ -7,11 +7,25 @@
 #ifndef ODP_PACKET_DPDK_H
 #define ODP_PACKET_DPDK_H
 
+#include <stdint.h>
+
 #include <odp/api/packet_io.h>
+
+#include <odp_packet_internal.h>
+#include <odp_pool_internal.h>
 
 struct rte_mbuf;
 
-/** Cache for storing packets */
+/**
+ * Calculate size of zero-copy DPDK packet pool object
+ */
+uint32_t _odp_dpdk_pool_obj_size(pool_t *pool, uint32_t block_size);
+
+/**
+ * Create zero-copy DPDK packet pool
+ */
+int _odp_dpdk_pool_create(pool_t *pool);
+
 /** Packet parser using DPDK interface */
 int _odp_dpdk_packet_parse_common(packet_parser_t *pkt_hdr,
 				  const uint8_t *ptr,

--- a/platform/linux-generic/include/odp_packet_internal.h
+++ b/platform/linux-generic/include/odp_packet_internal.h
@@ -95,9 +95,6 @@ typedef struct {
 	 * Members below are not initialized by packet_init()
 	 */
 
-	/* Type of extra data */
-	uint8_t extra_type;
-
 	/* Flow hash value */
 	uint32_t flow_hash;
 
@@ -113,11 +110,6 @@ typedef struct {
 	/* Context for IPsec */
 	odp_ipsec_packet_result_t ipsec_ctx;
 
-#ifdef ODP_PKTIO_DPDK
-	/* Extra space for packet descriptors. E.g. DPDK mbuf. Keep as the last
-	 * member before data. */
-	uint8_t ODP_ALIGNED_CACHE extra[PKT_EXTRA_LEN];
-#endif
 	/* Packet data storage */
 	uint8_t data[0];
 } odp_packet_hdr_t;

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -67,11 +67,15 @@ typedef struct pool_t {
 	uint32_t         max_len;
 	uint32_t         uarea_size;
 	uint32_t         block_size;
+	uint32_t         block_offset;
 	uint8_t         *base_addr;
 	uint8_t         *uarea_base_addr;
 
 	/* Used by DPDK zero-copy pktio */
-	uint8_t		mem_from_huge_pages;
+	uint32_t         dpdk_elt_size;
+	uint32_t         skipped_blocks;
+	uint8_t          pool_in_use;
+	uint8_t          mem_from_huge_pages;
 	pool_destroy_cb_fn ext_destroy;
 	void            *ext_desc;
 
@@ -110,7 +114,8 @@ static inline odp_buffer_hdr_t *buf_hdr_from_index(pool_t *pool,
 	uint64_t block_offset;
 	odp_buffer_hdr_t *buf_hdr;
 
-	block_offset = buffer_idx * (uint64_t)pool->block_size;
+	block_offset = (buffer_idx * (uint64_t)pool->block_size) +
+			pool->block_offset;
 
 	/* clang requires cast to uintptr_t */
 	buf_hdr = (odp_buffer_hdr_t *)(uintptr_t)&pool->base_addr[block_offset];

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -530,10 +530,11 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 		if (pktio_cls_enabled(pktio_entry)) {
 			packet_parse_reset(&parsed_hdr);
 			packet_set_len(&parsed_hdr, pkt_len);
-			if (dpdk_packet_parse_common(&parsed_hdr.p, data,
-						     pkt_len, pkt_len, mbuf,
-						     ODP_PROTO_LAYER_ALL,
-						     pktin_cfg)) {
+			if (_odp_dpdk_packet_parse_common(&parsed_hdr.p, data,
+							  pkt_len, pkt_len,
+							  mbuf,
+							  ODP_PROTO_LAYER_ALL,
+							  pktin_cfg)) {
 				odp_packet_free(pkt_table[i]);
 				rte_pktmbuf_free(mbuf);
 				continue;
@@ -557,8 +558,9 @@ static inline int mbuf_to_pkt(pktio_entry_t *pktio_entry,
 		if (pktio_cls_enabled(pktio_entry))
 			copy_packet_cls_metadata(&parsed_hdr, pkt_hdr);
 		else if (parse_layer != ODP_PROTO_LAYER_NONE)
-			if (dpdk_packet_parse_layer(pkt_hdr, mbuf, parse_layer,
-						    pktin_cfg)) {
+			if (_odp_dpdk_packet_parse_layer(pkt_hdr, mbuf,
+							 parse_layer,
+							 pktin_cfg)) {
 				odp_packet_free(pkt);
 				rte_pktmbuf_free(mbuf);
 				continue;
@@ -803,10 +805,11 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 		if (pktio_cls_enabled(pktio_entry)) {
 			packet_parse_reset(&parsed_hdr);
 			packet_set_len(&parsed_hdr, pkt_len);
-			if (dpdk_packet_parse_common(&parsed_hdr.p, data,
-						     pkt_len, pkt_len, mbuf,
-						     ODP_PROTO_LAYER_ALL,
-						     pktin_cfg)) {
+			if (_odp_dpdk_packet_parse_common(&parsed_hdr.p, data,
+							  pkt_len, pkt_len,
+							  mbuf,
+							  ODP_PROTO_LAYER_ALL,
+							  pktin_cfg)) {
 				rte_pktmbuf_free(mbuf);
 				continue;
 			}
@@ -830,8 +833,9 @@ static inline int mbuf_to_pkt_zero(pktio_entry_t *pktio_entry,
 		if (pktio_cls_enabled(pktio_entry))
 			copy_packet_cls_metadata(&parsed_hdr, pkt_hdr);
 		else if (parse_layer != ODP_PROTO_LAYER_NONE)
-			if (dpdk_packet_parse_layer(pkt_hdr, mbuf, parse_layer,
-						    pktin_cfg)) {
+			if (_odp_dpdk_packet_parse_layer(pkt_hdr, mbuf,
+							 parse_layer,
+							 pktin_cfg)) {
 				rte_pktmbuf_free(mbuf);
 				continue;
 			}

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -455,7 +455,8 @@ static struct rte_mempool *pool_create(pool_t *pool)
 	}
 
 	snprintf(pool_name, sizeof(pool_name),
-		 "dpdk_pktpool_%" PRIu32 "", pool->pool_idx);
+		 "dpdk_pktpool_%" PRIu32 "_%" PRIu32 "", odp_global_ro.main_pid,
+		 pool->pool_idx);
 	pkt_pool = mbuf_pool_create(pool_name, pool);
 
 	if (pkt_pool == NULL) {
@@ -1174,15 +1175,17 @@ static int dpdk_pktio_init(void)
 		cmdline = "";
 
 	/* masklen includes the terminating null as well */
-	cmd_len = strlen("odpdpdk -c --socket-mem ") + masklen +
-			 strlen(mem_str) + strlen(cmdline) + strlen("  ");
+	cmd_len = snprintf(NULL, 0, "odpdpdk --file-prefix %" PRIu32 "_ "
+			   "--proc-type auto -c %s --socket-mem %s %s ",
+			   odp_global_ro.main_pid, mask_str, mem_str, cmdline);
 
 	char full_cmd[cmd_len];
 
 	/* first argument is facility log, simply bind it to odpdpdk for now.*/
 	cmd_len = snprintf(full_cmd, cmd_len,
-			   "odpdpdk -c %s --socket-mem %s %s", mask_str,
-			   mem_str, cmdline);
+			   "odpdpdk --file-prefix %" PRIu32 "_ "
+			   "--proc-type auto -c %s --socket-mem %s %s ",
+			   odp_global_ro.main_pid, mask_str, mem_str, cmdline);
 
 	for (i = 0, dpdk_argc = 1; i < cmd_len; ++i) {
 		if (isspace(full_cmd[i]))

--- a/platform/linux-generic/pktio/dpdk_parse.c
+++ b/platform/linux-generic/pktio/dpdk_parse.c
@@ -457,10 +457,10 @@ int dpdk_packet_parse_common_l3_l4(packet_parser_t *prs,
 /**
  * DPDK packet parser
  */
-int dpdk_packet_parse_common(packet_parser_t *prs, const uint8_t *ptr,
-			     uint32_t frame_len, uint32_t seg_len,
-			     struct rte_mbuf *mbuf, int layer,
-			     odp_pktin_config_opt_t pktin_cfg)
+int _odp_dpdk_packet_parse_common(packet_parser_t *prs, const uint8_t *ptr,
+				  uint32_t frame_len, uint32_t seg_len,
+				  struct rte_mbuf *mbuf, int layer,
+				  odp_pktin_config_opt_t pktin_cfg)
 {
 	uint32_t offset;
 	uint16_t ethtype;


### PR DESCRIPTION
Improved zero-copy DPDK pktio implementation which better adheres to DPDK APIs. The new implementation reduces overhead by moving mbuf initialization to ODP pool create and by using offsets instead of saved pointers to do ODP packet / DPDK mbuf conversion.