### PR TITLE
validation: crypto: capability call should not fail

### DIFF
--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -647,8 +647,11 @@ static int check_alg_support(odp_cipher_alg_t cipher, odp_auth_alg_t auth)
 {
 	odp_crypto_capability_t capability;
 
-	if (odp_crypto_capability(&capability))
+	memset(&capability, 0, sizeof(odp_crypto_capability_t));
+	if (odp_crypto_capability(&capability)) {
+		fprintf(stderr, "odp_crypto_capability() failed\n");
 		return ODP_TEST_INACTIVE;
+	}
 
 	if (suite_context.packet) {
 		if (suite_context.op_mode == ODP_CRYPTO_SYNC &&
@@ -1571,6 +1574,7 @@ static int crypto_init(odp_instance_t *inst)
 	odp_pool_t pool;
 	odp_queue_t out_queue;
 	odp_pool_capability_t pool_capa;
+	odp_crypto_capability_t crypto_capa;
 
 	if (0 != odp_init_global(inst, NULL, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
@@ -1579,6 +1583,11 @@ static int crypto_init(odp_instance_t *inst)
 
 	if (0 != odp_init_local(*inst, ODP_THREAD_CONTROL)) {
 		fprintf(stderr, "error: odp_init_local() failed.\n");
+		return -1;
+	}
+
+	if (odp_crypto_capability(&crypto_capa)) {
+		fprintf(stderr, "error: odp_crypto_capability() failed.\n");
 		return -1;
 	}
 


### PR DESCRIPTION
Capability call should always succeed. It's possible that no
algorithms are supported, but also then the call should succeed.

Signed-off-by: Petri Savolainen <petri.savolainen@linaro.org>