### PR TITLE
[PATCH API-NEXT v3] api: schedule: wait and no_wait

### DIFF
--- a/include/odp/api/spec/schedule.h
+++ b/include/odp/api/spec/schedule.h
@@ -113,6 +113,35 @@ int odp_schedule_multi(odp_queue_t *from, uint64_t wait, odp_event_t events[],
 		       int num);
 
 /**
+ * Schedule, wait for events
+ *
+ * Like odp_schedule_multi(), but waits infinitely for events.
+ *
+ * @param[out] from    Output parameter for the source queue (where the event
+ *                     was dequeued from). Ignored if NULL.
+ * @param[out] events  Event array for output
+ * @param      num     Maximum number of events to output
+ *
+ * @return Number of events outputted (1 ... num)
+ */
+int odp_schedule_multi_wait(odp_queue_t *from, odp_event_t events[], int num);
+
+/**
+ * Schedule, do not wait for events
+ *
+ * Like odp_schedule_multi(), but does not wait for events.
+ *
+ * @param[out] from    Output parameter for the source queue (where the event
+ *                     was dequeued from). Ignored if NULL.
+ * @param[out] events  Event array for output
+ * @param      num     Maximum number of events to output
+ *
+ * @return Number of events outputted (0 ... num)
+ */
+int odp_schedule_multi_no_wait(odp_queue_t *from, odp_event_t events[],
+			       int num);
+
+/**
  * Pause scheduling
  *
  * Pause global scheduling for this thread. After this call, all schedule calls

--- a/platform/linux-generic/include/odp_schedule_if.h
+++ b/platform/linux-generic/include/odp_schedule_if.h
@@ -89,9 +89,14 @@ void sched_cb_pktio_stop_finalize(int pktio_index);
 
 /* API functions */
 typedef struct {
-	uint64_t (*schedule_wait_time)(uint64_t);
-	odp_event_t (*schedule)(odp_queue_t *, uint64_t);
-	int (*schedule_multi)(odp_queue_t *, uint64_t, odp_event_t [], int);
+	uint64_t (*schedule_wait_time)(uint64_t ns);
+	odp_event_t (*schedule)(odp_queue_t *from, uint64_t wait);
+	int (*schedule_multi)(odp_queue_t *from, uint64_t wait,
+			      odp_event_t events[], int num);
+	int (*schedule_multi_wait)(odp_queue_t *from, odp_event_t events[],
+				   int num);
+	int (*schedule_multi_no_wait)(odp_queue_t *from, odp_event_t events[],
+				      int num);
 	void (*schedule_pause)(void);
 	void (*schedule_resume)(void);
 	void (*schedule_release_atomic)(void);

--- a/platform/linux-generic/odp_schedule_if.c
+++ b/platform/linux-generic/odp_schedule_if.c
@@ -41,6 +41,16 @@ int odp_schedule_multi(odp_queue_t *from, uint64_t wait, odp_event_t events[],
 	return sched_api->schedule_multi(from, wait, events, num);
 }
 
+int odp_schedule_multi_wait(odp_queue_t *from, odp_event_t events[], int num)
+{
+	return sched_api->schedule_multi_wait(from, events, num);
+}
+
+int odp_schedule_multi_no_wait(odp_queue_t *from, odp_event_t events[], int num)
+{
+	return sched_api->schedule_multi_no_wait(from, events, num);
+}
+
 void odp_schedule_pause(void)
 {
 	return sched_api->schedule_pause();

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -1342,6 +1342,18 @@ static odp_event_t schedule(odp_queue_t *from, uint64_t wait)
 	return ev;
 }
 
+static int schedule_multi_wait(odp_queue_t *from, odp_event_t events[],
+			       int max_num)
+{
+	return schedule_multi(from, ODP_SCHED_WAIT, events, max_num);
+}
+
+static int schedule_multi_no_wait(odp_queue_t *from, odp_event_t events[],
+				  int max_num)
+{
+	return schedule_multi(from, ODP_SCHED_NO_WAIT, events, max_num);
+}
+
 static void schedule_pause(void)
 {
 	sched_ts->pause = true;
@@ -2123,6 +2135,8 @@ const schedule_api_t schedule_scalable_api = {
 	.schedule_wait_time		= schedule_wait_time,
 	.schedule			= schedule,
 	.schedule_multi			= schedule_multi,
+	.schedule_multi_wait            = schedule_multi_wait,
+	.schedule_multi_no_wait         = schedule_multi_no_wait,
 	.schedule_pause			= schedule_pause,
 	.schedule_resume		= schedule_resume,
 	.schedule_release_atomic	= schedule_release_atomic,

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -644,6 +644,18 @@ static odp_event_t schedule(odp_queue_t *from, uint64_t wait)
 	return ODP_EVENT_INVALID;
 }
 
+static int schedule_multi_wait(odp_queue_t *from, odp_event_t events[],
+			       int max_num)
+{
+	return schedule_multi(from, ODP_SCHED_WAIT, events, max_num);
+}
+
+static int schedule_multi_no_wait(odp_queue_t *from, odp_event_t events[],
+				  int max_num)
+{
+	return schedule_multi(from, ODP_SCHED_NO_WAIT, events, max_num);
+}
+
 static void schedule_pause(void)
 {
 	sched_local.pause = 1;
@@ -935,6 +947,8 @@ const schedule_api_t schedule_sp_api = {
 	.schedule_wait_time       = schedule_wait_time,
 	.schedule                 = schedule,
 	.schedule_multi           = schedule_multi,
+	.schedule_multi_wait      = schedule_multi_wait,
+	.schedule_multi_no_wait   = schedule_multi_no_wait,
 	.schedule_pause           = schedule_pause,
 	.schedule_resume          = schedule_resume,
 	.schedule_release_atomic  = schedule_release_atomic,


### PR DESCRIPTION
Optimized versions of schedule_multi call for most common wait values. Schedule call is one of the most used API calls, so saving couple of if-clauses per every call may improve performance on some platforms. L2fwd with basic scheduler didn't show significant improvement.

I'll add test cases into v2, after we have agreed on the API.