### PR TITLE
[PATCH v1] linux-gen: pool: increase minimum packet segment length

### DIFF
--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -125,8 +125,8 @@ extern "C" {
  * defined segment length (seg_len in odp_pool_param_t) will be rounded up into
  * this value.
  */
-#define CONFIG_PACKET_SEG_LEN_MIN ((2 * 1024) - \
-				   CONFIG_PACKET_HEADROOM - \
+#define CONFIG_PACKET_SEG_LEN_MIN ((2 * 1024) + \
+				   CONFIG_PACKET_HEADROOM + \
 				   CONFIG_PACKET_TAILROOM)
 
 /* Maximum number of shared memory blocks.

--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -327,6 +327,13 @@ static struct rte_mempool *mbuf_pool_create(const char *name,
 		goto fail;
 	}
 
+	if (pool_entry->seg_len < RTE_MBUF_DEFAULT_BUF_SIZE) {
+		ODP_ERR("Some NICs need at least %dB buffers to not segment "
+			 "standard ethernet frames. Increase pool seg_len.\n",
+			 RTE_MBUF_DEFAULT_BUF_SIZE);
+		goto fail;
+	}
+
 	total_size = rte_mempool_calc_obj_size(elt_size, MEMPOOL_F_NO_SPREAD,
 					       &sz);
 	if (total_size != pool_entry->block_size) {


### PR DESCRIPTION
Some DPDK NICs need at least 2176 byte buffers (2048B + headroom) to not
segment standard ethernet frames. Increase minimum segment length to avoid
this and add matching check to zero-copy dpdk pktio pool create.

Reported-by: P. Gyanesh Kumar Patra <pgyanesh.patra@gmail.com>
Signed-off-by: Matias Elo <matias.elo@nokia.com>