### PR TITLE
[PATCH v3] Travis tuning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,17 @@ jobs:
                           - docker run --privileged -i -t
                               -v `pwd`:/odp --shm-size 8g
                               -e CC="${CC}"
-                              -e CONF="${CONF}"
+                              -e CONF="--enable-user-guides"
+                              ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/distcheck.sh
+                - stage: test
+                  env: TEST=distcheck_nonabi
+                  compiler: gcc
+                  script:
+                          - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
+                          - docker run --privileged -i -t
+                              -v `pwd`:/odp --shm-size 8g
+                              -e CC="${CC}"
+                              -e CONF="--enable-user-guides --disable-abi-compat"
                               ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/distcheck.sh
                 - stage: "build only"
                   env: TEST=doxygen

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,28 @@ script:
 jobs:
         include:
                 - stage: test
+                  env: TEST=scheduler_sp
+                  compiler: gcc
+                  script:
+                          - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
+                          - docker run --privileged -i -t
+                              -v `pwd`:/odp --shm-size 8g
+                              -e CC="${CC}"
+                              -e CONF=""
+                              -e ODP_SCHEDULER=sp
+                              ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/check.sh
+                - stage: test
+                  env: TEST=scheduler_scalable
+                  compiler: gcc
+                  script:
+                          - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
+                          - docker run --privileged -i -t
+                              -v `pwd`:/odp --shm-size 8g
+                              -e CC="${CC}"
+                              -e CONF=""
+                              -e ODP_SCHEDULER=scalable
+                              ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/check.sh
+                - stage: test
                   env: TEST=process_mode
                   install:
                           - true

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,11 @@ env:
         - CODECOV_TOKEN=a733c34c-5f5c-4ff1-af4b-e9f5edb1ab5e
         - UBUNTU_VERS="16.04"
         - BUILD_ONLY=0
+        - NETMAP=0
     matrix:
         - CONF=""
         - CONF="--disable-abi-compat"
+        - NETMAP=1 CONF=""
         - BUILD_ONLY=1 ARCH="arm64"
         - BUILD_ONLY=1 ARCH="armhf"
         - BUILD_ONLY=1 ARCH="powerpc"
@@ -58,7 +60,7 @@ env:
         - BUILD_ONLY=1 ARCH="i386" CONF="--disable-abi-compat"
         - CONF="--enable-deprecated"
         - CONF="--enable-dpdk-zero-copy --disable-static-applications"
-        - CONF="--disable-static-applications"
+        - NETMAP=1 CONF="--disable-static-applications"
         - CONF="--disable-host-optimization"
         - CONF="--disable-host-optimization --disable-abi-compat"
         - BUILD_ONLY=1 ARCH="x86_64" CONF="--enable-pcapng-support"
@@ -77,13 +79,13 @@ compiler:
         - clang
 
 install:
-        - sudo apt-get install linux-headers-`uname -r`
-        - if [ -z "${ARCH}" -o "${ARCH}" == "x86_64" ] ; then
-               echo "compilling netmap";
+        - if [ ${NETMAP} -eq 1 ] ; then
+               echo "Installing NETMAP";
+               sudo apt-get install linux-headers-`uname -r` ;
                CDIR=`pwd` ;
                git -c advice.detachedHead=false clone -q --depth=1 --single-branch --branch=v11.2 https://github.com/luigirizzo/netmap.git;
                pushd netmap/LINUX;
-               ./configure;
+               ./configure --drivers= ;
                make -j $(nproc);
                popd;
                sudo insmod ./netmap/LINUX/netmap.ko;

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ cache:
                 - netmap
                 - $HOME/doxygen-install
 
+compiler:
+        - gcc
+        - clang
+
 env:
     global:
         #
@@ -73,10 +77,6 @@ matrix:
     env: BUILD_ONLY=1 ARCH="arm64"
   - compiler: gcc
     env: BUILD_ONLY=1 ARCH="i386"
