### PR TITLE
[PATCH v2] Pool config file option

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.0"
+config_file_version = "0.1.1"
 
 # Shared memory options
 shm: {
@@ -37,6 +37,16 @@ shm: {
 	# Allocate internal shared memory using a single virtual address space.
 	# Set to 1 to enable using process mode.
 	single_va = 0
+}
+
+# Pool options
+pool: {
+	# Packet pool options
+	pkt: {
+		# Maximum number of packets per pool. Power of two minus one
+		# results optimal memory usage (e.g. (256 * 1024) - 1).
+		max_num = 262143
+	}
 }
 
 # DPDK pktio options

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -27,13 +27,6 @@ extern "C" {
 #define ODP_CONFIG_QUEUES 1024
 
 /*
- * Maximum queue depth. Maximum number of elements that can be stored in a
- * queue. This value is used only when the size is not explicitly provided
- * during queue creation.
- */
-#define CONFIG_QUEUE_SIZE 4096
-
-/*
  * Maximum number of ordered locks per queue
  */
 #define CONFIG_QUEUE_MAX_ORD_LOCKS 2

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -150,7 +150,7 @@ extern "C" {
  * Maximum number of events in a pool. Power of two minus one results optimal
  * memory usage for the ring.
  */
-#define CONFIG_POOL_MAX_NUM ((256 * 1024) - 1)
+#define CONFIG_POOL_MAX_NUM ((1024 * 1024) - 1)
 
 /*
  * Maximum number of events in a thread local pool cache

--- a/platform/linux-generic/include/odp_pool_internal.h
+++ b/platform/linux-generic/include/odp_pool_internal.h
@@ -89,6 +89,11 @@ typedef struct pool_t {
 typedef struct pool_table_t {
 	pool_t    pool[ODP_CONFIG_POOLS];
 	odp_shm_t shm;
+
+	struct {
+		uint32_t pkt_max_num;
+	} config;
+
 } pool_table_t;
 
 extern pool_table_t *pool_tbl;

--- a/platform/linux-generic/include/odp_schedule_scalable_config.h
+++ b/platform/linux-generic/include/odp_schedule_scalable_config.h
@@ -9,6 +9,9 @@
 #ifndef ODP_SCHEDULE_SCALABLE_CONFIG_H_
 #define ODP_SCHEDULE_SCALABLE_CONFIG_H_
 
+/* Maximum number of events that can be stored in a queue */
+#define CONFIG_SCAL_QUEUE_SIZE 4096
+
 /*
  * Default scaling factor for the scheduler group
  *

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -572,6 +572,17 @@ static int check_params(odp_pool_param_t *params)
 		break;
 
 	case ODP_POOL_PACKET:
+		if (params->pkt.num > capa.pkt.max_num) {
+			ODP_ERR("pkt.num too large %u\n", params->pkt.num);
+			return -1;
+		}
+
+		if (params->pkt.max_num > capa.pkt.max_num) {
+			ODP_ERR("pkt.max_num too large %u\n",
+				params->pkt.max_num);
+			return -1;
+		}
+
 		if (params->pkt.len > capa.pkt.max_len) {
 			ODP_ERR("pkt.len too large %u\n", params->pkt.len);
 			return -1;
@@ -592,6 +603,12 @@ static int check_params(odp_pool_param_t *params)
 		if (params->pkt.uarea_size > capa.pkt.max_uarea_size) {
 			ODP_ERR("pkt.uarea_size too large %u\n",
 				params->pkt.uarea_size);
+			return -1;
+		}
+
+		if (params->pkt.headroom > capa.pkt.max_headroom) {
+			ODP_ERR("pkt.headroom too large %u\n",
+				params->pkt.headroom);
 			return -1;
 		}
 

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -555,17 +555,17 @@ static int check_params(odp_pool_param_t *params)
 	switch (params->type) {
 	case ODP_POOL_BUFFER:
 		if (params->buf.num > capa.buf.max_num) {
-			ODP_DBG("buf.num too large %u\n", params->buf.num);
+			ODP_ERR("buf.num too large %u\n", params->buf.num);
 			return -1;
 		}
 
 		if (params->buf.size > capa.buf.max_size) {
-			ODP_DBG("buf.size too large %u\n", params->buf.size);
+			ODP_ERR("buf.size too large %u\n", params->buf.size);
 			return -1;
 		}
 
 		if (params->buf.align > capa.buf.max_align) {
-			ODP_DBG("buf.align too large %u\n", params->buf.align);
+			ODP_ERR("buf.align too large %u\n", params->buf.align);
 			return -1;
 		}
 
@@ -573,24 +573,24 @@ static int check_params(odp_pool_param_t *params)
 
 	case ODP_POOL_PACKET:
 		if (params->pkt.len > capa.pkt.max_len) {
-			ODP_DBG("pkt.len too large %u\n", params->pkt.len);
+			ODP_ERR("pkt.len too large %u\n", params->pkt.len);
 			return -1;
 		}
 
 		if (params->pkt.max_len > capa.pkt.max_len) {
-			ODP_DBG("pkt.max_len too large %u\n",
+			ODP_ERR("pkt.max_len too large %u\n",
 				params->pkt.max_len);
 			return -1;
 		}
 
 		if (params->pkt.seg_len > capa.pkt.max_seg_len) {
-			ODP_DBG("pkt.seg_len too large %u\n",
+			ODP_ERR("pkt.seg_len too large %u\n",
 				params->pkt.seg_len);
 			return -1;
 		}
 
 		if (params->pkt.uarea_size > capa.pkt.max_uarea_size) {
-			ODP_DBG("pkt.uarea_size too large %u\n",
+			ODP_ERR("pkt.uarea_size too large %u\n",
 				params->pkt.uarea_size);
 			return -1;
 		}
@@ -599,13 +599,13 @@ static int check_params(odp_pool_param_t *params)
 
 	case ODP_POOL_TIMEOUT:
 		if (params->tmo.num > capa.tmo.max_num) {
-			ODP_DBG("tmo.num too large %u\n", params->tmo.num);
+			ODP_ERR("tmo.num too large %u\n", params->tmo.num);
 			return -1;
 		}
 		break;
 
 	default:
-		ODP_DBG("bad pool type %i\n", params->type);
+		ODP_ERR("bad pool type %i\n", params->type);
 		return -1;
 	}
 

--- a/platform/linux-generic/odp_pool.c
+++ b/platform/linux-generic/odp_pool.c
@@ -22,6 +22,7 @@
 #include <odp_ring_internal.h>
 #include <odp_shm_internal.h>
 #include <odp_global_data.h>
+#include <odp_libconfig_internal.h>
 
 #include <string.h>
 #include <stdio.h>
@@ -33,8 +34,9 @@
 #define UNLOCK(a)    odp_ticketlock_unlock(a)
 #define LOCK_INIT(a) odp_ticketlock_init(a)
 
-#define CACHE_BURST    32
-#define RING_SIZE_MIN  (2 * CACHE_BURST)
+#define CACHE_BURST       32
+#define RING_SIZE_MIN     (2 * CACHE_BURST)
+#define POOL_MAX_NUM_MIN  RING_SIZE_MIN
 
 /* Make sure packet buffers don't cross huge page boundaries starting from this
  * page size. 2MB is typically the smallest used huge page size. */
@@ -83,6 +85,32 @@ static inline pool_t *pool_from_buf(odp_buffer_t buf)
 	return buf_hdr->pool_ptr;
 }
 
+static int read_config_file(pool_table_t *pool_tbl)
+{
+	const char *str;
+	int val = 0;
+
+	ODP_PRINT("Pool config:\n");
+
+	str = "pool.pkt.max_num";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+
+	if (val > CONFIG_POOL_MAX_NUM || val < POOL_MAX_NUM_MIN) {
+		ODP_ERR("Bad value %s = %u\n", str, val);
+		return -1;
+	}
+
+	pool_tbl->config.pkt_max_num = val;
+	ODP_PRINT("  %s: %i\n", str, val);
+
+	ODP_PRINT("\n");
+
+	return 0;
+}
+
 int odp_pool_init_global(void)
 {
 	uint32_t i;
@@ -100,6 +128,11 @@ int odp_pool_init_global(void)
 
 	memset(pool_tbl, 0, sizeof(pool_table_t));
 	pool_tbl->shm = shm;
+
+	if (read_config_file(pool_tbl)) {
+		odp_shm_free(shm);
+		return -1;
+	}
 
 	for (i = 0; i < ODP_CONFIG_POOLS; i++) {
 		pool_t *pool = pool_entry(i);
@@ -950,7 +983,7 @@ int odp_pool_capability(odp_pool_capability_t *capa)
 	/* Packet pools */
 	capa->pkt.max_pools        = ODP_CONFIG_POOLS;
 	capa->pkt.max_len          = CONFIG_PACKET_MAX_LEN;
-	capa->pkt.max_num	   = CONFIG_POOL_MAX_NUM;
+	capa->pkt.max_num	   = pool_tbl->config.pkt_max_num;
 	capa->pkt.min_headroom     = CONFIG_PACKET_HEADROOM;
 	capa->pkt.max_headroom     = CONFIG_PACKET_HEADROOM;
 	capa->pkt.min_tailroom     = CONFIG_PACKET_TAILROOM;

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -110,7 +110,7 @@ static int queue_init(queue_entry_t *queue, const char *name,
 
 	sched_elem = &queue->s.sched_elem;
 	ring_size = param->size > 0 ?
-		ROUNDUP_POWER2_U32(param->size) : CONFIG_QUEUE_SIZE;
+		ROUNDUP_POWER2_U32(param->size) : CONFIG_SCAL_QUEUE_SIZE;
 	strncpy(queue->s.name, name ? name : "", ODP_QUEUE_NAME_LEN - 1);
 	queue->s.name[ODP_QUEUE_NAME_LEN - 1] = 0;
 	memcpy(&queue->s.param, param, sizeof(odp_queue_param_t));
@@ -212,15 +212,16 @@ static int queue_init_global(void)
 		/* Add size of the array holding the queues */
 		pool_size = sizeof(queue_table_t);
 		/* Add storage required for queues */
-		pool_size += (CONFIG_QUEUE_SIZE * sizeof(odp_buffer_hdr_t *)) *
-			     ODP_CONFIG_QUEUES;
+		pool_size += (CONFIG_SCAL_QUEUE_SIZE *
+			      sizeof(odp_buffer_hdr_t *)) * ODP_CONFIG_QUEUES;
+
 		/* Add the reorder window size */
 		pool_size += sizeof(reorder_window_t) * ODP_CONFIG_QUEUES;
 		/* Choose min_alloc and max_alloc such that buddy allocator is
 		 * is selected.
 		 */
 		min_alloc = 0;
-		max_alloc = CONFIG_QUEUE_SIZE * sizeof(odp_buffer_hdr_t *);
+		max_alloc = CONFIG_SCAL_QUEUE_SIZE * sizeof(odp_buffer_hdr_t *);
 		queue_shm_pool = _odp_ishm_pool_create("queue_shm_pool",
 						       pool_size,
 						       min_alloc, max_alloc,

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.0"
+config_file_version = "0.1.1"
 
 # Shared memory options
 shm: {


### PR DESCRIPTION
Add max num packets into config file as by default the max num packets needed to be limited to 256k. Changed max pool size back to 1M. So, that user can again create 1M packet pools (with config file change) if system memory allows.

Also cleaned up config header file as there was a scalable queue specific config.