### PR TITLE
[PATCH API-NEXT v2] api: init: add use_single_va member to odp_init_t

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.3"
+config_file_version = "0.1.4"
 
 # Shared memory options
 shm: {
@@ -33,10 +33,6 @@ shm: {
 	# When using process mode threads, this value should be set to 0
 	# because the current implementation won't work properly otherwise.
 	num_cached_hp = 0
-
-	# Allocate internal shared memory using a single virtual address space.
-	# Set to 1 to enable using process mode.
-	single_va = 0
 }
 
 # Pool options

--- a/example/ipsec/odp_ipsec.c
+++ b/example/ipsec/odp_ipsec.c
@@ -1186,6 +1186,7 @@ int pktio_thread(void *arg EXAMPLE_UNUSED)
 int
 main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	int num_workers;
 	int i;
@@ -1195,6 +1196,7 @@ main(int argc, char *argv[])
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 	odp_pool_param_t params;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 
 	/* create by default scheduled queues */
@@ -1207,8 +1209,19 @@ main(int argc, char *argv[])
 		schedule = polled_odp_schedule_cb;
 	}
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		EXAMPLE_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		EXAMPLE_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}
@@ -1401,9 +1414,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	};
 
 	static const char *shortopts = "+c:i:m:h:r:p:a:e:t:s:";
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	printf("\nParsing command line options\n");
 

--- a/example/ipsec_api/odp_ipsec.c
+++ b/example/ipsec_api/odp_ipsec.c
@@ -885,6 +885,7 @@ int pktio_thread(void *arg EXAMPLE_UNUSED)
 int
 main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	int num_workers;
 	int i;
@@ -894,6 +895,7 @@ main(int argc, char *argv[])
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 	odp_pool_param_t params;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 
 	/* create by default scheduled queues */
@@ -906,8 +908,19 @@ main(int argc, char *argv[])
 		schedule = polled_odp_schedule_cb;
 	}
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		EXAMPLE_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		EXAMPLE_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}
@@ -1102,9 +1115,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	};
 
 	static const char *shortopts = "+c:i:h:lm:r:p:a:e:t:s:";
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	appl_args->cpu_count = 1; /* use one worker by default */
 

--- a/example/packet/odp_pktio.c
+++ b/example/packet/odp_pktio.c
@@ -343,6 +343,7 @@ static int pktio_ifburst_thread(void *arg)
  */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	odp_pool_t pool;
 	int num_workers;
@@ -352,11 +353,23 @@ int main(int argc, char *argv[])
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 	odp_pool_param_t params;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 	odp_shm_t shm;
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		EXAMPLE_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		EXAMPLE_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}
@@ -581,9 +594,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	};
 
 	static const char *shortopts = "+c:i:+m:t:h";
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	appl_args->cpu_count = 1; /* use one worker by default */
 	appl_args->mode = APPL_MODE_PKT_SCHED;

--- a/example/time/time_global_test.c
+++ b/example/time/time_global_test.c
@@ -254,16 +254,26 @@ int main(int argc, char *argv[])
 	odp_shm_t shm_glbls = ODP_SHM_INVALID;
 	odp_shm_t shm_log = ODP_SHM_INVALID;
 	int log_size, log_enries_num;
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	printf("\nODP global time test starts\n");
 
