### PR TITLE
[PATCH v2] Sched prefer ratio config option

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.1"
+config_file_version = "0.1.2"
 
 # Shared memory options
 shm: {
@@ -80,12 +80,26 @@ queue_basic: {
 }
 
 sched_basic: {
-	# Priority level spread. Each priority level is spread into multiple
-	# scheduler internal queues. A higher spread value typically improves
-	# parallelism and thus is better for high thread counts, but causes
-	# uneven service level for low thread counts. Typically, optimal
-	# value is the number of threads using the scheduler.
+	# Priority level spread
+	#
+	# Each priority level is spread into multiple scheduler internal queues.
+	# This value defines the number of those queues. Minimum value is 1.
+	# Each thread prefers one of the queues over other queues. A higher
+	# spread value typically improves parallelism and thus is better for
+	# high thread counts, but causes uneven service level for low thread
+	# counts. Typically, optimal value is the number of threads using
+	# the scheduler.
 	prio_spread = 4
+
+	# Weight of the preferred scheduler internal queue
+	#
+	# Each thread prefers one of the internal queues over other queues.
+	# This value controls how many times the preferred queue is polled
+	# between a poll to another internal queue. Minimum value is 1. A higher
+	# value typically improves parallelism as threads work mostly on their
+	# preferred queues, but causes uneven service level for low thread
+	# counts as non-preferred queues are served less often
+	prio_spread_weight = 63
 
 	# Burst size configuration per priority. The first array element
 	# represents the highest queue priority. The scheduler tries to get

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -58,7 +58,7 @@ ODP_STATIC_ASSERT((ODP_SCHED_PRIO_NORMAL > 0) &&
 
 /* A thread polls a non preferred sched queue every this many polls
  * of the prefer queue. */
-#define MAX_PREFER_WEIGHT 63
+#define MAX_PREFER_WEIGHT 127
 #define MIN_PREFER_WEIGHT 1
 #define MAX_PREFER_RATIO  (MAX_PREFER_WEIGHT + 1)
 

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -333,7 +333,7 @@ static inline uint8_t prio_spread_index(uint32_t index)
 static void sched_local_init(void)
 {
 	int i;
-	uint8_t spread;
+	uint8_t spread, prefer_ratio;
 	uint8_t num_spread = sched->config.num_spread;
 	uint8_t offset = 1;
 
@@ -344,11 +344,12 @@ static void sched_local_init(void)
 	sched_local.stash.queue = ODP_QUEUE_INVALID;
 
 	spread = prio_spread_index(sched_local.thr);
+	prefer_ratio = sched->config.prefer_ratio;
 
 	for (i = 0; i < SPREAD_TBL_SIZE; i++) {
 		sched_local.spread_tbl[i] = spread;
 
-		if (num_spread > 1 && (i % MAX_PREFER_RATIO) == 0) {
+		if (num_spread > 1 && (i % prefer_ratio) == 0) {
 			sched_local.spread_tbl[i] = prio_spread_index(spread +
 								      offset);
 			offset++;
@@ -362,6 +363,7 @@ static int schedule_init_global(void)
 {
 	odp_shm_t shm;
 	int i, j, grp;
+	int prefer_ratio;
 
 	ODP_DBG("Schedule init ... ");
 
@@ -382,8 +384,10 @@ static int schedule_init_global(void)
 		return -1;
 	}
 
+	prefer_ratio = sched->config.prefer_ratio;
+
 	/* When num_spread == 1, only spread_tbl[0] is used. */
-	sched->max_spread = (sched->config.num_spread - 1) * MAX_PREFER_RATIO;
+	sched->max_spread = (sched->config.num_spread - 1) * prefer_ratio;
 	sched->shm  = shm;
 	odp_spinlock_init(&sched->mask_lock);
 

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.1"
+config_file_version = "0.1.2"
 
 # Shared memory options
 shm: {


### PR DESCRIPTION
Change prefer ratio from fixed value to a config file option. Small value is usable when having only few threads (uneven service of queues mapped to different internal schedule queues). Larger values improve performance on with multiple threads (due to better scalability). 