### PR TITLE
[PATCH v8] linux-gen: ishm: use pre-reserved single va memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -214,7 +214,7 @@ jobs:
                           - true
                   script:
                           - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
-                          - docker run  -i -t -v `pwd`:/odp
+                          - docker run -i -t -v `pwd`:/odp --shm-size 8g
                               -e CC="${CC}"
                               ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/build_${ARCH}.sh
                 - stage: "build only"
@@ -223,7 +223,7 @@ jobs:
                           - true
                   script:
                           - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
-                          - docker run  -i -t -v `pwd`:/odp
+                          - docker run -i -t -v `pwd`:/odp --shm-size 8g
                               -e CC="${CC}"
                               ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/build_${ARCH}.sh
                 - stage: "build only"
@@ -232,7 +232,7 @@ jobs:
                           - true
                   script:
                           - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
-                          - docker run  -i -t -v `pwd`:/odp
+                          - docker run -i -t -v `pwd`:/odp
                               -e CC="${CC}"
                               ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/build_${ARCH}.sh
                 - stage: "build only"
@@ -241,7 +241,7 @@ jobs:
                           - true
                   script:
                           - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
-                          - docker run  -i -t -v `pwd`:/odp
+                          - docker run -i -t -v `pwd`:/odp --shm-size 8g
                               -e CC="${CC}"
                               ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/build_${ARCH}.sh
                 - stage: test

