### PR TITLE
[PATCH v3] linuxgen: add dumpconfig utility

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,12 +5,14 @@ AM_DISTCHECK_CONFIGURE_FLAGS = --enable-user-guides	\
 
 if PLATFORM_IS_LINUX_GENERIC
 PLATFORM_DIR = platform/linux-generic
+PLATFORM_DUMPCONF_DIR = platform/linux-generic/dumpconfig
 PLATFORM_TEST_DIR = platform/linux-generic/test
 endif
 
 SUBDIRS = \
 	  include \
 	  $(PLATFORM_DIR) \
+	  $(PLATFORM_DUMPCONF_DIR) \
 	  helper \
 	  doc
 

--- a/platform/linux-generic/dumpconfig/.gitignore
+++ b/platform/linux-generic/dumpconfig/.gitignore
@@ -1,0 +1,1 @@
+odp_linuxgen_dumpconfig

--- a/platform/linux-generic/dumpconfig/Makefile.am
+++ b/platform/linux-generic/dumpconfig/Makefile.am
@@ -1,0 +1,10 @@
+include $(top_srcdir)/Makefile.inc
+
+AM_CPPFLAGS =  -I$(top_builddir)/platform/$(with_platform)/include
+AM_CPPFLAGS +=  -I$(top_srcdir)/platform/$(with_platform)/include
+
+bin_PROGRAMS = odp_linuxgen_dumpconfig
+
+odp_linuxgen_dumpconfig_SOURCES = dumpconfig.c
+
+TESTS = odp_linuxgen_dumpconfig

--- a/platform/linux-generic/dumpconfig/dumpconfig.c
+++ b/platform/linux-generic/dumpconfig/dumpconfig.c
@@ -1,0 +1,43 @@
+/* Copyright (c) 2018, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier:     BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <odp_libconfig_config.h>
+
+int main(void)
+{
+	unsigned int i;
+	const char *filename;
+	FILE *f;
+	char c;
+
+	printf("# Builtin platform config\n\n");
+	for (i = 0; i < sizeof(config_builtin); i++)
+		printf("%c", config_builtin[i]);
+
+	filename = getenv("ODP_CONFIG_FILE");
+	if (filename == NULL)
+		return 0;
+
+	printf("# Overridden section with ODP_CONFIG_FILE=%s\n\n", filename);
+
+	f = fopen(filename, "r");
+	if (f == NULL)  {
+		fprintf(stderr, "Error: open file %s\n", filename);
+		return -1;
+	}
+
+	while (1) {
+		c = fgetc(f);
+		if (feof(f))
+			break;
+		printf("%c", c);
+	}
+
+	fclose(f);
+	return 0;
+}

--- a/platform/linux-generic/m4/configure.m4
+++ b/platform/linux-generic/m4/configure.m4
@@ -27,6 +27,7 @@ AM_CONDITIONAL([PLATFORM_IS_LINUX_GENERIC],
 	       [test "${with_platform}" = "linux-generic"])
 AC_CONFIG_FILES([platform/linux-generic/Makefile
 		 platform/linux-generic/libodp-linux.pc
+		 platform/linux-generic/dumpconfig/Makefile
 		 platform/linux-generic/test/Makefile
 		 platform/linux-generic/test/validation/api/shmem/Makefile
 		 platform/linux-generic/test/validation/api/pktio/Makefile


### PR DESCRIPTION
it might be useful to package small binary which prints
platform default builtin config file.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>