### PR TITLE
[PATCH v1] Fix ring race condition in pool and scheduler

### DIFF
--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -157,7 +157,7 @@ extern "C" {
  * Maximum number of events in a pool. Power of two minus one results optimal
  * memory usage for the ring.
  */
-#define CONFIG_POOL_MAX_NUM ((1 * 1024 * 1024) - 1)
+#define CONFIG_POOL_MAX_NUM ((256 * 1024) - 1)
 
 /*
  * Maximum number of events in a thread local pool cache

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -154,9 +154,10 @@ extern "C" {
 #define CONFIG_BURST_SIZE 32
 
 /*
- * Maximum number of events in a pool
+ * Maximum number of events in a pool. Power of two minus one results optimal
+ * memory usage for the ring.
  */
-#define CONFIG_POOL_MAX_NUM (1 * 1024 * 1024)
+#define CONFIG_POOL_MAX_NUM ((1 * 1024 * 1024) - 1)
 
 /*
  * Maximum number of events in a thread local pool cache

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -38,7 +38,7 @@ typedef struct ODP_ALIGNED_CACHE {
 	ring_t   hdr;
 
 	/* Ring data: buffer handles */
-	uint32_t buf[CONFIG_POOL_MAX_NUM];
+	uint32_t buf[CONFIG_POOL_MAX_NUM + 1];
 
 } pool_ring_t;
 

--- a/platform/linux-generic/include/odp_ring_internal.h
+++ b/platform/linux-generic/include/odp_ring_internal.h
@@ -23,8 +23,9 @@ extern "C" {
  * Ring stores head and tail counters. Ring indexes are formed from these
  * counters with a mask (mask = ring_size - 1), which requires that ring size
  * must be a power of two. Also ring size must be larger than the maximum
- * number of data items that will be stored on it (there's no check against
- * overwriting). */
+ * number of data items that will be stored on it as write operations are
+ * assumed to succeed eventually (after readers complete their current
+ * operations). */
 typedef struct ODP_ALIGNED_CACHE {
 	/* Writer head and tail */
 	odp_atomic_u32_t w_head;
@@ -33,6 +34,7 @@ typedef struct ODP_ALIGNED_CACHE {
 
 	/* Reader head and tail */
 	odp_atomic_u32_t r_head;
+	odp_atomic_u32_t r_tail;
 
 	uint32_t data[0];
 } ring_t;
@@ -53,6 +55,7 @@ static inline void ring_init(ring_t *ring)
 	odp_atomic_init_u32(&ring->w_head, 0);
 	odp_atomic_init_u32(&ring->w_tail, 0);
 	odp_atomic_init_u32(&ring->r_head, 0);
+	odp_atomic_init_u32(&ring->r_tail, 0);
 }
 
 /* Dequeue data from the ring head */
@@ -75,12 +78,19 @@ static inline uint32_t ring_deq(ring_t *ring, uint32_t mask, uint32_t *data)
 		new_head = head + 1;
 
 	} while (odp_unlikely(cas_mo_u32(&ring->r_head, &head, new_head,
-					 __ATOMIC_ACQ_REL,
+					 __ATOMIC_ACQUIRE,
 					 __ATOMIC_ACQUIRE) == 0));
 
-	/* Read data. CAS acquire-release ensures that data read
-	 * does not move above from here. */
+	/* Read data. */
 	*data = ring->data[new_head & mask];
+
+	/* Wait until other readers have updated the tail */
+	while (odp_unlikely(odp_atomic_load_u32(&ring->r_tail) != head))
+		odp_cpu_pause();
+
+	/* Update the tail. Writers acquire it. */
+	odp_atomic_store_rel_u32(&ring->r_tail, new_head);
+
 	return 1;
 }
 
@@ -110,13 +120,19 @@ static inline uint32_t ring_deq_multi(ring_t *ring, uint32_t mask,
 		new_head = head + num;
 
 	} while (odp_unlikely(cas_mo_u32(&ring->r_head, &head, new_head,
-					 __ATOMIC_ACQ_REL,
+					 __ATOMIC_ACQUIRE,
 					 __ATOMIC_ACQUIRE) == 0));
 
