### PR TITLE
[PATCH API-NEXT v2] api: ipsec: improve salt specification

### DIFF
--- a/include/odp/api/spec/crypto.h
+++ b/include/odp/api/spec/crypto.h
@@ -422,7 +422,10 @@ typedef odp_packet_data_range_t ODP_DEPRECATE(odp_crypto_data_range_t);
  * Crypto API session creation parameters
  */
 typedef struct odp_crypto_session_param_t {
-	/** Encode vs. decode operation */
+	/** Encode vs. decode operation
+	 *
+	 *  The default value is ODP_CRYPTO_OP_ENCODE.
+	 */
 	odp_crypto_op_t op;
 
 	/** Authenticate cipher vs. plain text
@@ -435,18 +438,31 @@ typedef struct odp_crypto_session_param_t {
 	 *
 	 *  true:  Authenticate cipher text
 	 *  false: Authenticate plain text
+	 *
+	 *  The default value is false.
 	 */
 	odp_bool_t auth_cipher_text;
 
-	/** Preferred sync vs. async for odp_crypto_operation() */
+	/** Preferred sync vs. async for odp_crypto_operation()
+	 *
+	 *  The default value is ODP_CRYPTO_SYNC.
+	 */
 	odp_crypto_op_mode_t pref_mode;
 
-	/** Operation mode when using packet interface: sync or async */
+	/** Operation mode when using packet interface: sync or async
+	 *
+	 *  The default value is ODP_CRYPTO_SYNC.
+	 */
 	odp_crypto_op_mode_t op_mode;
 
 	/** Cipher algorithm
 	 *
-	 *  Use odp_crypto_capability() for supported algorithms.
+	 *  Select cipher algorithm to be used. ODP_CIPHER_ALG_NULL indicates
+	 *  that ciphering is disabled. Use odp_crypto_capability() for
+	 *  supported algorithms. Note that some algorithms restrict choice of
+	 *  the pairing authentication algorithm. When ciphering is enabled
+	 *  cipher key and IV need to be set. The default value is
+	 *  ODP_CIPHER_ALG_NULL.
 	 */
 	odp_cipher_alg_t cipher_alg;
 
@@ -467,7 +483,18 @@ typedef struct odp_crypto_session_param_t {
 
 	/** Authentication algorithm
 	 *
-	 *  Use odp_crypto_capability() for supported algorithms.
+	 *  Select authentication algorithm to be used. ODP_AUTH_ALG_NULL
+	 *  indicates that authentication is disabled. Use
+	 *  odp_crypto_capability() for supported algorithms. Note that some
+	 *  algorithms restrict choice of the pairing cipher algorithm. When
+	 *  single algorithm provides both ciphering and authentication
+	 *  (i.e. Authenticated Encryption), authentication side key
+	 *  (auth_key) and IV (auth_iv) are ignored, and cipher side values are
+	 *  used instead. These algorithms ignore authentication side key
+	 *  and IV: ODP_AUTH_ALG_AES_GCM, ODP_AUTH_ALG_AES_CCM and
+	 *  ODP_AUTH_ALG_CHACHA20_POLY1305. Otherwise, all authentication side
+	 *  parameters must be set when authentication is enabled. The default
+	 *  value is ODP_AUTH_ALG_NULL.
 	 */
 	odp_auth_alg_t auth_alg;
 

--- a/include/odp/api/spec/ipsec.h
+++ b/include/odp/api/spec/ipsec.h
@@ -364,26 +364,64 @@ typedef enum odp_ipsec_tunnel_type_t {
  * IPSEC crypto parameters
  */
 typedef struct odp_ipsec_crypto_param_t {
-	/** Cipher algorithm */
+	/** Cipher algorithm
+	 *
+	 *  Select cipher algorithm to be used. ODP_CIPHER_ALG_NULL indicates
+	 *  that ciphering is disabled. See 'ciphers' field of
+	 *  odp_ipsec_capability_t for supported cipher algorithms. Algorithm
+	 *  descriptions can be found from odp_cipher_alg_t documentation. Note
+	 *  that some algorithms restrict choice of the pairing authentication
+	 *  algorithm. When ciphering is enabled, cipher key and potential extra
+	 *  key material (cipher_key_extra) need to be set. The default value
+	 *  is ODP_CIPHER_ALG_NULL.
+	 */
 	odp_cipher_alg_t cipher_alg;
 
 	/** Cipher key */
 	odp_crypto_key_t cipher_key;
 
-	/** Extra keying material for cipher key
+	/** Extra keying material for cipher algorithm
 	 *
 	 *  Additional data used as salt or nonce if the algorithm requires it,
 	 *  other algorithms ignore this field. These algorithms require this
-	 *  field set:
-	 *  - AES_GCM: 4 bytes of salt
-	 **/
+	 *  field to be set:
+	 *  - ODP_CIPHER_ALG_AES_CTR: 4 bytes of nonce
+	 *  - ODP_CIPHER_ALG_AES_GCM: 4 bytes of salt
+	 *  - ODP_CIPHER_ALG_AES_CCM: 3 bytes of salt
+	 *  - ODP_CIPHER_ALG_CHACHA20_POLY1305: 4 bytes of salt
+	 */
 	odp_crypto_key_t cipher_key_extra;
 
-	/** Authentication algorithm */
+	/** Authentication algorithm
+	 *
+	 *  Select authentication algorithm to be used. ODP_AUTH_ALG_NULL
+	 *  indicates that authentication is disabled. See 'auths' field of
+	 *  odp_ipsec_capability_t for supported authentication algorithms.
+	 *  Algorithm descriptions can be found from odp_auth_alg_t
+	 *  documentation. Note that some algorithms restrict choice of the
+	 *  pairing cipher algorithm. When single algorithm provides both
+	 *  ciphering and authentication (i.e. Authenticated Encryption),
+	 *  authentication side key information ('auth_key' and
+	 *  'auth_key_extra') is ignored, and cipher side values are
+	 *  used instead. These algorithms ignore authentication side key
+	 *  information: ODP_AUTH_ALG_AES_GCM, ODP_AUTH_ALG_AES_CCM and
+	 *  ODP_AUTH_ALG_CHACHA20_POLY1305. Otherwise, authentication side
+	 *  parameters must be set when authentication is enabled. The default
+	 *  value is ODP_AUTH_ALG_NULL.
+	 */
 	odp_auth_alg_t auth_alg;
 
 	/** Authentication key */
 	odp_crypto_key_t auth_key;
+
+	/** Extra keying material for authentication algorithm
+	 *
+	 *  Additional data used as salt or nonce if the algorithm requires it,
+	 *  other algorithms ignore this field. These algorithms require this
+	 *  field to be set:
+	 *  - ODP_AUTH_ALG_AES_GMAC: 4 bytes of salt
+	 */
+	odp_crypto_key_t auth_key_extra;
 
 } odp_ipsec_crypto_param_t;
 

--- a/platform/linux-generic/odp_ipsec_sad.c
+++ b/platform/linux-generic/odp_ipsec_sad.c
@@ -530,7 +530,7 @@ odp_ipsec_sa_t odp_ipsec_sa_create(const odp_ipsec_sa_param_t *param)
 		ipsec_sa->esp_block_len = 16;
 		crypto_param.auth_iv.length = 12;
 		ipsec_sa->salt_length = 4;
-		salt_param = &param->crypto.cipher_key_extra;
+		salt_param = &param->crypto.auth_key_extra;
 		break;
 	case ODP_AUTH_ALG_CHACHA20_POLY1305:
 		crypto_param.auth_aad_len = sizeof(ipsec_aad_t);

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -345,7 +345,7 @@ static ipsec_alg_config_t algs_config[] = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
 			},
-			.cipher_key_extra = {
+			.auth_key_extra = {
 				.data = test_salt,
 				.length = 4,
 			},

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -277,6 +277,10 @@ static ipsec_alg_config_t algs_config[] = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
 			},
+			.cipher_key_extra = {
+				.data = test_salt,
+				.length = 4,
+			},
 			.auth_alg = ODP_AUTH_ALG_NULL
 		},
 	},