-	if (odp_init_global(&instance, NULL, NULL)) {
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		EXAMPLE_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		err = 1;
 		EXAMPLE_ERR("ODP global init failed.\n");
 		goto end;

--- a/example/timer/odp_timer_test.c
+++ b/example/timer/odp_timer_test.c
@@ -274,9 +274,6 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 
 	static const char *shortopts = "+c:r:m:x:p:t:h";
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	/* defaults */
 	odp_timer_capability(ODP_CLOCK_CPU, &timer_capa);
 
@@ -334,6 +331,7 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
  */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	int num_workers;
 	odp_queue_t queue;
@@ -345,6 +343,7 @@ int main(int argc, char *argv[])
 	odp_cpumask_t cpumask;
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 	odp_shm_t shm = ODP_SHM_INVALID;
 	test_globals_t *gbls = NULL;
@@ -352,7 +351,18 @@ int main(int argc, char *argv[])
 
 	printf("\nODP timer example starts\n");
 
-	if (odp_init_global(&instance, NULL, NULL)) {
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		EXAMPLE_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		err = 1;
 		printf("ODP global init failed.\n");
 		goto err_global;

--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -94,6 +94,11 @@ typedef struct {
 	};
 } odph_odpthread_t;
 
+/** Linux helper options */
+typedef struct {
+	odph_linux_thread_type_t linux_thr_type; /**< Process or pthread */
+} odph_helper_options_t;
+
 /**
  * Creates and launches odpthreads (as linux threads or processes)
  *
@@ -158,6 +163,18 @@ int odph_odpthread_getaffinity(void);
  *         the number of removed helper options.
  */
 int odph_parse_options(int argc, char *argv[]);
+
+/**
+ * Get linux helper options
+ *
+ * Return used ODP helper options. odph_parse_options() must be called before
+ * using this function.
+ *
+ * @param[out] options  ODP helper options
+ *
+ * @return 0 on success, -1 on failure
+ */
+int odph_options(odph_helper_options_t *options);
 
 /**
  * @}

--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -55,11 +55,10 @@ typedef struct {
 } odph_linux_process_t;
 
 /** odpthread linux type: whether an ODP thread is a linux thread or process */
-typedef enum odph_odpthread_linuxtype_e {
-	ODPTHREAD_NOT_STARTED = 0,
-	ODPTHREAD_PROCESS,
-	ODPTHREAD_PTHREAD
-} odph_odpthread_linuxtype_t;
+typedef enum odph_linux_thread_type_e {
+	ODPH_THREAD_PTHREAD = 0,
+	ODPH_THREAD_PROCESS
+} odph_linux_thread_type_t;
 
 /** odpthread parameters for odp threads (pthreads and processes) */
 typedef struct {
@@ -71,7 +70,7 @@ typedef struct {
 
 /** The odpthread starting arguments, used both in process or thread mode */
 typedef struct {
-	odph_odpthread_linuxtype_t linuxtype; /**< process or pthread */
+	odph_linux_thread_type_t linux_thr_type; /**< process or pthread */
 	odph_odpthread_params_t thr_params; /**< odpthread start parameters */
 } odph_odpthread_start_args_t;
 

--- a/helper/test/odpthreads.c
+++ b/helper/test/odpthreads.c
@@ -64,18 +64,28 @@ static int worker_fn(void *arg ODPH_UNUSED)
 /* Create additional dataplane opdthreads */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_params_t thr_params;
 	odph_odpthread_t thread_tbl[NUMBER_WORKERS];
 	odp_cpumask_t cpu_mask;
+	odp_init_t init_param;
 	int num_workers;
 	int cpu, affinity;
 	int ret;
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
 	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		ODPH_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
 
-	if (odp_init_global(&odp_instance, NULL, NULL)) {
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (odp_init_global(&odp_instance, &init_param, NULL)) {
 		ODPH_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}

--- a/helper/threads.c
+++ b/helper/threads.c
@@ -23,9 +23,7 @@
 
 #define FAILED_CPU -1
 
-static struct {
-	int proc; /* true when process mode is required, false otherwise */
-} helper_options;
+static odph_helper_options_t helper_options;
 
 /*
  * wrapper for odpthreads, either implemented as linux threads or processes.
@@ -181,7 +179,7 @@ int odph_odpthreads_create(odph_odpthread_t *thread_tbl,
 
 	cpu = odp_cpumask_first(mask);
 	for (i = 0; i < num; i++) {
-		if (!helper_options.proc) {
+		if (helper_options.linux_thr_type == ODPH_THREAD_PTHREAD) {
 			if (odph_linux_thread_create(&thread_tbl[i],
 						     cpu,
 						     thr_params))
@@ -330,19 +328,19 @@ int odph_parse_options(int argc, char *argv[])
 	char *env;
 	int i, j;
 
-	helper_options.proc = 0;
+	helper_options.linux_thr_type = ODPH_THREAD_PTHREAD;
 
 	/* Enable process mode using environment variable. Setting environment
 	 * variable is easier for CI testing compared to command line
 	 * argument. */
 	env = getenv("ODPH_PROC_MODE");
 	if (env && atoi(env))
-		helper_options.proc = 1;
+		helper_options.linux_thr_type = ODPH_THREAD_PROCESS;
 
 	/* Find and remove option */
 	for (i = 0; i < argc;) {
 		if (strcmp(argv[i], "--odph_proc") == 0) {
-			helper_options.proc = 1;
+			helper_options.linux_thr_type = ODPH_THREAD_PROCESS;
 
 			for (j = i; j < argc - 1; j++)
 				argv[j] = argv[j + 1];
@@ -355,4 +353,13 @@ int odph_parse_options(int argc, char *argv[])
 	}
 
 	return argc;
+}
+
+int odph_options(odph_helper_options_t *options)
+{
+	memset(options, 0, sizeof(odph_helper_options_t));
+
+	options->linux_thr_type = helper_options.linux_thr_type;
+
+	return 0;
 }

--- a/helper/threads.c
+++ b/helper/threads.c
@@ -21,6 +21,8 @@
 #include <odp/helper/threads.h>
 #include "odph_debug.h"
 
+#define FAILED_CPU -1
+
 static struct {
 	int proc; /* true when process mode is required, false otherwise */
 } helper_options;
@@ -42,7 +44,7 @@ static void *_odph_thread_run_start_routine(void *arg)
 	/* ODP thread local init */
 	if (odp_init_local(thr_params->instance, thr_params->thr_type)) {
 		ODPH_ERR("Local init failed\n");
-		if (start_args->linuxtype == ODPTHREAD_PROCESS)
+		if (start_args->linux_thr_type == ODPH_THREAD_PROCESS)
 			_exit(EXIT_FAILURE);
 		return (void *)-1;
 	}
@@ -50,7 +52,7 @@ static void *_odph_thread_run_start_routine(void *arg)
 	ODPH_DBG("helper: ODP %s thread started as linux %s. (pid=%d)\n",
 		 thr_params->thr_type == ODP_THREAD_WORKER ?
 		 "worker" : "control",
-		 (start_args->linuxtype == ODPTHREAD_PTHREAD) ?
+		 (start_args->linux_thr_type == ODPH_THREAD_PTHREAD) ?
 		 "pthread" : "process",
 		 (int)getpid());
 
@@ -61,7 +63,7 @@ static void *_odph_thread_run_start_routine(void *arg)
 		ODPH_ERR("Local term failed\n");
 
 	/* for process implementation of odp threads, just return status... */
-	if (start_args->linuxtype == ODPTHREAD_PROCESS)
+	if (start_args->linux_thr_type == ODPH_THREAD_PROCESS)
 		_exit(status);
 
 	/* threads implementation return void* pointers: cast status to that. */
@@ -81,14 +83,14 @@ static int _odph_linux_process_create(odph_odpthread_t *thread_tbl,
 	CPU_ZERO(&cpu_set);
 	CPU_SET(cpu, &cpu_set);
 
-	thread_tbl->start_args.thr_params    = *thr_params; /* copy */
-	thread_tbl->start_args.linuxtype     = ODPTHREAD_PROCESS;
+	thread_tbl->start_args.thr_params = *thr_params; /* copy */
+	thread_tbl->start_args.linux_thr_type = ODPH_THREAD_PROCESS;
 	thread_tbl->cpu = cpu;
 
 	pid = fork();
 	if (pid < 0) {
 		ODPH_ERR("fork() failed\n");
-		thread_tbl->start_args.linuxtype = ODPTHREAD_NOT_STARTED;
+		thread_tbl->cpu = FAILED_CPU;
 		return -1;
 	}
 
@@ -136,8 +138,8 @@ static int odph_linux_thread_create(odph_odpthread_t *thread_tbl,
 	pthread_attr_setaffinity_np(&thread_tbl->thread.attr,
 				    sizeof(cpu_set_t), &cpu_set);
 
-	thread_tbl->start_args.thr_params    = *thr_params; /* copy */
-	thread_tbl->start_args.linuxtype     = ODPTHREAD_PTHREAD;
+	thread_tbl->start_args.thr_params = *thr_params; /* copy */
+	thread_tbl->start_args.linux_thr_type = ODPH_THREAD_PTHREAD;
 
 	ret = pthread_create(&thread_tbl->thread.thread_id,
 			     &thread_tbl->thread.attr,
@@ -145,7 +147,7 @@ static int odph_linux_thread_create(odph_odpthread_t *thread_tbl,
 			     &thread_tbl->start_args);
 	if (ret != 0) {
 		ODPH_ERR("Failed to start thread on cpu #%d\n", cpu);
-		thread_tbl->start_args.linuxtype = ODPTHREAD_NOT_STARTED;
+		thread_tbl->cpu = FAILED_CPU;
 		return ret;
 	}
 
@@ -215,9 +217,13 @@ int odph_odpthreads_join(odph_odpthread_t *thread_tbl)
 
 	/* joins linux threads or wait for processes */
 	do {
+		if (thread_tbl[i].cpu == FAILED_CPU) {
+			ODPH_DBG("ODP thread %d not started.\n", i);
+			continue;
+		}
 		/* pthreads: */
-		switch (thread_tbl[i].start_args.linuxtype) {
-		case ODPTHREAD_PTHREAD:
+		if (thread_tbl[i].start_args.linux_thr_type ==
+				ODPH_THREAD_PTHREAD) {
 			/* Wait thread to exit */
 			ret = pthread_join(thread_tbl[i].thread.thread_id,
 					   &thread_ret);
@@ -234,10 +240,7 @@ int odph_odpthreads_join(odph_odpthread_t *thread_tbl)
 				}
 			}
 			pthread_attr_destroy(&thread_tbl[i].thread.attr);
-			break;
-
-		case ODPTHREAD_PROCESS:
-
+		} else {
 			/* processes: */
 			pid = waitpid(thread_tbl[i].proc.pid, &status, 0);
 
@@ -263,16 +266,7 @@ int odph_odpthreads_join(odph_odpthread_t *thread_tbl)
 					 signo, strsignal(signo), (int)pid);
 				retval = -1;
 			}
-			break;
-
-		case ODPTHREAD_NOT_STARTED:
-			ODPH_DBG("No join done on not started ODPthread.\n");
-			break;
-		default:
-			ODPH_DBG("Invalid case statement value!\n");
-			break;
 		}
-
 	} while (!thread_tbl[i++].last);
 
 	return (retval < 0) ? retval : terminated;

--- a/include/odp/api/spec/init.h
+++ b/include/odp/api/spec/init.h
@@ -172,6 +172,15 @@ typedef struct odp_init_t {
 	 */
 	odp_feature_t not_used;
 
+	/** Use single virtual address space for all ODP implementation internal
+	 * shared memory allocations. This guarantees that all ODP threads will
+	 * see the memory at the same address - regardless of ODP thread type
+	 * (e.g. pthread vs. process).
+	 *
+	 * @see ODP_SHM_SINGLE_VA
+	 */
+	odp_bool_t use_single_va;
+
 	/** Shared memory parameters */
 	struct {
 		/** Maximum memory usage in bytes. This is the maximum

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -274,6 +274,8 @@ int odp_init_global(odp_instance_t *instance,
 			odp_global_ro.log_fn = params->log_fn;
 		if (params->abort_fn != NULL)
 			odp_global_ro.abort_fn = params->abort_fn;
+		if (params->use_single_va)
+			odp_global_ro.shm_single_va = 1;
 	}
 
 	if (_odp_libconfig_init_global()) {

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -301,14 +301,7 @@ static void hp_init(void)
 	char filename[ISHM_FILENAME_MAXLEN];
 	char dir[ISHM_FILENAME_MAXLEN];
 	int count;
-	int single_va = 0;
 	void *addr;
-
-	if (_odp_libconfig_lookup_ext_int("shm", NULL, "single_va",
-					  &single_va)) {
-		odp_global_ro.shm_single_va = single_va;
-		ODP_DBG("Shm single VA: %d\n", odp_global_ro.shm_single_va);
-	}
 
 	if (!_odp_libconfig_lookup_ext_int("shm", NULL, "num_cached_hp",
 					   &count)) {

--- a/platform/linux-generic/test/mmap_vlan_ins/mmap_vlan_ins.c
+++ b/platform/linux-generic/test/mmap_vlan_ins/mmap_vlan_ins.c
@@ -135,14 +135,20 @@ int main(int argc, char **argv)
 	odp_pool_t pool;
 	odp_pool_param_t params;
 	odp_cpumask_t cpumask;
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thd[MAX_WORKERS];
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 	odp_shm_t shm;
 	int ret;
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
 	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		printf("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
 
 	if (argc < 3) {
 		printf("Too few arguments (%i).\n"
@@ -150,7 +156,11 @@ int main(int argc, char **argv)
 		exit(0);
 	}
 
-	if (odp_init_global(&instance, NULL, NULL)) {
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		printf("Error: ODP global init failed.\n");
 		exit(1);
 	}

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,10 +1,7 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.3"
+config_file_version = "0.1.4"
 
 # Shared memory options
 shm: {
-	# Override default option and allocate internal shms using single
-	# virtual address space.
-	single_va = 1
 }

--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -79,7 +79,19 @@ int odp_cunit_thread_exit(pthrd_arg *arg)
 
 static int tests_global_init(odp_instance_t *inst)
 {
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
+
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/performance/odp_bench_packet.c
+++ b/test/performance/odp_bench_packet.c
@@ -1315,9 +1315,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 
 	static const char *shortopts =  "b:i:h";
 
-	/* Let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	appl_args->bench_idx = 0; /* Run all benchmarks */
 	appl_args->burst_size = TEST_DEF_BURST;
 
@@ -1511,6 +1508,7 @@ bench_info_t test_suite[] = {
  */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t worker_thread;
 	int cpu;
 	odp_shm_t shm;
@@ -1519,11 +1517,23 @@ int main(int argc, char *argv[])
 	odp_pool_capability_t capa;
 	odp_pool_param_t params;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	uint32_t pkt_num;
 	uint8_t ret;
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		LOG_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		LOG_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -928,9 +928,6 @@ static void parse_args(int argc, char *argv[], ipsec_args_t *cargs)
 
 	static const char *shortopts = "+a:c:df:hi:m:nl:sptu";
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	cargs->in_place = 0;
 	cargs->in_flight = 1;
 	cargs->debug_packets = 0;
@@ -1012,12 +1009,25 @@ int main(int argc, char *argv[])
 	odp_cpumask_t cpumask;
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 	int num_workers = 1;
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thr[num_workers];
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odp_pool_capability_t capa;
 	odp_ipsec_config_t config;
 	uint32_t max_seg_len;
 	unsigned int i;
+
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		app_err("Reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
 
 	memset(&cargs, 0, sizeof(cargs));
 
@@ -1025,7 +1035,7 @@ int main(int argc, char *argv[])
 	parse_args(argc, argv, &cargs);
 
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		app_err("ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}

--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -1184,9 +1184,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 
 	static const char *shortopts =  "+c:+t:+a:i:m:o:r:d:s:e:k:g:vh";
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	appl_args->time = 0; /* loop forever if time to run is 0 */
 	appl_args->accuracy = 1; /* get and print pps stats second */
 	appl_args->cpu_count = 1; /* use one worker by default */
@@ -1428,6 +1425,7 @@ static void create_groups(int num, odp_schedule_group_t *group)
  */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	odp_pool_t pool;
 	int i;
@@ -1449,6 +1447,13 @@ int main(int argc, char *argv[])
 	odp_pool_capability_t pool_capa;
 	uint32_t pkt_len, pkt_num;
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		LOG_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
 	odp_init_param_init(&init);
 
 	/* List features not to be used (may optimize performance) */
@@ -1457,6 +1462,9 @@ int main(int argc, char *argv[])
 	init.not_used.feat.ipsec  = 1;
 	init.not_used.feat.timer  = 1;
 	init.not_used.feat.tm     = 1;
+
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init.use_single_va = true;
 
 	/* Signal handler has to be registered before global init in case ODP
 	 * implementation creates internal threads/processes. */

--- a/test/performance/odp_pktio_ordered.c
+++ b/test/performance/odp_pktio_ordered.c
@@ -866,9 +866,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 
 	static const char *shortopts =  "+c:+t:+a:i:m:d:r:f:e:h";
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	appl_args->time = 0; /* loop forever if time to run is 0 */
 	appl_args->accuracy = DEF_STATS_INT;
 	appl_args->cpu_count = 1; /* use one worker by default */
@@ -1060,12 +1057,14 @@ int main(int argc, char *argv[])
 {
 	odp_cpumask_t cpumask;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odp_pool_t pool;
 	odp_pool_param_t params;
 	odp_shm_t shm;
 	odp_queue_capability_t queue_capa;
 	odp_pool_capability_t pool_capa;
 	odph_ethaddr_t new_addr;
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	stats_t *stats;
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
@@ -1077,8 +1076,19 @@ int main(int argc, char *argv[])
 	int in_mode;
 	uint32_t queue_size, pool_size;
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		LOG_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		LOG_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -578,9 +578,6 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->burst_size = 32;
 	test_options->pipe_queue_size = 256;
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
 
@@ -1431,9 +1428,17 @@ int main(int argc, char *argv[])
 	odp_init_t init;
 	odp_shm_t shm;
 	odp_time_t t1, t2;
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread[MAX_WORKERS];
 	test_options_t test_options;
 	int ret = 0;
+
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		printf("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
 
 	signal(SIGINT, sig_handler);
 
@@ -1450,6 +1455,9 @@ int main(int argc, char *argv[])
 
 	if (test_options.timeout_us)
 		init.not_used.feat.timer = 0;
+
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init.use_single_va = true;
 
 	/* Init ODP before calling anything else */
 	if (odp_init_global(&instance, &init, NULL)) {

--- a/test/performance/odp_scheduling.c
+++ b/test/performance/odp_scheduling.c
@@ -762,9 +762,6 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 
 	static const char *shortopts = "+c:fh";
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	args->cpu_count = 1; /* use one worker by default */
 
 	while (1) {
@@ -798,6 +795,7 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
  */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t *thread_tbl;
 	test_args_t args;
 	int num_workers;
@@ -811,6 +809,7 @@ int main(int argc, char *argv[])
 	odp_pool_param_t params;
 	int ret = 0;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 	odp_queue_capability_t capa;
 	odp_pool_capability_t pool_capa;
@@ -818,11 +817,22 @@ int main(int argc, char *argv[])
 
 	printf("\nODP example starts\n\n");
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		LOG_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
 	memset(&args, 0, sizeof(args));
 	parse_args(argc, argv, &args);
 
 	/* ODP global init */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		LOG_ERR("ODP global init failed.\n");
 		return -1;
 	}

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -8,6 +8,7 @@
 
 #include <malloc.h>
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include <unistd.h>
@@ -554,8 +555,19 @@ static int atomic_init(odp_instance_t *inst)
 	uint32_t workers_count, max_threads;
 	int ret = 0;
 	odp_cpumask_t mask;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/barrier/barrier.c
+++ b/test/validation/api/barrier/barrier.c
@@ -8,6 +8,7 @@
 
 #include <malloc.h>
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include <unistd.h>
@@ -329,8 +330,19 @@ static int barrier_init(odp_instance_t *inst)
 	uint32_t workers_count, max_threads;
 	int ret = 0;
 	odp_cpumask_t mask;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include "test_vectors.h"
@@ -2029,8 +2030,19 @@ static int crypto_init(odp_instance_t *inst)
 	odp_pool_t pool;
 	odp_queue_t out_queue;
 	odp_pool_capability_t pool_capa;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/init/init_main_ok.c
+++ b/test/validation/api/init/init_main_ok.c
@@ -14,8 +14,12 @@ static void init_test_odp_init_global(void)
 {
 	int status;
 	odp_instance_t instance;
+	odp_init_t init_data;
 
-	status = odp_init_global(&instance, NULL, NULL);
+	odp_init_param_init(&init_data);
+	init_data.use_single_va = 1;
+
+	status = odp_init_global(&instance, &init_data, NULL);
 	CU_ASSERT_FATAL(status == 0);
 
 	status = odp_term_global(instance);

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -906,8 +906,19 @@ int ipsec_init(odp_instance_t *inst)
 	odp_queue_t out_queue;
 	odp_pool_capability_t pool_capa;
 	odp_pktio_t pktio;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/lock/lock.c
+++ b/test/validation/api/lock/lock.c
@@ -8,6 +8,7 @@
 
 #include <malloc.h>
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include <unistd.h>
@@ -1163,8 +1164,19 @@ static int lock_init(odp_instance_t *inst)
 	uint32_t workers_count, max_threads;
 	int ret = 0;
 	odp_cpumask_t mask;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/thread/thread.c
+++ b/test/validation/api/thread/thread.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <odp_cunit_common.h>
 #include <mask_common.h>
 #include <test_debug.h>
@@ -24,8 +25,19 @@ static global_shared_mem_t *global_mem;
 static int thread_global_init(odp_instance_t *inst)
 {
 	odp_shm_t global_shm;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -61,8 +61,19 @@ static global_shared_mem_t *global_mem;
 static int timer_global_init(odp_instance_t *inst)
 {
 	odp_shm_t global_shm;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	if (helper_options.linux_thr_type == ODPH_THREAD_PROCESS)
+		init_param.use_single_va = true;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}


### PR DESCRIPTION
Enables an application to support process mode without the need to modify ODP configuration file.

New odph_options() helper function is added to enable an application to find out if ODP should be started in process mode.

The first three commits are copied from master branch and are not part of this PR:
    linux-gen: queue: add internal interface for adding/removing inline timers
    linux-gen: timer: reduce inline timer overhead
    linux-gen: timer: run inline timers during queue dequeue operations