-	/* Read data. CAS acquire-release ensures that data read
-	 * does not move above from here. */
+	/* Read data. */
 	for (i = 0; i < num; i++)
 		data[i] = ring->data[(head + 1 + i) & mask];
+
+	/* Wait until other readers have updated the tail */
+	while (odp_unlikely(odp_atomic_load_u32(&ring->r_tail) != head))
+		odp_cpu_pause();
+
+	/* Update the tail. Writers acquire it. */
+	odp_atomic_store_rel_u32(&ring->r_tail, new_head);
 
 	return num;
 }
@@ -125,16 +141,24 @@ static inline uint32_t ring_deq_multi(ring_t *ring, uint32_t mask,
 static inline void ring_enq(ring_t *ring, uint32_t mask, uint32_t data)
 {
 	uint32_t old_head, new_head;
+	uint32_t size = mask + 1;
 
 	/* Reserve a slot in the ring for writing */
 	old_head = odp_atomic_fetch_inc_u32(&ring->w_head);
 	new_head = old_head + 1;
 
+	/* Wait for the last reader to finish. This prevents overwrite when
+	 * a reader has been left behind (e.g. due to an interrupt) and is
+	 * still reading the same slot. */
+	while (odp_unlikely(new_head - odp_atomic_load_acq_u32(&ring->r_tail)
+			    >= size))
+		odp_cpu_pause();
+
 	/* Write data */
 	ring->data[new_head & mask] = data;
 
 	/* Wait until other writers have updated the tail */
-	while (odp_unlikely(odp_atomic_load_acq_u32(&ring->w_tail) != old_head))
+	while (odp_unlikely(odp_atomic_load_u32(&ring->w_tail) != old_head))
 		odp_cpu_pause();
 
 	/* Release the new writer tail, readers acquire it. */
@@ -146,17 +170,25 @@ static inline void ring_enq_multi(ring_t *ring, uint32_t mask, uint32_t data[],
 				  uint32_t num)
 {
 	uint32_t old_head, new_head, i;
+	uint32_t size = mask + 1;
 
 	/* Reserve a slot in the ring for writing */
 	old_head = odp_atomic_fetch_add_u32(&ring->w_head, num);
 	new_head = old_head + 1;
+
+	/* Wait for the last reader to finish. This prevents overwrite when
+	 * a reader has been left behind (e.g. due to an interrupt) and is
+	 * still reading these slots. */
+	while (odp_unlikely(new_head - odp_atomic_load_acq_u32(&ring->r_tail)
+			    >= size))
+		odp_cpu_pause();
 
 	/* Write data */
 	for (i = 0; i < num; i++)
 		ring->data[(new_head + i) & mask] = data[i];
 
 	/* Wait until other writers have updated the tail */
-	while (odp_unlikely(odp_atomic_load_acq_u32(&ring->w_tail) != old_head))
+	while (odp_unlikely(odp_atomic_load_u32(&ring->w_tail) != old_head))
 		odp_cpu_pause();
 
 	/* Release the new writer tail, readers acquire it. */

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -471,10 +471,11 @@ static odp_pool_t pool_create(const char *name, odp_pool_param_t *params,
 				FIRST_HP_SIZE - 1) / FIRST_HP_SIZE);
 	}
 
-	if (num <= RING_SIZE_MIN)
+	/* Ring size must be larger than the number of items stored */
+	if (num + 1 <= RING_SIZE_MIN)
 		ring_size = RING_SIZE_MIN;
 	else
-		ring_size = ROUNDUP_POWER2_U32(num);
+		ring_size = ROUNDUP_POWER2_U32(num + 1);
 
 	pool->ring_mask      = ring_size - 1;
 	pool->num            = num;

--- a/test/performance/odp_sched_latency.c
+++ b/test/performance/odp_sched_latency.c
@@ -641,11 +641,13 @@ int main(int argc, char *argv[])
 	odph_odpthread_params_t thr_params;
 	odp_cpumask_t cpumask;
 	odp_pool_t pool;
+	odp_pool_capability_t pool_capa;
 	odp_pool_param_t params;
 	odp_shm_t shm;
 	test_globals_t *globals;
 	test_args_t args;
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
+	uint32_t pool_size;
 	int i, j;
 	int ret = 0;
 	int num_workers = 0;
@@ -706,10 +708,19 @@ int main(int argc, char *argv[])
 	/*
 	 * Create event pool
 	 */
+	if (odp_pool_capability(&pool_capa)) {
+		LOG_ERR("pool capa failed\n");
+		return -1;
+	}
+
+	pool_size = EVENT_POOL_SIZE;
+	if (pool_capa.buf.max_num && pool_capa.buf.max_num < EVENT_POOL_SIZE)
+		pool_size = pool_capa.buf.max_num;
+
 	odp_pool_param_init(&params);
 	params.buf.size  = sizeof(test_event_t);
 	params.buf.align = 0;
-	params.buf.num   = EVENT_POOL_SIZE;
+	params.buf.num   = pool_size;
 	params.type      = ODP_POOL_BUFFER;
 
 	pool = odp_pool_create("event_pool", &params);

--- a/test/performance/odp_scheduling.c
+++ b/test/performance/odp_scheduling.c
@@ -30,7 +30,7 @@
 /* GNU lib C */
 #include <getopt.h>
 
-#define NUM_MSG              (512 * 1024)   /**< Number of msg in pool */
+#define MAX_BUF              (512 * 1024)   /**< Maximum pool size */
 #define MAX_ALLOCS            32            /**< Alloc burst size */
 #define QUEUES_PER_PRIO       64            /**< Queue per priority */
 #define NUM_PRIOS             2             /**< Number of tested priorities */
@@ -813,7 +813,8 @@ int main(int argc, char *argv[])
 	odp_instance_t instance;
 	odph_odpthread_params_t thr_params;
 	odp_queue_capability_t capa;
-	uint32_t num_queues;
+	odp_pool_capability_t pool_capa;
+	uint32_t num_queues, num_buf;
 
 	printf("\nODP example starts\n\n");
 
@@ -869,11 +870,19 @@ int main(int argc, char *argv[])
 	/*
 	 * Create message pool
 	 */
+	if (odp_pool_capability(&pool_capa)) {
+		LOG_ERR("Pool capabilities failed.\n");
+		return -1;
+	}
+
+	num_buf = MAX_BUF;
+	if (pool_capa.buf.max_num && pool_capa.buf.max_num < MAX_BUF)
+		num_buf = pool_capa.buf.max_num;
 
 	odp_pool_param_init(&params);
 	params.buf.size  = sizeof(test_message_t);
 	params.buf.align = 0;
-	params.buf.num   = NUM_MSG;
+	params.buf.num   = num_buf;
 	params.type      = ODP_POOL_BUFFER;
 
 	pool = odp_pool_create("msg_pool", &params);

--- a/test/performance/odp_scheduling_run.sh
+++ b/test/performance/odp_scheduling_run.sh
@@ -17,7 +17,12 @@ run()
 	echo odp_scheduling_run starts requesting $1 worker threads
 	echo ===============================================
 
-	$TEST_DIR/odp_scheduling${EXEEXT} -c $1 || ret=1
+	$TEST_DIR/odp_scheduling${EXEEXT} -c $1
+
+	if [ $? -ne 0 ]; then
+		echo odp_scheduling FAILED
+		exit $?
+	fi
 }
 
 run 1
@@ -26,4 +31,4 @@ run 8
 run 11
 run $ALL
 
-exit $ret
+exit 0


### PR DESCRIPTION
This issue was introduced few months back when optimizing the ring enq/deq functions too much. The actual fix is in patch 7. Enqueue operation needs to wait until a potential reader has finished reading the slot it is going to overwrite. This can happen also when there is far less items than ring slots, as a reader may have stalled in the middle of an dequeue operation, while other readers/writers continue use the ring - and eventually wrap around to the same slot the stalled reader is holding.

Other patches are (mainly) fixing issues found when reducing the maximum pool size. Maximum pool size needs to be smaller so that max pool size capability can be offered and tested. Pool size configuration will be moved to config file, since it depends on system memory size. The default will likely stay at 256k packets as it fits under 1GB. User can then use config file to go over 1GB.

Performance impact is 0...-1.8% for tested scheduler performance test cases.
