### PR TITLE
[PATCH v1] Remove pktin poll old

### DIFF
--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -74,7 +74,6 @@ extern const schedule_fn_t *sched_fn;
 /* Interface for the scheduler */
 int sched_cb_pktin_poll(int pktio_index, int pktin_index,
 			odp_buffer_hdr_t *hdr_tbl[], int num);
-int sched_cb_pktin_poll_old(int pktio_index, int num_queue, int index[]);
 int sched_cb_pktin_poll_one(int pktio_index, int rx_queue, odp_event_t evts[]);
 void sched_cb_pktio_stop_finalize(int pktio_index);
 


### PR DESCRIPTION
Change SP scheduler to use the same pktin poll function as the basic scheduler. Remove the old pktin poll function.