### PR TITLE
[PATCH v2] Sched automatic worker group config

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.2"
+config_file_version = "0.1.3"
 
 # Shared memory options
 shm: {
@@ -114,4 +114,15 @@ sched_basic: {
 	burst_size_default = [ 32,  32,  32,  32,  32, 16,  8, 4]
 	burst_size_max     = [255, 255, 255, 255, 255, 16, 16, 8]
 
+	# Automatically updated schedule groups
+	#
+	# API specification defines that ODP_SCHED_GROUP_ALL,
+	# _WORKER and _CONTROL are updated automatically. These options can be
+	# used to disable these group when not used. Set value to 0 to disable
+	# a group. Performance may improve when unused groups are disabled.
+	group_enable: {
+		all     = 1
+		worker  = 1
+		control = 1
+	}
 }

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -19,6 +19,15 @@ extern "C" {
 /* Number of ordered locks per queue */
 #define SCHEDULE_ORDERED_LOCKS_PER_QUEUE 2
 
+typedef struct schedule_config_t {
+	struct {
+		int all;
+		int worker;
+		int control;
+	} group_enable;
+
+} schedule_config_t;
+
 typedef void (*schedule_pktio_start_fn_t)(int pktio_index,
 					 int num_in_queue,
 					 int in_queue_idx[],
@@ -44,7 +53,7 @@ typedef void (*schedule_order_unlock_lock_fn_t)(void);
 typedef void (*schedule_order_lock_start_fn_t)(void);
 typedef void (*schedule_order_lock_wait_fn_t)(void);
 typedef uint32_t (*schedule_max_ordered_locks_fn_t)(void);
-typedef void (*schedule_save_context_fn_t)(uint32_t queue_index);
+typedef void (*schedule_config_fn_t)(schedule_config_t *config);
 
 typedef struct schedule_fn_t {
 	schedule_pktio_start_fn_t   pktio_start;
@@ -65,6 +74,7 @@ typedef struct schedule_fn_t {
 	schedule_order_lock_wait_fn_t	wait_order_lock;
 	schedule_order_unlock_lock_fn_t  order_unlock_lock;
 	schedule_max_ordered_locks_fn_t max_ordered_locks;
+	schedule_config_fn_t        config;
 
 } schedule_fn_t;
 

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -226,6 +226,9 @@ typedef struct {
 
 	order_context_t order[ODP_CONFIG_QUEUES];
 
+	/* Scheduler interface config options (not used in fast path) */
+	schedule_config_t config_if;
+
 } sched_global_t;
 
 /* Check that queue[] variables are large enough */
@@ -320,7 +323,37 @@ static int read_config_file(sched_global_t *sched)
 			return -1;
 		}
 	}
-	ODP_PRINT("\n\n");
+
+	ODP_PRINT("\n");
+
+	str = "sched_basic.group_enable.all";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+
+	sched->config_if.group_enable.all = val;
+	ODP_PRINT("  %s: %i\n", str, val);
+
+	str = "sched_basic.group_enable.worker";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+
+	sched->config_if.group_enable.worker = val;
+	ODP_PRINT("  %s: %i\n", str, val);
+
+	str = "sched_basic.group_enable.control";
+	if (!_odp_libconfig_lookup_int(str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", str);
+		return -1;
+	}
+
+	sched->config_if.group_enable.control = val;
+	ODP_PRINT("  %s: %i\n", str, val);
+
+	ODP_PRINT("\n");
 
 	return 0;
 }
@@ -1474,6 +1507,11 @@ static int schedule_num_grps(void)
 	return NUM_SCHED_GRPS;
 }
 
+static void schedule_config(schedule_config_t *config)
+{
+	*config = *(&sched->config_if);
+}
+
 /* Fill in scheduler interface */
 const schedule_fn_t schedule_basic_fn = {
 	.pktio_start = schedule_pktio_start,
@@ -1490,7 +1528,8 @@ const schedule_fn_t schedule_basic_fn = {
 	.term_local  = schedule_term_local,
 	.order_lock = order_lock,
 	.order_unlock = order_unlock,
-	.max_ordered_locks = schedule_max_ordered_locks
+	.max_ordered_locks = schedule_max_ordered_locks,
+	.config = schedule_config
 };
 
 /* Fill in scheduler API calls */

--- a/platform/linux-generic/odp_thread.c
+++ b/platform/linux-generic/odp_thread.c
@@ -136,6 +136,20 @@ int odp_thread_init_local(odp_thread_type_t type)
 {
 	int id;
 	int cpu;
+	int group_all, group_worker, group_control;
+
+	group_all = 1;
+	group_worker = 1;
+	group_control = 1;
+
+	if (sched_fn->config) {
+		schedule_config_t schedule_config;
+
+		sched_fn->config(&schedule_config);
+		group_all = schedule_config.group_enable.all;
+		group_worker = schedule_config.group_enable.worker;
+		group_control = schedule_config.group_enable.control;
+	}
 
 	odp_spinlock_lock(&thread_globals->lock);
 	id = alloc_id(type);
@@ -159,11 +173,13 @@ int odp_thread_init_local(odp_thread_type_t type)
 
 	_odp_this_thread = &thread_globals->thr[id];
 
-	sched_fn->thr_add(ODP_SCHED_GROUP_ALL, id);
+	if (group_all)
+		sched_fn->thr_add(ODP_SCHED_GROUP_ALL, id);
 
-	if (type == ODP_THREAD_WORKER)
+	if (type == ODP_THREAD_WORKER && group_worker)
 		sched_fn->thr_add(ODP_SCHED_GROUP_WORKER, id);
-	else if (type == ODP_THREAD_CONTROL)
+
+	if (type == ODP_THREAD_CONTROL && group_control)
 		sched_fn->thr_add(ODP_SCHED_GROUP_CONTROL, id);
 
 	return 0;
@@ -172,14 +188,30 @@ int odp_thread_init_local(odp_thread_type_t type)
 int odp_thread_term_local(void)
 {
 	int num;
+	int group_all, group_worker, group_control;
 	int id = _odp_this_thread->thr;
 	odp_thread_type_t type = _odp_this_thread->type;
 
-	sched_fn->thr_rem(ODP_SCHED_GROUP_ALL, id);
+	group_all = 1;
+	group_worker = 1;
+	group_control = 1;
 
-	if (type == ODP_THREAD_WORKER)
+	if (sched_fn->config) {
+		schedule_config_t schedule_config;
+
+		sched_fn->config(&schedule_config);
+		group_all = schedule_config.group_enable.all;
+		group_worker = schedule_config.group_enable.worker;
+		group_control = schedule_config.group_enable.control;
+	}
+
+	if (group_all)
+		sched_fn->thr_rem(ODP_SCHED_GROUP_ALL, id);
+
+	if (type == ODP_THREAD_WORKER && group_worker)
 		sched_fn->thr_rem(ODP_SCHED_GROUP_WORKER, id);
-	else if (type == ODP_THREAD_CONTROL)
+
+	if (type == ODP_THREAD_CONTROL && group_control)
 		sched_fn->thr_rem(ODP_SCHED_GROUP_CONTROL, id);
 
 	odp_spinlock_lock(&thread_globals->lock);

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.2"
+config_file_version = "0.1.3"
 
 # Shared memory options
 shm: {


### PR DESCRIPTION
Add config file options to disable unused automatic schedule groups. These are enabled by default as API spec requires it. By default, scheduler polls/checks if there are active queues in both "all" and "worker" groups (for a worker thread). If only "all" groups is used, disabling "worker" group improves performance a bit. The improvement is significant when burst size is small (as there are more schedule() call cycles per event). With a sched_pktio test case (2 stage pipeline) and burst size forced to 1, improvement was 4-7%.

This config can be later added to schedule config API and this implementation is reusable for that (config file option changes to API option, but other code remain the same).

Sched_pktio burst size change was needed to test the performance effect.

This needs to be rebased on top of #736 once it's merged.
 