### PR TITLE
[PATCH API-NEXT v1] api: scheduler priority functions

### DIFF
--- a/include/odp/api/abi-default/schedule_types.h
+++ b/include/odp/api/abi-default/schedule_types.h
@@ -21,8 +21,6 @@ extern "C" {
  *  @{
  */
 
-typedef int odp_schedule_prio_t;
-
 #define ODP_SCHED_PRIO_HIGHEST  0
 
 #define ODP_SCHED_PRIO_NORMAL   4

--- a/include/odp/api/abi-default/schedule_types.h
+++ b/include/odp/api/abi-default/schedule_types.h
@@ -21,13 +21,13 @@ extern "C" {
  *  @{
  */
 
-#define ODP_SCHED_PRIO_HIGHEST  0
+#define ODP_SCHED_PRIO_HIGHEST  (odp_schedule_max_prio())
 
-#define ODP_SCHED_PRIO_NORMAL   4
+#define ODP_SCHED_PRIO_NORMAL   (odp_schedule_default_prio())
 
-#define ODP_SCHED_PRIO_LOWEST   7
+#define ODP_SCHED_PRIO_LOWEST   (odp_schedule_min_prio())
 
-#define ODP_SCHED_PRIO_DEFAULT  ODP_SCHED_PRIO_NORMAL
+#define ODP_SCHED_PRIO_DEFAULT  (odp_schedule_default_prio())
 
 typedef int odp_schedule_sync_t;
 

--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -181,7 +181,48 @@ void odp_schedule_release_ordered(void);
 void odp_schedule_prefetch(int num);
 
 /**
+ * Maximum scheduling priority level
+ *
+ * This is the maximum value that can be set to 'prio' field in
+ * odp_schedule_param_t (e.g. @see odp_queue_create()). Queues with a higher
+ * priority value are served with higher priority than queues with a lower
+ * priority value.
+ *
+ * @return Maximum scheduling priority level
+ */
+int odp_schedule_max_prio(void);
+
+/**
+ * Minimum scheduling priority level
+ *
+ * This is the minimum value that can be set to 'prio' field in
+ * odp_schedule_param_t (e.g. @see odp_queue_create()). Queues with a higher
+ * priority value are served with higher priority than queues with a lower
+ * priority value.
+ *
+ * @return Minimum scheduling priority level
+ */
+int odp_schedule_min_prio(void);
+
+/**
+ * Default scheduling priority level
+ *
+ * This is the default value of 'prio' field in odp_schedule_param_t
+ * (e.g. @see odp_queue_param_init()). The default value should be suitable for
+ * an application that uses single priority level for all its queues (uses
+ * scheduler only for load balancing and synchronization). Typically,
+ * the default value is between minimum and maximum values, but with a few
+ * priority levels it may be close or equal to those.
+ *
+ * @return Default scheduling priority level
+ */
+int odp_schedule_default_prio(void);
+
+/**
  * Number of scheduling priorities
+ *
+ * The number of priority levels support by the scheduler. It equals to
+ * odp_schedule_max_prio() - odp_schedule_min_prio() + 1.
  *
  * @return Number of scheduling priorities
  */

--- a/include/odp/api/spec/schedule_types.h
+++ b/include/odp/api/spec/schedule_types.h
@@ -23,11 +23,6 @@ extern "C" {
  */
 
 /**
- * @typedef odp_schedule_prio_t
- * Scheduler priority level
- */
-
-/**
  * @def ODP_SCHED_PRIO_HIGHEST
  * Highest scheduling priority
  */
@@ -135,6 +130,15 @@ extern "C" {
  * @def ODP_SCHED_GROUP_CONTROL
  * Predefined scheduler group of all control threads
  */
+
+/**
+ * Scheduling priority level
+ *
+ * Priority level is an integer value between odp_schedule_min_prio() and
+ * odp_schedule_max_prio(). Queues with a higher priority value are served with
+ * higher priority than queues with a lower priority value.
+ */
+typedef int odp_schedule_prio_t;
 
 /** Scheduler parameters */
 typedef	struct odp_schedule_param_t {

--- a/include/odp/api/spec/schedule_types.h
+++ b/include/odp/api/spec/schedule_types.h
@@ -24,24 +24,26 @@ extern "C" {
 
 /**
  * @def ODP_SCHED_PRIO_HIGHEST
- * Highest scheduling priority
+ * This macro is equivalent of calling odp_schedule_max_prio() and will be
+ * deprecated. Use direct function call instead.
  */
 
 /**
  * @def ODP_SCHED_PRIO_NORMAL
- * Normal scheduling priority
+ * This macro is equivalent of calling odp_schedule_default_prio() and will be
+ * deprecated. Use direct function call instead.
  */
 
 /**
  * @def ODP_SCHED_PRIO_LOWEST
- * Lowest scheduling priority
+ * This macro is equivalent of calling odp_schedule_min_prio() and will be
+ * deprecated. Use direct function call instead.
  */
 
 /**
  * @def ODP_SCHED_PRIO_DEFAULT
- * Default scheduling priority. User does not care about the selected priority
- * level - throughput, load balancing and synchronization features are more
- * important than priority scheduling.
+ * This macro is equivalent of calling odp_schedule_default_prio() and will be
+ * deprecated. Use direct function call instead.
  */
 
 /**
@@ -144,7 +146,7 @@ typedef int odp_schedule_prio_t;
 typedef	struct odp_schedule_param_t {
 	/** Priority level
 	  *
-	  * Default value is ODP_SCHED_PRIO_DEFAULT. */
+	  * Default value is returned by odp_schedule_default_prio(). */
 	odp_schedule_prio_t  prio;
 
 	/** Synchronization method

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -88,6 +88,9 @@ typedef struct {
 	void (*schedule_release_atomic)(void);
 	void (*schedule_release_ordered)(void);
 	void (*schedule_prefetch)(int);
+	int (*schedule_min_prio)(void);
+	int (*schedule_max_prio)(void);
+	int (*schedule_default_prio)(void);
 	int (*schedule_num_prio)(void);
 	odp_schedule_group_t (*schedule_group_create)(const char *,
 						      const odp_thrmask_t *);

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -163,6 +163,8 @@ static int queue_init(queue_entry_t *queue, const char *name,
 
 	/* Queue initialized successfully, add it to the sched group */
 	if (queue->s.type == ODP_QUEUE_TYPE_SCHED) {
+		int prio = odp_schedule_max_prio() - param->sched.prio;
+
 		if (queue->s.param.sched.sync == ODP_SCHED_SYNC_ORDERED) {
 			sched_elem->rwin =
 				rwin_alloc(queue_shm_pool,
@@ -173,9 +175,9 @@ static int queue_init(queue_entry_t *queue, const char *name,
 			}
 		}
 		sched_elem->sched_grp = param->sched.group;
-		sched_elem->sched_prio = param->sched.prio;
+		sched_elem->sched_prio = prio;
 		sched_elem->schedq =
-			sched_queue_add(param->sched.group, param->sched.prio);
+			sched_queue_add(param->sched.group, prio);
 		ODP_ASSERT(sched_elem->schedq != NULL);
 
 	}
@@ -356,13 +358,24 @@ static odp_queue_t queue_create(const char *name,
 				const odp_queue_param_t *param)
 {
 	int queue_idx;
-	odp_queue_t handle = ODP_QUEUE_INVALID;
 	queue_entry_t *queue;
+	odp_queue_type_t type;
 	odp_queue_param_t default_param;
+	odp_queue_t handle = ODP_QUEUE_INVALID;
 
 	if (param == NULL) {
 		odp_queue_param_init(&default_param);
 		param = &default_param;
+	}
+
+	type = param->type;
+
+	if (type == ODP_QUEUE_TYPE_SCHED) {
+		if (param->sched.prio < odp_schedule_min_prio() ||
+		    param->sched.prio > odp_schedule_max_prio()) {
+			ODP_ERR("Bad queue priority: %i\n", param->sched.prio);
+			return ODP_QUEUE_INVALID;
+		}
 	}
 
 	for (queue_idx = 0; queue_idx < ODP_CONFIG_QUEUES; queue_idx++) {
@@ -860,7 +873,7 @@ static void queue_param_init(odp_queue_param_t *params)
 	params->enq_mode = ODP_QUEUE_OP_MT;
 	params->deq_mode = ODP_QUEUE_OP_MT;
 	params->nonblocking = ODP_BLOCKING;
-	params->sched.prio = ODP_SCHED_PRIO_DEFAULT;
+	params->sched.prio = odp_schedule_default_prio();
 	params->sched.sync = ODP_SCHED_SYNC_PARALLEL;
 	params->sched.group = ODP_SCHED_GROUP_ALL;
 }

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -37,13 +37,6 @@
 /* Number of priority levels  */
 #define NUM_PRIO 8
 
-ODP_STATIC_ASSERT(ODP_SCHED_PRIO_LOWEST == (NUM_PRIO - 1),
-		  "lowest_prio_does_not_match_with_num_prios");
-
-ODP_STATIC_ASSERT((ODP_SCHED_PRIO_NORMAL > 0) &&
-		  (ODP_SCHED_PRIO_NORMAL < (NUM_PRIO - 1)),
-		  "normal_prio_is_not_between_highest_and_lowest");
-
 /* Number of scheduling groups */
 #define NUM_SCHED_GRPS 32
 
@@ -199,6 +192,7 @@ typedef struct {
 
 	struct {
 		uint8_t grp;
+		/* Inverted prio value (max = 0) vs API (min = 0)*/
 		uint8_t prio;
 		uint8_t spread;
 		uint8_t sync;
@@ -496,6 +490,31 @@ static uint32_t schedule_max_ordered_locks(void)
 	return CONFIG_QUEUE_MAX_ORD_LOCKS;
 }
 
+static int schedule_min_prio(void)
+{
+	return 0;
+}
+
+static int schedule_max_prio(void)
+{
+	return NUM_PRIO - 1;
+}
+
+static int schedule_default_prio(void)
+{
+	return schedule_max_prio() / 2;
+}
+
+static int schedule_num_prio(void)
+{
+	return NUM_PRIO;
+}
+
+static inline int prio_level_from_api(int api_prio)
+{
+	return schedule_max_prio() - api_prio;
+}
+
 static void pri_set(int id, int prio)
 {
 	odp_spinlock_lock(&sched->mask_lock);
@@ -535,7 +554,7 @@ static int schedule_init_queue(uint32_t queue_index,
 {
 	uint32_t ring_size;
 	int i;
-	int prio = sched_param->prio;
+	int prio = prio_level_from_api(sched_param->prio);
 
 	pri_set_queue(queue_index, prio);
 	sched->queue[queue_index].grp  = sched_param->group;
@@ -1249,11 +1268,6 @@ static uint64_t schedule_wait_time(uint64_t ns)
 	return ns;
 }
 
-static int schedule_num_prio(void)
-{
-	return NUM_PRIO;
-}
-
 static odp_schedule_group_t schedule_group_create(const char *name,
 						  const odp_thrmask_t *mask)
 {
@@ -1496,6 +1510,9 @@ const schedule_api_t schedule_basic_api = {
 	.schedule_release_atomic  = schedule_release_atomic,
 	.schedule_release_ordered = schedule_release_ordered,
 	.schedule_prefetch        = schedule_prefetch,
+	.schedule_min_prio        = schedule_min_prio,
+	.schedule_max_prio        = schedule_max_prio,
+	.schedule_default_prio    = schedule_default_prio,
 	.schedule_num_prio        = schedule_num_prio,
 	.schedule_group_create    = schedule_group_create,
 	.schedule_group_destroy   = schedule_group_destroy,

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -66,6 +66,21 @@ void odp_schedule_prefetch(int num)
 	return sched_api->schedule_prefetch(num);
 }
 
+int odp_schedule_min_prio(void)
+{
+	return sched_api->schedule_min_prio();
+}
+
+int odp_schedule_max_prio(void)
+{
+	return sched_api->schedule_max_prio();
+}
+
+int odp_schedule_default_prio(void)
+{
+	return sched_api->schedule_default_prio();
+}
+
 int odp_schedule_num_prio(void)
 {
 	return sched_api->schedule_num_prio();

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -48,13 +48,6 @@
 
 static _odp_ishm_pool_t *sched_shm_pool;
 
-ODP_STATIC_ASSERT(ODP_SCHED_PRIO_LOWEST == (ODP_SCHED_PRIO_NUM - 2),
-		  "lowest_prio_does_not_match_with_num_prios");
-
-ODP_STATIC_ASSERT((ODP_SCHED_PRIO_NORMAL > 0) &&
-		  (ODP_SCHED_PRIO_NORMAL < (ODP_SCHED_PRIO_NUM - 2)),
-		  "normal_prio_is_not_between_highest_and_lowest");
-
 ODP_STATIC_ASSERT(CHECK_IS_POWER2(ODP_CONFIG_QUEUES),
 		  "Number_of_queues_is_not_power_of_two");
 
@@ -1369,6 +1362,21 @@ static int schedule_num_prio(void)
 	return ODP_SCHED_PRIO_NUM - 1; /* Discount the pktin priority level */
 }
 
+static int schedule_min_prio(void)
+{
+	return 0;
+}
+
+static int schedule_max_prio(void)
+{
+	return schedule_num_prio() - 1;
+}
+
+static int schedule_default_prio(void)
+{
+	return schedule_max_prio() / 2;
+}
+
 static int schedule_group_update(sched_group_t *sg,
 				 uint32_t sgi,
 				 const odp_thrmask_t *mask,
@@ -2099,6 +2107,9 @@ const schedule_api_t schedule_scalable_api = {
 	.schedule_release_atomic	= schedule_release_atomic,
 	.schedule_release_ordered	= schedule_release_ordered,
 	.schedule_prefetch		= schedule_prefetch,
+	.schedule_min_prio		= schedule_min_prio,
+	.schedule_max_prio		= schedule_max_prio,
+	.schedule_default_prio		= schedule_default_prio,
 	.schedule_num_prio		= schedule_num_prio,
 	.schedule_group_create		= schedule_group_create,
 	.schedule_group_destroy		= schedule_group_destroy,

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -26,11 +26,12 @@
 #define NUM_QUEUE         ODP_CONFIG_QUEUES
 #define NUM_PKTIO         ODP_CONFIG_PKTIO_ENTRIES
 #define NUM_ORDERED_LOCKS 1
-#define NUM_PRIO          3
 #define NUM_STATIC_GROUP  3
 #define NUM_GROUP         (NUM_STATIC_GROUP + 9)
 #define NUM_PKTIN         32
-#define LOWEST_QUEUE_PRIO (NUM_PRIO - 2)
+#define NUM_PRIO          3
+#define MAX_API_PRIO      (NUM_PRIO - 2)
+/* Lowest internal priority */
 #define PKTIN_PRIO        (NUM_PRIO - 1)
 #define CMD_QUEUE         0
 #define CMD_PKTIO         1
@@ -366,8 +367,8 @@ static int init_queue(uint32_t qi, const odp_schedule_param_t *sched_param)
 	if (!sched_group->s.group[group].allocated)
 		return -1;
 
-	if (sched_param->prio > 0)
-		prio = LOWEST_QUEUE_PRIO;
+	/* Inverted prio value (max = 0) vs API */
+	prio = MAX_API_PRIO - sched_param->prio;
 
 	sched_global->queue_cmd[qi].s.prio  = prio;
 	sched_global->queue_cmd[qi].s.group = group;
@@ -620,6 +621,21 @@ static void schedule_release_ordered(void)
 static void schedule_prefetch(int num)
 {
 	(void)num;
+}
+
+static int schedule_min_prio(void)
+{
+	return 0;
+}
+
+static int schedule_max_prio(void)
+{
+	return MAX_API_PRIO;
+}
+
+static int schedule_default_prio(void)
+{
+	return schedule_max_prio() / 2;
 }
 
 static int schedule_num_prio(void)
@@ -880,6 +896,9 @@ const schedule_api_t schedule_sp_api = {
 	.schedule_release_atomic  = schedule_release_atomic,
 	.schedule_release_ordered = schedule_release_ordered,
 	.schedule_prefetch        = schedule_prefetch,
+	.schedule_min_prio        = schedule_min_prio,
+	.schedule_max_prio        = schedule_max_prio,
+	.schedule_default_prio    = schedule_default_prio,
 	.schedule_num_prio        = schedule_num_prio,
 	.schedule_group_create    = schedule_group_create,
 	.schedule_group_destroy   = schedule_group_destroy,

--- a/test/validation/api/classification/odp_classification_common.c
+++ b/test/validation/api/classification/odp_classification_common.c
@@ -201,7 +201,7 @@ odp_queue_t queue_create(const char *queuename, bool sched)
 	if (sched) {
 		odp_queue_param_init(&qparam);
 		qparam.type       = ODP_QUEUE_TYPE_SCHED;
-		qparam.sched.prio = ODP_SCHED_PRIO_HIGHEST;
+		qparam.sched.prio = odp_schedule_max_prio();
 		qparam.sched.sync = ODP_SCHED_SYNC_PARALLEL;
 		qparam.sched.group = ODP_SCHED_GROUP_ALL;
 

--- a/test/validation/api/classification/odp_classification_tests.c
+++ b/test/validation/api/classification/odp_classification_tests.c
@@ -158,7 +158,7 @@ void configure_cls_pmr_chain(void)
 
 	odp_queue_param_init(&qparam);
 	qparam.type       = ODP_QUEUE_TYPE_SCHED;
-	qparam.sched.prio = ODP_SCHED_PRIO_NORMAL;
+	qparam.sched.prio = odp_schedule_default_prio();
 	qparam.sched.sync = ODP_SCHED_SYNC_PARALLEL;
 	qparam.sched.group = ODP_SCHED_GROUP_ALL;
 	qparam.sched.lock_count = queue_capa.max_ordered_locks;
@@ -183,7 +183,7 @@ void configure_cls_pmr_chain(void)
 
 	odp_queue_param_init(&qparam);
 	qparam.type       = ODP_QUEUE_TYPE_SCHED;
-	qparam.sched.prio = ODP_SCHED_PRIO_NORMAL;
+	qparam.sched.prio = odp_schedule_default_prio();
 	qparam.sched.sync = ODP_SCHED_SYNC_PARALLEL;
 	qparam.sched.group = ODP_SCHED_GROUP_ALL;
 	sprintf(queuename, "%s", "DstQueue");
@@ -293,7 +293,7 @@ void configure_pktio_default_cos(void)
 
 	odp_queue_param_init(&qparam);
 	qparam.type       = ODP_QUEUE_TYPE_SCHED;
-	qparam.sched.prio = ODP_SCHED_PRIO_DEFAULT;
+	qparam.sched.prio = odp_schedule_default_prio();
 	qparam.sched.sync = ODP_SCHED_SYNC_PARALLEL;
 	qparam.sched.group = ODP_SCHED_GROUP_ALL;
 	sprintf(queuename, "%s", "DefaultQueue");
@@ -356,7 +356,7 @@ void configure_pktio_error_cos(void)
 
 	odp_queue_param_init(&qparam);
 	qparam.type       = ODP_QUEUE_TYPE_SCHED;
-	qparam.sched.prio = ODP_SCHED_PRIO_LOWEST;
+	qparam.sched.prio = odp_schedule_min_prio();
 	qparam.sched.sync = ODP_SCHED_SYNC_PARALLEL;
 	qparam.sched.group = ODP_SCHED_GROUP_ALL;
 	sprintf(queuename, "%s", "ErrorCos");
@@ -468,7 +468,7 @@ void configure_cos_with_l2_priority(void)
 	qparam.sched.sync = ODP_SCHED_SYNC_PARALLEL;
 	qparam.sched.group = ODP_SCHED_GROUP_ALL;
 	for (i = 0; i < num_qos; i++) {
-		qparam.sched.prio = ODP_SCHED_PRIO_LOWEST + i;
+		qparam.sched.prio = odp_schedule_min_prio() + i;
 		sprintf(queuename, "%s_%d", "L2_Queue", i);
 		queue_tbl[i] = odp_queue_create(queuename, &qparam);
 		CU_ASSERT_FATAL(queue_tbl[i] != ODP_QUEUE_INVALID);
@@ -544,7 +544,7 @@ void configure_pmr_cos(void)
 
 	odp_queue_param_init(&qparam);
 	qparam.type       = ODP_QUEUE_TYPE_SCHED;
-	qparam.sched.prio = ODP_SCHED_PRIO_HIGHEST;
+	qparam.sched.prio = odp_schedule_max_prio();
 	qparam.sched.sync = ODP_SCHED_SYNC_PARALLEL;
 	qparam.sched.group = ODP_SCHED_GROUP_ALL;
 	sprintf(queuename, "%s", "PMR_CoS");
@@ -619,7 +619,7 @@ void configure_pktio_pmr_composite(void)
 
 	odp_queue_param_init(&qparam);
 	qparam.type       = ODP_QUEUE_TYPE_SCHED;
-	qparam.sched.prio = ODP_SCHED_PRIO_HIGHEST;
+	qparam.sched.prio = odp_schedule_max_prio();
 	qparam.sched.sync = ODP_SCHED_SYNC_PARALLEL;
 	qparam.sched.group = ODP_SCHED_GROUP_ALL;
 	sprintf(queuename, "%s", "cos_pmr_composite_queue");

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -608,7 +608,7 @@ static void queue_test_param(void)
 	/* Schedule type queue */
 	odp_queue_param_init(&qparams);
 	qparams.type       = ODP_QUEUE_TYPE_SCHED;
-	qparams.sched.prio = ODP_SCHED_PRIO_LOWEST;
+	qparams.sched.prio = odp_schedule_min_prio();
 	qparams.sched.sync = ODP_SCHED_SYNC_PARALLEL;
 	qparams.sched.group = ODP_SCHED_GROUP_WORKER;
 
@@ -618,7 +618,7 @@ static void queue_test_param(void)
 		  odp_queue_to_u64(ODP_QUEUE_INVALID));
 	CU_ASSERT(queue == odp_queue_lookup("test_queue"));
 	CU_ASSERT(ODP_QUEUE_TYPE_SCHED    == odp_queue_type(queue));
-	CU_ASSERT(ODP_SCHED_PRIO_LOWEST   == odp_queue_sched_prio(queue));
+	CU_ASSERT(odp_schedule_min_prio()   == odp_queue_sched_prio(queue));
 	CU_ASSERT(ODP_SCHED_SYNC_PARALLEL == odp_queue_sched_type(queue));
 	CU_ASSERT(ODP_SCHED_GROUP_WORKER  == odp_queue_sched_group(queue));
 
@@ -719,7 +719,7 @@ static void queue_test_info(void)
 	/* Create a scheduled ordered queue with explicitly set params */
 	odp_queue_param_init(&param);
 	param.type       = ODP_QUEUE_TYPE_SCHED;
-	param.sched.prio = ODP_SCHED_PRIO_NORMAL;
+	param.sched.prio = odp_schedule_default_prio();
 	param.sched.sync = ODP_SCHED_SYNC_ORDERED;
 	param.sched.group = ODP_SCHED_GROUP_ALL;
 	param.sched.lock_count = capability.max_ordered_locks;

--- a/test/validation/api/queue/queue.c
+++ b/test/validation/api/queue/queue.c
@@ -605,8 +605,21 @@ static void queue_test_param(void)
 	odp_queue_param_t qparams;
 	odp_buffer_t enbuf;
 
-	/* Schedule type queue */
+	/* Defaults */
 	odp_queue_param_init(&qparams);
+	CU_ASSERT(qparams.type == ODP_QUEUE_TYPE_PLAIN);
+	CU_ASSERT(qparams.enq_mode == ODP_QUEUE_OP_MT);
+	CU_ASSERT(qparams.deq_mode == ODP_QUEUE_OP_MT);
+	CU_ASSERT(qparams.sched.prio == odp_schedule_default_prio());
+	CU_ASSERT(qparams.sched.sync == ODP_SCHED_SYNC_PARALLEL);
+	CU_ASSERT(qparams.sched.group == ODP_SCHED_GROUP_ALL);
+	CU_ASSERT(qparams.sched.lock_count == 0);
+	CU_ASSERT(qparams.nonblocking == ODP_BLOCKING);
+	CU_ASSERT(qparams.context == NULL);
+	CU_ASSERT(qparams.context_len == 0);
+	CU_ASSERT(qparams.size == 0);
+
+	/* Schedule type queue */
 	qparams.type       = ODP_QUEUE_TYPE_SCHED;
 	qparams.sched.prio = odp_schedule_min_prio();
 	qparams.sched.sync = ODP_SCHED_SYNC_PARALLEL;

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -158,7 +158,7 @@ static void scheduler_test_wait_time(void)
 	odp_queue_param_init(&qp);
 	qp.type        = ODP_QUEUE_TYPE_SCHED;
 	qp.sched.sync  = ODP_SCHED_SYNC_PARALLEL;
-	qp.sched.prio  = ODP_SCHED_PRIO_NORMAL;
+	qp.sched.prio  = odp_schedule_default_prio();
 	qp.sched.group = ODP_SCHED_GROUP_ALL;
 	queue = odp_queue_create("dummy_queue", &qp);
 	CU_ASSERT_FATAL(queue != ODP_QUEUE_INVALID);
@@ -241,7 +241,7 @@ static void scheduler_test_queue_destroy(void)
 
 	for (i = 0; i < 3; i++) {
 		qp.type        = ODP_QUEUE_TYPE_SCHED;
-		qp.sched.prio  = ODP_SCHED_PRIO_DEFAULT;
+		qp.sched.prio  = odp_schedule_default_prio();
 		qp.sched.sync  = sync[i];
 		qp.sched.group = ODP_SCHED_GROUP_ALL;
 
@@ -324,7 +324,7 @@ static void scheduler_test_queue_size(void)
 
 		odp_queue_param_init(&queue_param);
 		queue_param.type = ODP_QUEUE_TYPE_SCHED;
-		queue_param.sched.prio  = ODP_SCHED_PRIO_DEFAULT;
+		queue_param.sched.prio  = odp_schedule_default_prio();
 		queue_param.sched.sync  = sync[i];
 		queue_param.sched.group = ODP_SCHED_GROUP_ALL;
 		queue_param.size = queue_size;
@@ -483,7 +483,7 @@ static void scheduler_test_groups(void)
 
 		odp_queue_param_init(&qp);
 		qp.type        = ODP_QUEUE_TYPE_SCHED;
-		qp.sched.prio  = ODP_SCHED_PRIO_DEFAULT;
+		qp.sched.prio  = odp_schedule_default_prio();
 		qp.sched.sync  = sync[i];
 		qp.sched.group = mygrp1;
 
@@ -701,7 +701,7 @@ static void chaos_run(unsigned int qtype)
 	pool = odp_pool_create("sched_chaos_pool", &params);
 	CU_ASSERT_FATAL(pool != ODP_POOL_INVALID);
 	qp.type        = ODP_QUEUE_TYPE_SCHED;
-	qp.sched.prio  = ODP_SCHED_PRIO_DEFAULT;
+	qp.sched.prio  = odp_schedule_default_prio();
 	qp.sched.group = ODP_SCHED_GROUP_ALL;
 
 	for (i = 0; i < CHAOS_NUM_QUEUES; i++) {

--- a/test/validation/api/scheduler/scheduler.c
+++ b/test/validation/api/scheduler/scheduler.c
@@ -206,12 +206,24 @@ static void scheduler_test_wait_time(void)
 
 static void scheduler_test_num_prio(void)
 {
-	int prio;
+	int num_prio, min_prio, max_prio, default_prio;
 
-	prio = odp_schedule_num_prio();
+	num_prio = odp_schedule_num_prio();
+	CU_ASSERT(num_prio > 0);
 
-	CU_ASSERT(prio > 0);
-	CU_ASSERT(prio == odp_schedule_num_prio());
+	min_prio = odp_schedule_min_prio();
+	max_prio = odp_schedule_max_prio();
+	default_prio = odp_schedule_default_prio();
+
+	CU_ASSERT(min_prio <= max_prio);
+	CU_ASSERT(min_prio <= default_prio);
+	CU_ASSERT(default_prio <= max_prio);
+	CU_ASSERT(num_prio == (max_prio - min_prio + 1));
+
+	CU_ASSERT(min_prio == ODP_SCHED_PRIO_LOWEST);
+	CU_ASSERT(max_prio == ODP_SCHED_PRIO_HIGHEST);
+	CU_ASSERT(default_prio == ODP_SCHED_PRIO_DEFAULT);
+	CU_ASSERT(default_prio == ODP_SCHED_PRIO_NORMAL);
 }
 
 static void scheduler_test_queue_destroy(void)

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -321,7 +321,6 @@ static void timer_test_queue_type(odp_queue_type_t queue_type)
 	odp_queue_param_init(&queue_param);
 	if (queue_type == ODP_QUEUE_TYPE_SCHED) {
 		queue_param.type = ODP_QUEUE_TYPE_SCHED;
-		queue_param.sched.prio  = ODP_SCHED_PRIO_DEFAULT;
 		queue_param.sched.sync  = ODP_SCHED_SYNC_ATOMIC;
 		queue_param.sched.group = ODP_SCHED_GROUP_ALL;
 	}


### PR DESCRIPTION
Introduce functions for min/max/default priorities. Functions avoid fixed number of priorities in ABI compat mode. Also a scheduler may be configured with different number of priorities at start up. Macros are not yet deprecated but are turned into function calls.