-
-compiler:
-        - gcc
-        - clang
 
 install:
         - if [ ${NETMAP} -eq 1 ] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,12 +129,11 @@ jobs:
                           - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
                           - docker run --privileged -i -t
                               -v `pwd`:/odp --shm-size 8g
-                              -e CODECOV_TOKEN="${CODECOV_TOKEN}"
                               -e CC="${CC}"
-                              -e CONF="${CONF}"
+                              -e CONF=""
                               -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/process-mode.conf
                               -e ODPH_PROC_MODE=1
-                              ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_${UBUNTU_VERS} /odp/scripts/ci/check.sh ;
+                              ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/check.sh
                 - stage: test
                   env: TEST=coverage
                   compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ env:
         - CONF="--disable-static-applications"
         - CONF="--disable-host-optimization"
         - CONF="--disable-host-optimization --disable-abi-compat"
-        - CONF="--enable-pcapng-support"
+        - BUILD_ONLY=1 ARCH="x86_64" CONF="--enable-pcapng-support"
         - CONF="--without-openssl"
         - CONF="" UBUNTU_VERS="18.04"
 
@@ -85,7 +85,7 @@ install:
 script:
         - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
         - if [ ${BUILD_ONLY} -eq 1 ] ; then
-               docker run  -i -t -v `pwd`:/odp
+               docker run  -i -t -v `pwd`:/odp --shm-size 8g
                  -e CC="${CC}"
                  -e CONF="${CONF}"
                  ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_${UBUNTU_VERS} /odp/scripts/ci/build_${ARCH}.sh ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,16 @@ script:
 jobs:
         include:
                 - stage: test
+                  env: TEST=coverage
+                  compiler: gcc
+                  script:
+                          - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
+                          - docker run --privileged -i -t
+                              -v `pwd`:/odp --shm-size 8g
+                              -e CODECOV_TOKEN="${CODECOV_TOKEN}"
+                              -e CC="${CC}"
+                              ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/coverage.sh
+                - stage: test
                   env: TEST=scheduler_sp
                   compiler: gcc
                   script:
@@ -142,17 +152,6 @@ jobs:
                               -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/process-mode.conf
                               -e ODPH_PROC_MODE=1
                               ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/check.sh
-                - stage: test
-                  env: TEST=coverage
-                  compiler: gcc
-                  script:
-                          - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
-                          - docker run --privileged -i -t
-                              -v `pwd`:/odp --shm-size 8g
-                              -e CODECOV_TOKEN="${CODECOV_TOKEN}"
-                              -e CC="${CC}"
-                              -e CONF="${CONF}"
-                              ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/coverage.sh
                 - stage: test
                   env: TEST=distcheck
                   compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,17 +44,18 @@ env:
         # you need generated new one at https://codecov.io specific for your repo.
         - CODECOV_TOKEN=a733c34c-5f5c-4ff1-af4b-e9f5edb1ab5e
         - UBUNTU_VERS="16.04"
+        - BUILD_ONLY=0
     matrix:
         - CONF=""
         - CONF="--disable-abi-compat"
-        - CROSS_ARCH="arm64"
-        - CROSS_ARCH="armhf"
-        - CROSS_ARCH="powerpc"
-        - CROSS_ARCH="i386"
-        - CROSS_ARCH="arm64" CONF="--disable-abi-compat"
-        - CROSS_ARCH="armhf" CONF="--disable-abi-compat"
-        - CROSS_ARCH="powerpc" CONF="--disable-abi-compat"
-        - CROSS_ARCH="i386" CONF="--disable-abi-compat"
+        - BUILD_ONLY=1 ARCH="arm64"
+        - BUILD_ONLY=1 ARCH="armhf"
+        - BUILD_ONLY=1 ARCH="powerpc"
+        - BUILD_ONLY=1 ARCH="i386"
+        - BUILD_ONLY=1 ARCH="arm64" CONF="--disable-abi-compat"
+        - BUILD_ONLY=1 ARCH="armhf" CONF="--disable-abi-compat"
+        - BUILD_ONLY=1 ARCH="powerpc" CONF="--disable-abi-compat"
+        - BUILD_ONLY=1 ARCH="i386" CONF="--disable-abi-compat"
         - CONF="--enable-deprecated"
         - CONF="--enable-dpdk-zero-copy --disable-static-applications"
         - CONF="--disable-static-applications"