@@ -287,6 +291,10 @@ static ipsec_alg_config_t algs_config[] = {
 			.cipher_key = {
 				.data = test_key16,
 				.length = sizeof(test_key16)
+			},
+			.cipher_key_extra = {
+				.data = test_salt,
+				.length = 4,
 			},
 			.auth_alg = ODP_AUTH_ALG_SHA1_HMAC,
 			.auth_key = {

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -345,7 +345,8 @@ void ipsec_sa_param_fill(odp_ipsec_sa_param_t *param,
 			 const odp_crypto_key_t *cipher_key,
 			 odp_auth_alg_t auth_alg,
 			 const odp_crypto_key_t *auth_key,
-			 const odp_crypto_key_t *extra_key)
+			 const odp_crypto_key_t *cipher_key_extra,
+			 const odp_crypto_key_t *auth_key_extra)
 {
 	odp_ipsec_sa_param_init(param);
 	param->dir = in ? ODP_IPSEC_DIR_INBOUND :
@@ -378,8 +379,11 @@ void ipsec_sa_param_fill(odp_ipsec_sa_param_t *param,
 	if (auth_key)
 		param->crypto.auth_key = *auth_key;
 
-	if (extra_key)
-		param->crypto.cipher_key_extra = *extra_key;
+	if (cipher_key_extra)
+		param->crypto.cipher_key_extra = *cipher_key_extra;
+
+	if (auth_key_extra)
+		param->crypto.auth_key_extra = *auth_key_extra;
 }
 
 void ipsec_sa_destroy(odp_ipsec_sa_t sa)

--- a/test/validation/api/ipsec/ipsec.h
+++ b/test/validation/api/ipsec/ipsec.h
@@ -68,7 +68,8 @@ void ipsec_sa_param_fill(odp_ipsec_sa_param_t *param,
 			 const odp_crypto_key_t *cipher_key,
 			 odp_auth_alg_t auth_alg,
 			 const odp_crypto_key_t *auth_key,
-			 const odp_crypto_key_t *extra_key);
+			 const odp_crypto_key_t *cipher_key_extra,
+			 const odp_crypto_key_t *auth_key_extra);
 
 void ipsec_sa_destroy(odp_ipsec_sa_t sa);
 odp_packet_t ipsec_packet(const ipsec_test_packet *itp);

--- a/test/validation/api/ipsec/ipsec_test_in.c
+++ b/test/validation/api/ipsec/ipsec_test_in.c
@@ -19,7 +19,7 @@ static void test_in_ipv4_ah_sha256(void)
 			    true, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -52,7 +52,7 @@ static void test_in_ipv4_ah_sha256_tun_ipv4(void)
 			    true, true, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -85,7 +85,7 @@ static void test_in_ipv4_ah_sha256_tun_ipv6(void)
 			    true, true, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -117,7 +117,7 @@ static void test_in_ipv4_ah_sha256_tun_ipv4_notun(void)
 			    true, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -150,7 +150,7 @@ static void test_in_ipv4_esp_null_sha256(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -182,7 +182,7 @@ static void test_in_ipv4_esp_aes_cbc_null(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_AES_CBC, &key_a5_128,
 			    ODP_AUTH_ALG_NULL, NULL,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -214,7 +214,7 @@ static void test_in_ipv4_esp_aes_cbc_sha256(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_AES_CBC, &key_a5_128,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -246,7 +246,7 @@ static void test_in_ipv4_esp_aes_ctr_null(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_AES_CTR, &key_a5_128,
 			    ODP_AUTH_ALG_NULL, NULL,
-			    &key_mcgrew_gcm_salt_3);
+			    &key_mcgrew_gcm_salt_3, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -278,7 +278,7 @@ static void test_in_ipv4_ah_sha256_lookup(void)
 			    true, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -311,7 +311,7 @@ static void test_in_ipv4_esp_null_sha256_lookup(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -345,7 +345,7 @@ static void test_in_ipv4_esp_null_sha256_tun_ipv4(void)
 			    true, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -378,7 +378,7 @@ static void test_in_ipv4_esp_null_sha256_tun_ipv6(void)
 			    true, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -410,7 +410,7 @@ static void test_in_ipv4_esp_udp_null_sha256(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.opt.udp_encap = 1;
 
 	sa = odp_ipsec_sa_create(&param);
@@ -443,7 +443,7 @@ static void test_in_ipv4_esp_udp_null_sha256_lookup(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.opt.udp_encap = 1;
 
 	sa = odp_ipsec_sa_create(&param);
@@ -477,7 +477,7 @@ static void test_in_ipv4_ah_sha256_noreplay(void)
 			    true, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.inbound.antireplay_ws = 0;
 
 	sa = odp_ipsec_sa_create(&param);
@@ -525,7 +525,7 @@ static void test_in_ipv4_ah_sha256_replay(void)
 			    true, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.inbound.antireplay_ws = 32;
 
 	sa = odp_ipsec_sa_create(&param);
@@ -583,7 +583,7 @@ static void test_in_ipv4_esp_null_sha256_noreplay(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.inbound.antireplay_ws = 0;
 
 	sa = odp_ipsec_sa_create(&param);
@@ -631,7 +631,7 @@ static void test_in_ipv4_esp_null_sha256_replay(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.inbound.antireplay_ws = 32;
 
 	sa = odp_ipsec_sa_create(&param);
@@ -694,7 +694,7 @@ static void test_in_ipv4_ah_esp_pkt(void)
 			    true, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -729,7 +729,7 @@ static void test_in_ipv4_esp_ah_pkt(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -759,7 +759,7 @@ static void test_in_ipv4_ah_esp_pkt_lookup(void)
 			    true, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -790,7 +790,7 @@ static void test_in_ipv4_esp_ah_pkt_lookup(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -821,7 +821,7 @@ static void test_in_ipv4_ah_sha256_bad1(void)
 			    true, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -851,7 +851,7 @@ static void test_in_ipv4_ah_sha256_bad2(void)
 			    true, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -881,7 +881,7 @@ static void test_in_ipv4_esp_null_sha256_bad1(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -911,7 +911,7 @@ static void test_in_ipv4_rfc3602_5_esp(void)
 			    true, false, 0x4321, NULL,
 			    ODP_CIPHER_ALG_AES_CBC, &key_rfc3602,
 			    ODP_AUTH_ALG_NULL, NULL,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -943,7 +943,7 @@ static void test_in_ipv4_rfc3602_6_esp(void)
 			    true, false, 0x4321, NULL,
 			    ODP_CIPHER_ALG_AES_CBC, &key_rfc3602,
 			    ODP_AUTH_ALG_NULL, NULL,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -976,7 +976,7 @@ static void test_in_ipv4_rfc3602_7_esp(void)
 			    true, false, 0x8765, &tunnel,
 			    ODP_CIPHER_ALG_AES_CBC, &key_rfc3602_2,
 			    ODP_AUTH_ALG_NULL, NULL,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1009,7 +1009,7 @@ static void test_in_ipv4_rfc3602_8_esp(void)
 			    true, false, 0x8765, &tunnel,
 			    ODP_CIPHER_ALG_AES_CBC, &key_rfc3602_2,
 			    ODP_AUTH_ALG_NULL, NULL,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1042,7 +1042,7 @@ static void test_in_ipv4_mcgrew_gcm_2_esp(void)
 			    true, false, 0xa5f8, &tunnel,
 			    ODP_CIPHER_ALG_AES_GCM, &key_mcgrew_gcm_2,
 			    ODP_AUTH_ALG_AES_GCM, NULL,
-			    &key_mcgrew_gcm_salt_2);
+			    &key_mcgrew_gcm_salt_2, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1075,7 +1075,7 @@ static void test_in_ipv4_mcgrew_gcm_3_esp(void)
 			    true, false, 0x4a2cbfe3, &tunnel,
 			    ODP_CIPHER_ALG_AES_GCM, &key_mcgrew_gcm_3,
 			    ODP_AUTH_ALG_AES_GCM, NULL,
-			    &key_mcgrew_gcm_salt_3);
+			    &key_mcgrew_gcm_salt_3, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1108,7 +1108,7 @@ static void test_in_ipv4_mcgrew_gcm_4_esp(void)
 			    true, false, 0x00000000, &tunnel,
 			    ODP_CIPHER_ALG_AES_GCM, &key_mcgrew_gcm_4,
 			    ODP_AUTH_ALG_AES_GCM, NULL,
-			    &key_mcgrew_gcm_salt_4);
+			    &key_mcgrew_gcm_salt_4, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1146,7 +1146,7 @@ static void test_in_ipv4_mcgrew_gcm_12_esp(void)
 			    true, false, 0x335467ae, &tunnel,
 			    ODP_CIPHER_ALG_AES_GCM, &key_mcgrew_gcm_12,
 			    ODP_AUTH_ALG_AES_GCM, NULL,
-			    &key_mcgrew_gcm_salt_12);
+			    &key_mcgrew_gcm_salt_12, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1178,7 +1178,7 @@ static void test_in_ipv4_mcgrew_gcm_12_esp_notun(void)
 			    true, false, 0x335467ae, NULL,
 			    ODP_CIPHER_ALG_AES_GCM, &key_mcgrew_gcm_12,
 			    ODP_AUTH_ALG_AES_GCM, NULL,
-			    &key_mcgrew_gcm_salt_12);
+			    &key_mcgrew_gcm_salt_12, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1211,7 +1211,7 @@ static void test_in_ipv4_mcgrew_gcm_15_esp(void)
 			    true, false, 0x00004321, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_AES_GMAC, &key_mcgrew_gcm_15,
-			    &key_mcgrew_gcm_salt_15);
+			    NULL, &key_mcgrew_gcm_salt_15);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1244,7 +1244,7 @@ static void test_in_ipv4_rfc7634_chacha(void)
 			    true, false, 0x01020304, &tunnel,
 			    ODP_CIPHER_ALG_CHACHA20_POLY1305, &key_rfc7634,
 			    ODP_AUTH_ALG_CHACHA20_POLY1305, NULL,
-			    &key_rfc7634_salt);
+			    &key_rfc7634_salt, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1276,7 +1276,7 @@ static void test_in_ipv4_ah_aes_gmac_128(void)
 			    true, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_AES_GMAC, &key_a5_128,
-			    &key_mcgrew_gcm_salt_2);
+			    NULL, &key_mcgrew_gcm_salt_2);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1308,7 +1308,7 @@ static void test_in_ipv4_esp_null_aes_gmac_128(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_AES_GMAC, &key_a5_128,
-			    &key_mcgrew_gcm_salt_2);
+			    NULL, &key_mcgrew_gcm_salt_2);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1340,7 +1340,7 @@ static void test_in_ipv6_ah_sha256(void)
 			    true, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1373,7 +1373,7 @@ static void test_in_ipv6_ah_sha256_tun_ipv4(void)
 			    true, true, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1406,7 +1406,7 @@ static void test_in_ipv6_ah_sha256_tun_ipv6(void)
 			    true, true, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1438,7 +1438,7 @@ static void test_in_ipv6_esp_null_sha256(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1471,7 +1471,7 @@ static void test_in_ipv6_esp_null_sha256_tun_ipv4(void)
 			    true, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1504,7 +1504,7 @@ static void test_in_ipv6_esp_null_sha256_tun_ipv6(void)
 			    true, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1536,7 +1536,7 @@ static void test_in_ipv6_esp_udp_null_sha256(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.opt.udp_encap = 1;
 
 	sa = odp_ipsec_sa_create(&param);
@@ -1569,7 +1569,7 @@ static void test_in_ipv6_esp_udp_null_sha256_lookup(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.opt.udp_encap = 1;
 
 	sa = odp_ipsec_sa_create(&param);

--- a/test/validation/api/ipsec/ipsec_test_out.c
+++ b/test/validation/api/ipsec/ipsec_test_out.c
@@ -19,7 +19,7 @@ static void test_out_ipv4_ah_sha256(void)
 			    false, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -62,7 +62,7 @@ static void test_out_ipv4_ah_sha256_tun_ipv4(void)
 			    false, true, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -106,7 +106,7 @@ static void test_out_ipv4_ah_sha256_tun_ipv6(void)
 			    false, true, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -136,7 +136,7 @@ static void test_out_ipv4_esp_null_sha256(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -174,7 +174,7 @@ static void test_out_ipv4_esp_null_sha256_tun_ipv4(void)
 			    false, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -219,7 +219,7 @@ static void test_out_ipv4_esp_null_sha256_tun_ipv6(void)
 			    false, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -251,7 +251,7 @@ static void test_out_ipv4_esp_aes_cbc_null(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_AES_CBC, &key_a5_128,
 			    ODP_AUTH_ALG_NULL, NULL,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -261,7 +261,7 @@ static void test_out_ipv4_esp_aes_cbc_null(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_AES_CBC, &key_a5_128,
 			    ODP_AUTH_ALG_NULL, NULL,
-			    NULL);
+			    NULL, NULL);
 
 	sa2 = odp_ipsec_sa_create(&param);
 
@@ -294,7 +294,7 @@ static void test_out_ipv4_esp_udp_null_sha256(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.opt.udp_encap = 1;
 
 	sa = odp_ipsec_sa_create(&param);
@@ -326,7 +326,7 @@ static void test_out_ipv4_esp_aes_cbc_sha256(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_AES_CBC, &key_a5_128,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -336,7 +336,7 @@ static void test_out_ipv4_esp_aes_cbc_sha256(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_AES_CBC, &key_a5_128,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa2 = odp_ipsec_sa_create(&param);
 
@@ -370,7 +370,7 @@ static void test_out_ipv4_esp_aes_ctr_null(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_AES_CTR, &key_a5_128,
 			    ODP_AUTH_ALG_NULL, NULL,
-			    &key_mcgrew_gcm_salt_3);
+			    &key_mcgrew_gcm_salt_3, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -380,7 +380,7 @@ static void test_out_ipv4_esp_aes_ctr_null(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_AES_CTR, &key_a5_128,
 			    ODP_AUTH_ALG_NULL, NULL,
-			    &key_mcgrew_gcm_salt_3);
+			    &key_mcgrew_gcm_salt_3, NULL);
 
 	sa2 = odp_ipsec_sa_create(&param);
 
@@ -414,7 +414,7 @@ static void test_out_ipv4_esp_aes_gcm128(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_AES_GCM, &key_a5_128,
 			    ODP_AUTH_ALG_AES_GCM, &key_a5_128,
-			    &key_mcgrew_gcm_salt_2);
+			    &key_mcgrew_gcm_salt_2, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -424,7 +424,7 @@ static void test_out_ipv4_esp_aes_gcm128(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_AES_GCM, &key_a5_128,
 			    ODP_AUTH_ALG_AES_GCM, &key_a5_128,
-			    &key_mcgrew_gcm_salt_2);
+			    &key_mcgrew_gcm_salt_2, NULL);
 
 	sa2 = odp_ipsec_sa_create(&param);
 
@@ -457,7 +457,7 @@ static void test_out_ipv4_ah_aes_gmac_128(void)
 			    false, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_AES_GMAC, &key_a5_128,
-			    &key_mcgrew_gcm_salt_2);
+			    NULL, &key_mcgrew_gcm_salt_2);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -487,7 +487,7 @@ static void test_out_ipv4_esp_null_aes_gmac_128(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_AES_GMAC, &key_a5_128,
-			    &key_mcgrew_gcm_salt_2);
+			    NULL, &key_mcgrew_gcm_salt_2);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -518,7 +518,7 @@ static void test_out_ipv4_esp_chacha20_poly1305(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_CHACHA20_POLY1305, &key_rfc7634,
 			    ODP_AUTH_ALG_CHACHA20_POLY1305, NULL,
-			    &key_rfc7634_salt);
+			    &key_rfc7634_salt, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -528,7 +528,7 @@ static void test_out_ipv4_esp_chacha20_poly1305(void)
 			    true, false, 123, NULL,
 			    ODP_CIPHER_ALG_CHACHA20_POLY1305, &key_rfc7634,
 			    ODP_AUTH_ALG_CHACHA20_POLY1305, NULL,
-			    &key_rfc7634_salt);
+			    &key_rfc7634_salt, NULL);
 
 	sa2 = odp_ipsec_sa_create(&param);
 
@@ -561,7 +561,7 @@ static void test_out_ipv4_ah_sha256_frag_check(void)
 			    false, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.outbound.frag_mode = ODP_IPSEC_FRAG_CHECK;
 	param.outbound.mtu = 100;
 
@@ -608,7 +608,7 @@ static void test_out_ipv4_ah_sha256_frag_check_2(void)
 			    false, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.outbound.frag_mode = ODP_IPSEC_FRAG_CHECK;
 	param.outbound.mtu = 100;
 
@@ -654,7 +654,7 @@ static void test_out_ipv4_esp_null_sha256_frag_check(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	param.outbound.frag_mode = ODP_IPSEC_FRAG_CHECK;
 	param.outbound.mtu = 100;
@@ -702,7 +702,7 @@ static void test_out_ipv4_esp_null_sha256_frag_check_2(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	param.outbound.frag_mode = ODP_IPSEC_FRAG_CHECK;
 	param.outbound.mtu = 100;
@@ -749,7 +749,7 @@ static void test_out_ipv6_ah_sha256(void)
 			    false, true, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -787,7 +787,7 @@ static void test_out_ipv6_ah_sha256_tun_ipv4(void)
 			    false, true, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -831,7 +831,7 @@ static void test_out_ipv6_ah_sha256_tun_ipv6(void)
 			    false, true, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -861,7 +861,7 @@ static void test_out_ipv6_esp_null_sha256(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -899,7 +899,7 @@ static void test_out_ipv6_esp_null_sha256_tun_ipv4(void)
 			    false, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -944,7 +944,7 @@ static void test_out_ipv6_esp_null_sha256_tun_ipv6(void)
 			    false, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -975,7 +975,7 @@ static void test_out_ipv6_esp_udp_null_sha256(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 	param.opt.udp_encap = 1;
 
 	sa = odp_ipsec_sa_create(&param);
@@ -1020,7 +1020,7 @@ static void test_out_dummy_esp_null_sha256_tun_ipv4(void)
 			    false, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1030,7 +1030,7 @@ static void test_out_dummy_esp_null_sha256_tun_ipv4(void)
 			    true, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa2 = odp_ipsec_sa_create(&param);
 
@@ -1102,7 +1102,7 @@ static void test_out_dummy_esp_null_sha256_tun_ipv6(void)
 			    false, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 
@@ -1112,7 +1112,7 @@ static void test_out_dummy_esp_null_sha256_tun_ipv6(void)
 			    true, false, 123, &tunnel,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa2 = odp_ipsec_sa_create(&param);
 
@@ -1164,7 +1164,7 @@ static void test_out_ipv4_udp_esp_null_sha256(void)
 			    false, false, 123, NULL,
 			    ODP_CIPHER_ALG_NULL, NULL,
 			    ODP_AUTH_ALG_SHA256_HMAC, &key_5a_256,
-			    NULL);
+			    NULL, NULL);
 
 	sa = odp_ipsec_sa_create(&param);
 


### PR DESCRIPTION
Both crypto and IPSEC API documentation needed improvement on how key, IV and extra keying material paramters are expected to be used. Especially, AEAD algorithms needed additional specification. Also, IPSEC with GMAC need a new parameter for extra auth key material. 