--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.3"
+config_file_version = "0.1.4"
 
 # Shared memory options
 shm: {
@@ -37,6 +37,9 @@ shm: {
 	# Allocate internal shared memory using a single virtual address space.
 	# Set to 1 to enable using process mode.
 	single_va = 0
+
+ 	# Amount of memory pre-reserved for ODP_SHM_SINGLE_VA usage in kilobytes
+	single_va_size_kb = 131072
 }
 
 # Pool options

--- a/platform/linux-generic/include/odp_config_internal.h
+++ b/platform/linux-generic/include/odp_config_internal.h
@@ -129,16 +129,6 @@ extern "C" {
 #define ODP_CONFIG_SHM_BLOCKS (ODP_CONFIG_POOLS + 48)
 
 /*
- * Size of the virtual address space pre-reserver for ISHM
- *
- * This is just virtual space preallocation size, not memory allocation.
- * This address space is used by ISHM to map things at a common address in
- * all ODP threads (when the _ODP_ISHM_SINGLE_VA flag is used).
- * In bytes.
- */
-#define ODP_CONFIG_ISHM_VA_PREALLOC_SZ (1024 * 1024 * 1024L)
-
-/*
  * Maximum event burst size
  *
  * This controls the burst size on various enqueue, dequeue, etc calls. Large

--- a/platform/linux-generic/include/odp_ishmphy_internal.h
+++ b/platform/linux-generic/include/odp_ishmphy_internal.h
@@ -13,9 +13,9 @@ extern "C" {
 
 #include <stdint.h>
 
-void *_odp_ishmphy_book_va(uintptr_t len, intptr_t align);
-int   _odp_ishmphy_unbook_va(void);
-void *_odp_ishmphy_map(int fd, void *start, uint64_t size, int flags);
+void *_odp_ishmphy_reserve_single_va(uint64_t len, int fd);
+int   _odp_ishmphy_free_single_va(void);
+void *_odp_ishmphy_map(int fd, uint64_t size, uint64_t offset, int flags);
 int   _odp_ishmphy_unmap(void *start, uint64_t len, int flags);
 
 #ifdef __cplusplus

--- a/platform/linux-generic/include/odp_ishmpool_internal.h
+++ b/platform/linux-generic/include/odp_ishmpool_internal.h
@@ -46,7 +46,6 @@ int _odp_ishm_pool_destroy(_odp_ishm_pool_t *pool);
 void *_odp_ishm_pool_alloc(_odp_ishm_pool_t *pool, uint64_t size);
 int _odp_ishm_pool_free(_odp_ishm_pool_t *pool, void *addr);
 int _odp_ishm_pool_status(const char *title, _odp_ishm_pool_t *pool);
-_odp_ishm_pool_t *_odp_ishm_pool_lookup(const char *pool_name);
 void _odp_ishm_pool_init(void);
 
 #ifdef __cplusplus

--- a/platform/linux-generic/include/odp_shm_internal.h
+++ b/platform/linux-generic/include/odp_shm_internal.h
@@ -40,11 +40,7 @@ odp_shm_t _odp_shm_reserve(const char *name, uint64_t size, uint32_t align,
 int   _odp_ishm_reserve(const char *name, uint64_t size, int fd, uint32_t align,
 			uint32_t flags, uint32_t user_flags);
 int   _odp_ishm_free_by_index(int block_index);
-int   _odp_ishm_free_by_name(const char *name);
-int   _odp_ishm_free_by_address(void *addr);
-void *_odp_ishm_lookup_by_index(int block_index);
 int   _odp_ishm_lookup_by_name(const char *name);
-int   _odp_ishm_lookup_by_address(void *addr);
 int   _odp_ishm_find_exported(const char *remote_name,
 			      pid_t external_odp_pid,
 			      const char *local_name);

--- a/platform/linux-generic/include/odp_shm_internal.h
+++ b/platform/linux-generic/include/odp_shm_internal.h
@@ -38,7 +38,7 @@ odp_shm_t _odp_shm_reserve(const char *name, uint64_t size, uint32_t align,
 			   uint32_t flags, uint32_t extra_flags);
 
 int   _odp_ishm_reserve(const char *name, uint64_t size, int fd, uint32_t align,
-			uint32_t flags, uint32_t user_flags);
+			uint64_t offset, uint32_t flags, uint32_t user_flags);
 int   _odp_ishm_free_by_index(int block_index);
 int   _odp_ishm_lookup_by_name(const char *name);
 int   _odp_ishm_find_exported(const char *remote_name,

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -1335,9 +1335,8 @@ static void *block_lookup(int block_index)
 
 /*
  * Lookup for an ishm shared memory, identified by its block name.
- * Map this ishm area in the process VA (if not already present).
- * Return the block index, or -1  if the index
- * does not match any known ishm blocks.
+ * Return the block index, or -1  if the index does not match any known ishm
+ * blocks.
  */
 int _odp_ishm_lookup_by_name(const char *name)
 {
@@ -1348,42 +1347,25 @@ int _odp_ishm_lookup_by_name(const char *name)
 
 	/* search the block in main ishm table: return -1 if not found: */
 	block_index = find_block_by_name(name);
-	if ((block_index < 0) || (!block_lookup(block_index))) {
-		odp_spinlock_unlock(&ishm_tbl->lock);
-		return -1;
-	}
 
 	odp_spinlock_unlock(&ishm_tbl->lock);
 	return block_index;
 }
 
 /*
- * Returns the VA address of a given block (which has to be known in the current
- * process). Returns NULL if the block is unknown.
+ * Returns the VA address of a given block. Maps this ishm area in the process
+ * VA (if not already present).
+ * Returns NULL if the block is unknown.
  */
 void *_odp_ishm_address(int block_index)
 {
-	int proc_index;
 	void *addr;
 
 	odp_spinlock_lock(&ishm_tbl->lock);
 	procsync();
 
-	if ((block_index < 0) ||
-	    (block_index >= ISHM_MAX_NB_BLOCKS) ||
-	    (ishm_tbl->block[block_index].len == 0)) {
-		ODP_ERR("Request for address on an invalid block\n");
-		odp_spinlock_unlock(&ishm_tbl->lock);
-		return NULL;
-	}
+	addr = block_lookup(block_index);
 
-	proc_index = procfind_block(block_index);
-	if (proc_index < 0) {
-		odp_spinlock_unlock(&ishm_tbl->lock);
-		return NULL;
-	}
-
-	addr = ishm_proctable->entry[proc_index].start;
 	odp_spinlock_unlock(&ishm_tbl->lock);
 	return addr;
 }

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -1499,11 +1499,23 @@ int _odp_ishm_init_global(const odp_init_t *init)
 	void *addr;
 	void *spce_addr;
 	int i;
+	int single_va_size_kb = 0;
 	uid_t uid;
 	char *hp_dir = odp_global_ro.hugepage_info.default_huge_page_dir;
 	uint64_t align;
-	uint64_t max_memory = ODP_CONFIG_ISHM_VA_PREALLOC_SZ;
-	uint64_t internal   = ODP_CONFIG_ISHM_VA_PREALLOC_SZ / 8;
+	uint64_t max_memory;
+	uint64_t internal;
+
+	if (!_odp_libconfig_lookup_ext_int("shm", NULL, "single_va_size_kb",
+					   &single_va_size_kb)) {
+		ODP_ERR("Unable to read single VA size from config\n");
+		return -1;
+	}
+
+	ODP_DBG("Shm single VA size: %dkB\n", single_va_size_kb);
+
+	max_memory = single_va_size_kb * 1024;
+	internal   = max_memory / 8;
 
 	/* user requested memory size + some extra for internal use */
 	if (init && init->shm.max_memory)

--- a/platform/linux-generic/odp_ishmphy.c
+++ b/platform/linux-generic/odp_ishmphy.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <inttypes.h>
 #include <odp_ishmphy_internal.h>
 
 static void *common_va_address;
@@ -39,112 +40,72 @@ static uint64_t common_va_len;
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
-/* Book some virtual address space
- * This function is called at odp_init_global() time to pre-book some
- * virtual address space inherited by all odpthreads (i.e. descendant
- * processes and threads) and later used to guarantee the unicity the
- * the mapping VA address when memory is reserver with the _ODP_ISHM_SINGLE_VA
- * flag.
+/* Reserve single VA memory
+ * This function is called at odp_init_global() time to pre-reserve some memory
+ * which is inherited by all odpthreads (i.e. descendant processes and threads).
+ * This memory block is later used when memory is reserved with
+ * _ODP_ISHM_SINGLE_VA flag.
  * returns the address of the mapping or NULL on error.
  */
-void *_odp_ishmphy_book_va(uintptr_t len, intptr_t align)
+void *_odp_ishmphy_reserve_single_va(uint64_t len, int fd)
 {
 	void *addr;
 
-	addr = mmap(NULL, len + align, PROT_NONE,
-		    MAP_SHARED | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+	addr = mmap(NULL, len, PROT_READ | PROT_WRITE,
+		    MAP_SHARED | MAP_POPULATE, fd, 0);
 	if (addr == MAP_FAILED) {
-		ODP_ERR("_ishmphy_book_va failure\n");
+		ODP_ERR("mmap failed: %s\n", strerror(errno));
 		return NULL;
 	}
 
-	if (mprotect(addr, len, PROT_NONE))
-			ODP_ERR("failure for protect\n");
+	if (mprotect(addr, len, PROT_READ | PROT_WRITE))
+		ODP_ERR("mprotect failed: %s\n", strerror(errno));
 
-	ODP_DBG("VA Reserved: %p, len=%p\n", addr, len + align);
+	ODP_DBG("VA Reserved: %p, len=%" PRIu64 "\n", addr, len);
 
 	common_va_address = addr;
 	common_va_len	  = len;
 
-	/* return the nearest aligned address: */
-	return (void *)(((uintptr_t)addr + align - 1) & (-align));
+	return addr;
 }
 
-/* Un-book some virtual address space
- * This function is called at odp_term_global() time to unbook
- * the virtual address space booked by _ishmphy_book_va()
+/* Free single VA memory
+ * This function is called at odp_term_global() time to free the memory reserved
+ * by _odp_ishmphy_reserve_single_va()
  */
-int _odp_ishmphy_unbook_va(void)
+int _odp_ishmphy_free_single_va(void)
 {
 	int ret;
 
+	if (!common_va_address)
+		return 0;
+
 	ret = munmap(common_va_address, common_va_len);
 	if (ret)
-		ODP_ERR("_unishmphy_book_va failure\n");
+		ODP_ERR("munmap failed: %s\n", strerror(errno));
 	return ret;
 }
 
 /*
  * do a mapping:
  * Performs a mapping of the provided file descriptor to the process VA
- * space. If the _ODP_ISHM_SINGLE_VA flag is set, 'start' is assumed to be
- * the VA address where the mapping is to be done.
- * If the flag is not set, a new VA address is taken.
+ * space. Not to be used with _ODP_ISHM_SINGLE_VA blocks.
  * returns the address of the mapping or NULL on error.
  */
-void *_odp_ishmphy_map(int fd, void *start, uint64_t size,
-		       int flags)
+void *_odp_ishmphy_map(int fd, uint64_t size, uint64_t offset, int flags)
 {
-	void *mapped_addr_tmp, *mapped_addr;
+	void *mapped_addr;
 	int mmap_flags = MAP_POPULATE;
 
-	if (flags & _ODP_ISHM_SINGLE_VA) {
-		if (!start) {
-			ODP_ERR("failure: missing address\n");
-			return NULL;
-		}
-		/* maps over fragment of reserved VA: */
-		/* first, try a normal map. If that works, remap it where it
-		 * should (on the prereverved space), and remove the initial
-		 * normal mapping:
-		 * This is because it turned out that if a mapping fails
-		 * on a the prereserved virtual address space, then
-		 * the prereserved address space which was tried to be mapped
-		 * on becomes available to the kernel again! This was not
-		 * according to expectations: the assumption was that if a
-		 * mapping fails, the system should remain unchanged, but this
-		 * is obvioulsy not true (at least for huge pages when
-		 * exhausted).
-		 * So the strategy is to first map at a non reserved place
-		 * (which can then be freed and returned to the kernel on
-		 * failure) and peform a new map to the prereserved space on
-		 * success (which is then guaranteed to work).
-		 * The initial free maping can then be removed.
-		 */
-		mapped_addr = MAP_FAILED;
-		mapped_addr_tmp = mmap(NULL, size, PROT_READ | PROT_WRITE,
-				       MAP_SHARED | mmap_flags, fd, 0);
-		if (mapped_addr_tmp != MAP_FAILED) {
-			/* If OK, do new map at right fixed location... */
-			mapped_addr = mmap(start,
-					   size, PROT_READ | PROT_WRITE,
-					   MAP_SHARED | MAP_FIXED | mmap_flags,
-					   fd, 0);
-			if (mapped_addr != start)
-				ODP_ERR("new map failed:%s\n", strerror(errno));
-			/* ... and remove initial mapping: */
-			if (munmap(mapped_addr_tmp, size))
-				ODP_ERR("munmap failed:%s\n", strerror(errno));
-		}
-	} else {
-		/* just do a new mapping in the VA space: */
-		mapped_addr = mmap(NULL, size, PROT_READ | PROT_WRITE,
-				   MAP_SHARED | mmap_flags, fd, 0);
-		if ((mapped_addr >= common_va_address) &&
-		    ((char *)mapped_addr <
-			(char *)common_va_address + common_va_len)) {
-			ODP_ERR("VA SPACE OVERLAP!\n");
-		}
+	ODP_ASSERT(!(flags & _ODP_ISHM_SINGLE_VA));
+
+	/* do a new mapping in the VA space: */
+	mapped_addr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+			   MAP_SHARED | mmap_flags, fd, offset);
+	if ((mapped_addr >= common_va_address) &&
+	    ((char *)mapped_addr <
+		(char *)common_va_address + common_va_len)) {
+		ODP_ERR("VA SPACE OVERLAP!\n");
 	}
 
 	if (mapped_addr == MAP_FAILED)
@@ -153,9 +114,9 @@ void *_odp_ishmphy_map(int fd, void *start, uint64_t size,
 	/* if locking is requested, lock it...*/
 	if (flags & _ODP_ISHM_LOCK) {
 		if (mlock(mapped_addr, size)) {
+			ODP_ERR("mlock failed: %s\n", strerror(errno));
 			if (munmap(mapped_addr, size))
-				ODP_ERR("munmap failed:%s\n", strerror(errno));
-			ODP_ERR("mlock failed:%s\n", strerror(errno));
+				ODP_ERR("munmap failed: %s\n", strerror(errno));
 			return NULL;
 		}
 	}
@@ -163,44 +124,25 @@ void *_odp_ishmphy_map(int fd, void *start, uint64_t size,
 }
 
 /* free a mapping:
- * If the _ODP_ISHM_SINGLE_VA flag was given at creation time the virtual
- * address range must be returned to the preoallocated "pool". this is
- * done by mapping non accessibly memory there (hence blocking the VA but
- * releasing the physical memory).
- * If the _ODP_ISHM_SINGLE_VA flag was not given, both physical memory and
- * virtual address space are realeased by calling the normal munmap.
+ * _ODP_ISHM_SINGLE_VA memory is not returned back to linux until global
+ * terminate. If the _ODP_ISHM_SINGLE_VA flag was not given, both physical
+ * memory and virtual address space are released by calling the normal munmap.
  * return 0 on success or -1 on error.
  */
 int _odp_ishmphy_unmap(void *start, uint64_t len, int flags)
 {
-	void *addr;
 	int ret;
-	int mmap_flgs;
-
-	mmap_flgs = MAP_SHARED | MAP_FIXED | MAP_ANONYMOUS | MAP_NORESERVE;
 
 	/* if locking was requested, unlock...*/
 	if (flags & _ODP_ISHM_LOCK)
 		munlock(start, len);
 
-	if (flags & _ODP_ISHM_SINGLE_VA) {
-		/* map unnaccessible memory overwrites previous mapping
-		 * and free the physical memory, but guarantees to block
-		 * the VA range from other mappings
-		 */
-		addr = mmap(start, len, PROT_NONE, mmap_flgs, -1, 0);
-		if (addr == MAP_FAILED) {
-			ODP_ERR("_ishmphy_free failure for ISHM_SINGLE_VA\n");
-			return -1;
-		}
-		if (mprotect(start, len, PROT_NONE))
-			ODP_ERR("_ishmphy_free failure for protect\n");
+	if (flags & _ODP_ISHM_SINGLE_VA)
 		return 0;
-	}
 
 	/* just release the mapping */
 	ret = munmap(start, len);
 	if (ret)
-		ODP_ERR("_ishmphy_free failure: %s\n", strerror(errno));
+		ODP_ERR("munmap failed: %s\n", strerror(errno));
 	return ret;
 }

--- a/platform/linux-generic/odp_ishmpool.c
+++ b/platform/linux-generic/odp_ishmpool.c
@@ -223,7 +223,7 @@ static pool_t *_odp_ishmbud_pool_create(const char *pool_name, int store_idx,
 
 	/* allocate required memory: */
 	blk_idx = _odp_ishm_reserve(pool_name, total_sz, -1,
-				    ODP_CACHE_LINE_SIZE, flags, 0);
+				    ODP_CACHE_LINE_SIZE, 0, flags, 0);
 	if (blk_idx < 0) {
 		ODP_ERR("_odp_ishm_reserve failed.");
 		return NULL;
@@ -558,7 +558,7 @@ static pool_t *_odp_ishmslab_pool_create(const char *pool_name, int store_idx,
 
 	/* allocate required memory: */
 	blk_idx = _odp_ishm_reserve(pool_name, total_sz, -1,
-				    ODP_CACHE_LINE_SIZE, flags, 0);
+				    ODP_CACHE_LINE_SIZE, 0, flags, 0);
 	if (blk_idx < 0) {
 		ODP_ERR("_odp_ishm_reserve failed.");
 		return NULL;

--- a/platform/linux-generic/odp_ishmpool.c
+++ b/platform/linux-generic/odp_ishmpool.c
@@ -784,23 +784,3 @@ void _odp_ishm_pool_init(void)
 	for (i = 0; i < MAX_NB_POOL; i++)
 		pool_blk_idx[i] = -1;
 }
-
-_odp_ishm_pool_t *_odp_ishm_pool_lookup(const char *pool_name)
-{
-	int block_idx;
-	int store_idx;
-
-	/* search for a _ishm block with the given name */
-	block_idx = _odp_ishm_lookup_by_name(pool_name);
-	if (block_idx < 0)
-		return NULL;
-
-	/* a block with that name exists: make sure it is within
-	 * the registered pools */
-	for (store_idx = 0; store_idx < MAX_NB_POOL; store_idx++) {
-		if (pool_blk_idx[store_idx] == block_idx)
-			return  _odp_ishm_address(block_idx);
-	}
-
-	return NULL;
-}

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -225,8 +225,7 @@ static int queue_init_global(void)
 	max_alloc = CONFIG_SCAL_QUEUE_SIZE * sizeof(odp_buffer_hdr_t *);
 	queue_shm_pool = _odp_ishm_pool_create("queue_shm_pool",
 					       pool_size,
-					       min_alloc, max_alloc,
-					       _ODP_ISHM_SINGLE_VA);
+					       min_alloc, max_alloc, 0);
 	if (queue_shm_pool == NULL) {
 		ODP_ERR("Failed to allocate shared memory pool for"
 			" queues\n");

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -207,34 +207,30 @@ static int queue_init_global(void)
 	_odp_queue_inline_offset.context = offsetof(queue_entry_t,
 						    s.param.context);
 
-	/* Attach to the pool if it exists */
-	queue_shm_pool = _odp_ishm_pool_lookup("queue_shm_pool");
-	if (queue_shm_pool == NULL) {
-		/* Create shared memory pool to allocate shared memory for the
-		 * queues. Use the default queue size.
-		 */
-		/* Add size of the array holding the queues */
-		pool_size = sizeof(queue_table_t);
-		/* Add storage required for queues */
-		pool_size += (CONFIG_SCAL_QUEUE_SIZE *
-			      sizeof(odp_buffer_hdr_t *)) * ODP_CONFIG_QUEUES;
+	/* Create shared memory pool to allocate shared memory for the
+	 * queues. Use the default queue size.
+	 */
+	/* Add size of the array holding the queues */
+	pool_size = sizeof(queue_table_t);
+	/* Add storage required for queues */
+	pool_size += (CONFIG_SCAL_QUEUE_SIZE *
+		      sizeof(odp_buffer_hdr_t *)) * ODP_CONFIG_QUEUES;
 
-		/* Add the reorder window size */
-		pool_size += sizeof(reorder_window_t) * ODP_CONFIG_QUEUES;
-		/* Choose min_alloc and max_alloc such that buddy allocator is
-		 * is selected.
-		 */
-		min_alloc = 0;
-		max_alloc = CONFIG_SCAL_QUEUE_SIZE * sizeof(odp_buffer_hdr_t *);
-		queue_shm_pool = _odp_ishm_pool_create("queue_shm_pool",
-						       pool_size,
-						       min_alloc, max_alloc,
-						       _ODP_ISHM_SINGLE_VA);
-		if (queue_shm_pool == NULL) {
-			ODP_ERR("Failed to allocate shared memory pool for"
-				" queues\n");
-			goto queue_shm_pool_create_failed;
-		}
+	/* Add the reorder window size */
+	pool_size += sizeof(reorder_window_t) * ODP_CONFIG_QUEUES;
+	/* Choose min_alloc and max_alloc such that buddy allocator is
+	 * is selected.
+	 */
+	min_alloc = 0;
+	max_alloc = CONFIG_SCAL_QUEUE_SIZE * sizeof(odp_buffer_hdr_t *);
+	queue_shm_pool = _odp_ishm_pool_create("queue_shm_pool",
+					       pool_size,
+					       min_alloc, max_alloc,
+					       _ODP_ISHM_SINGLE_VA);
+	if (queue_shm_pool == NULL) {
+		ODP_ERR("Failed to allocate shared memory pool for"
+			" queues\n");
+		goto queue_shm_pool_create_failed;
 	}
 
 	queue_tbl = (queue_table_t *)

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -1770,6 +1770,7 @@ static int schedule_init_global(void)
 	odp_schedule_group_t tmp_wrkr;
 	odp_schedule_group_t tmp_ctrl;
 	odp_shm_t shm;
+	_odp_ishm_pool_t *pool;
 	uint32_t bits;
 	uint32_t pool_size;
 	uint64_t min_alloc;
@@ -1788,34 +1789,28 @@ static int schedule_init_global(void)
 	memset(global, 0, sizeof(sched_global_t));
 	global->shm = shm;
 
-	/* Attach to the pool if it exists */
-	global->sched_shm_pool = _odp_ishm_pool_lookup("sched_shm_pool");
-	if (global->sched_shm_pool == NULL) {
-		_odp_ishm_pool_t *pool;
-
-		/* Add storage required for sched groups. Assume worst case
-		 * xfactor of MAXTHREADS.
-		 */
-		pool_size = (sizeof(sched_group_t) +
-			     (ODP_SCHED_PRIO_NUM * MAXTHREADS - 1) *
-			     sizeof(sched_queue_t)) * MAX_SCHED_GROUP;
-		/* Choose min_alloc and max_alloc such that slab allocator
-		 * is selected.
-		 */
-		min_alloc = sizeof(sched_group_t) +
-			    (ODP_SCHED_PRIO_NUM * MAXTHREADS - 1) *
-			    sizeof(sched_queue_t);
-		max_alloc = min_alloc;
-		pool = _odp_ishm_pool_create("sched_shm_pool", pool_size,
-					     min_alloc, max_alloc,
-					     _ODP_ISHM_SINGLE_VA);
-		if (pool == NULL) {
-			ODP_ERR("Failed to allocate shared memory pool "
-				"for sched\n");
-			goto failed_sched_shm_pool_create;
-		}
-		global->sched_shm_pool = pool;
+	/* Add storage required for sched groups. Assume worst case
+	 * xfactor of MAXTHREADS.
+	 */
+	pool_size = (sizeof(sched_group_t) +
+		     (ODP_SCHED_PRIO_NUM * MAXTHREADS - 1) *
+		     sizeof(sched_queue_t)) * MAX_SCHED_GROUP;
+	/* Choose min_alloc and max_alloc such that slab allocator
+	 * is selected.
+	 */
+	min_alloc = sizeof(sched_group_t) +
+		    (ODP_SCHED_PRIO_NUM * MAXTHREADS - 1) *
+		    sizeof(sched_queue_t);
+	max_alloc = min_alloc;
+	pool = _odp_ishm_pool_create("sched_shm_pool", pool_size,
+				     min_alloc, max_alloc,
+				     _ODP_ISHM_SINGLE_VA);
+	if (pool == NULL) {
+		ODP_ERR("Failed to allocate shared memory pool "
+			"for sched\n");
+		goto failed_sched_shm_pool_create;
 	}
+	global->sched_shm_pool = pool;
 
 	odp_spinlock_init(&global->sched_grp_lock);
 

--- a/platform/linux-generic/odp_shared_memory.c
+++ b/platform/linux-generic/odp_shared_memory.c
@@ -53,7 +53,7 @@ odp_shm_t _odp_shm_reserve(const char *name, uint64_t size, uint32_t align,
 	flgs = get_ishm_flags(flags);
 	flgs |= extra_flags;
 
-	block_index = _odp_ishm_reserve(name, size, -1, align, flgs, flags);
+	block_index = _odp_ishm_reserve(name, size, -1, align, 0, flgs, flags);
 	if (block_index >= 0)
 		return to_handle(block_index);
 	else

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,10 +1,13 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.3"
+config_file_version = "0.1.4"
 
 # Shared memory options
 shm: {
 	# Override default option and allocate internal shms using single
 	# virtual address space.
 	single_va = 1
+
+ 	# Increase the amount of single VA memory
+	single_va_size_kb = 1048576
 }

--- a/platform/linux-generic/test/validation/api/shmem/shmem_linux.c
+++ b/platform/linux-generic/test/validation/api/shmem/shmem_linux.c
@@ -110,7 +110,8 @@
 static int read_shmem_attribues(uint64_t ext_odp_pid, const char *blockname,
 				char *filename, uint64_t *len,
 				uint32_t *flags, uint64_t *user_len,
-				uint32_t *user_flags, uint32_t *align)
+				uint32_t *user_flags, uint32_t *align,
+				uint64_t *offset)
 {
 	char shm_attr_filename[PATH_MAX];
 	FILE *export_file;
@@ -149,6 +150,9 @@ static int read_shmem_attribues(uint64_t ext_odp_pid, const char *blockname,
 		goto export_file_read_err;
 
 	if (fscanf(export_file, "align: %" PRIu32 " ", align) != 1)
+		goto export_file_read_err;
+
+	if (fscanf(export_file, "offset: %" PRIu64 " ", offset) != 1)
 		goto export_file_read_err;
 
 	fclose(export_file);
@@ -209,6 +213,7 @@ int main(int argc __attribute__((unused)), char *argv[])
 	int fifo_fd = -1;
 	char shm_filename[PATH_MAX];/* shared mem device name, under /dev/shm */
 	uint64_t len;
+	uint64_t offset;
 	uint32_t flags;
 	uint64_t user_len;
 	uint32_t user_flags;
@@ -260,8 +265,9 @@ int main(int argc __attribute__((unused)), char *argv[])
 	/* read the shared memory attributes (includes the shm filename): */
 	if (read_shmem_attribues(odp_app1, SHM_NAME,
 				 shm_filename, &len, &flags,
-				 &user_len, &user_flags, &align) != 0) {
-		printf("erorr read_shmem_attribues\n");
+				 &user_len, &user_flags, &align,
+				 &offset) != 0) {
+		printf("error read_shmem_attribues\n");
 		test_failure(fifo_name, fifo_fd, odp_app1);
 	}
 
@@ -281,9 +287,10 @@ int main(int argc __attribute__((unused)), char *argv[])
 	 */
 	size = sizeof(test_shared_linux_data_t);
 
-	addr = mmap(NULL, size, PROT_READ, MAP_SHARED, shm_fd, 0);
+	addr = mmap(NULL, size, PROT_READ, MAP_SHARED, shm_fd, offset);
 	if (addr == MAP_FAILED) {
-		fprintf(stderr, "shmem_linux: map failed!\n");
+		fprintf(stderr, "shmem_linux: mmap failed: %s\n",
+			strerror(errno));
 		test_failure(fifo_name, fifo_fd, odp_app1);
 	}
 

--- a/test/validation/api/shmem/shmem.c
+++ b/test/validation/api/shmem/shmem.c
@@ -468,7 +468,7 @@ static int run_test_singleva_after_fork(void *arg ODP_UNUSED)
 		size = sizeof(shared_test_data_small_t);
 		shm = odp_shm_reserve(glob_data->name[thr_index], size,
 				      0, ODP_SHM_SINGLE_VA);
-		CU_ASSERT(ODP_SHM_INVALID != shm);
+		CU_ASSERT_FATAL(ODP_SHM_INVALID != shm);
 		glob_data->shm[thr_index] = shm;
 		pattern_small = odp_shm_addr(shm);
 		CU_ASSERT_PTR_NOT_NULL(pattern_small);
@@ -480,7 +480,7 @@ static int run_test_singleva_after_fork(void *arg ODP_UNUSED)
 		size = sizeof(shared_test_data_medium_t);
 		shm = odp_shm_reserve(glob_data->name[thr_index], size,
 				      0, ODP_SHM_SINGLE_VA);
-		CU_ASSERT(ODP_SHM_INVALID != shm);
+		CU_ASSERT_FATAL(ODP_SHM_INVALID != shm);
 		glob_data->shm[thr_index] = shm;
 		pattern_medium = odp_shm_addr(shm);
 		CU_ASSERT_PTR_NOT_NULL(pattern_medium);
@@ -492,7 +492,7 @@ static int run_test_singleva_after_fork(void *arg ODP_UNUSED)
 		size = sizeof(shared_test_data_big_t);
 		shm = odp_shm_reserve(glob_data->name[thr_index], size,
 				      0, ODP_SHM_SINGLE_VA);
-		CU_ASSERT(ODP_SHM_INVALID != shm);
+		CU_ASSERT_FATAL(ODP_SHM_INVALID != shm);
 		glob_data->shm[thr_index] = shm;
 		pattern_big = odp_shm_addr(shm);
 		CU_ASSERT_PTR_NOT_NULL(pattern_big);
@@ -550,7 +550,7 @@ static void shmem_test_singleva_after_fork(void)
 	glob_data = odp_shm_addr(shm);
 	CU_ASSERT_PTR_NOT_NULL(glob_data);
 
-	thrdarg.numthrds = odp_cpumask_default_worker(&unused, 0);
+	thrdarg.numthrds = odp_cpumask_default_worker(&unused, 3);
 	if (thrdarg.numthrds > MAX_WORKERS)
 		thrdarg.numthrds = MAX_WORKERS;
 
@@ -578,21 +578,21 @@ static void shmem_test_singleva_after_fork(void)
 		case 0:
 			pattern_small =
 				odp_shm_addr(glob_data->shm[thr_index]);
-			CU_ASSERT_PTR_NOT_NULL(pattern_small);
+			CU_ASSERT_PTR_NOT_NULL_FATAL(pattern_small);
 			for (i = 0; i < SMALL_MEM; i++)
 				CU_ASSERT(pattern_small->data[i] == i);
 			break;
 		case 1:
 			pattern_medium =
 				odp_shm_addr(glob_data->shm[thr_index]);
-			CU_ASSERT_PTR_NOT_NULL(pattern_medium);
+			CU_ASSERT_PTR_NOT_NULL_FATAL(pattern_medium);
 			for (i = 0; i < MEDIUM_MEM; i++)
 				CU_ASSERT(pattern_medium->data[i] == (i << 2));
 			break;
 		case 2:
 			pattern_big =
 				odp_shm_addr(glob_data->shm[thr_index]);
-			CU_ASSERT_PTR_NOT_NULL(pattern_big);
+			CU_ASSERT_PTR_NOT_NULL_FATAL(pattern_big);
 			for (i = 0; i < BIG_MEM; i++)
 				CU_ASSERT(pattern_big->data[i] == (i >> 2));
 			break;


### PR DESCRIPTION
Reserve single VA memory in global init instead of only allocating the virtual address space. This enables reserving shm blocks in process mode after ODP process has been already forked.

V2:
- single_va_size -> single_va_size_kb (Bill & Maxim)

V5:
- Use MAP_POPULATE flag with mmap

V6:
- Fix new pool validation test running out of buffers

V7:
- Increase default single VA size to 128MB

V8:
- Rebase (Maxim)