@@ -70,7 +71,7 @@ compiler:
 
 install:
         - sudo apt-get install linux-headers-`uname -r`
-        - if [ -z "${CROSS_ARCH}" ] ; then
+        - if [ -z "${ARCH}" -o "${ARCH}" == "x86_64" ] ; then
                echo "compilling netmap";
                CDIR=`pwd` ;
                git -c advice.detachedHead=false clone -q --depth=1 --single-branch --branch=v11.2 https://github.com/luigirizzo/netmap.git;
@@ -83,11 +84,11 @@ install:
           fi
 script:
         - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
-        - if [ -n "${CROSS_ARCH}" ] ; then
+        - if [ ${BUILD_ONLY} -eq 1 ] ; then
                docker run  -i -t -v `pwd`:/odp
                  -e CC="${CC}"
                  -e CONF="${CONF}"
-                 ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_${UBUNTU_VERS} /odp/scripts/ci/build_${CROSS_ARCH}.sh ;
+                 ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_${UBUNTU_VERS} /odp/scripts/ci/build_${ARCH}.sh ;
           else
                echo "Running test" ;
                docker run --privileged -i -t

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,13 @@ env:
         - CONF="--without-openssl"
         - CONF="" UBUNTU_VERS="18.04"
 
+matrix:
+  exclude:
+  - compiler: gcc
+    env: BUILD_ONLY=1 ARCH="arm64"
+  - compiler: gcc
+    env: BUILD_ONLY=1 ARCH="i386"
+
 compiler:
         - gcc
         - clang

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$0")"/../..
 	--prefix=/opt/odp \
 	${CONF}
 
-make -j 8
+make -j $(nproc)
 
 make install
 

--- a/scripts/ci/distcheck.sh
+++ b/scripts/ci/distcheck.sh
@@ -7,15 +7,13 @@ fi
 
 cd "$(dirname "$0")"/../..
 ./bootstrap
-./configure \
-	--enable-user-guides
+./configure ${CONF}
 
 # Ignore possible failures there because these tests depends on measurements
 # and systems might differ in performance.
 export CI="true"
 
+# Additional configure flags for distcheck
+export DISTCHECK_CONFIGURE_FLAGS="${CONF}"
+
 make distcheck
-
-make clean
-
-make distcheck DISTCHECK__CONFIGURE_FLAGS=--disable-abi-compat


### PR DESCRIPTION
Tune, fix and (try to) optimize travis build/test sequence. Many small patches are used for easier validation that each fix works as it should.

Build/test time optimizations:
- Use make -j
- Prefer many equal length tests vs one long test => enables parallel execution
- Start long test early => enables parallel execution of other jobs while the long one is running
- Avoid duplicate tests, and duplicate 'make check' when build only is enough
- Fail fast. Run first all tests with GCC, if all those pass it's very likely that the same passes on clang (first phase include already generic clang build)
- Don't install and test Netmap on every test case. Many test cases do not affect netmap operation, but netmap build/test takes time

Fixes:
- Build/test optional schedulers (sp and scalable) with normal compiler flags (== optimizations on)

Additionally, it seems that netmap tests has been (and are still) skipped. So, there's no difference in netmap vs non-netmap test times, but there should once netmap tests are fixed to run again. 

Travis run time improvement:1 hr 36 min 36 sec -  1 hr 21 min 33 sec = 15min
V3: 1 hr 37 min 23 sec - 1 hr 22 min 12 sec = 15min
