### PR TITLE
[PATCH v2] Classifier shm usage optimization

### DIFF
--- a/platform/linux-generic/odp_classification.c
+++ b/platform/linux-generic/odp_classification.c
@@ -94,6 +94,7 @@ int odp_classification_init_global(void)
 
 	shm = odp_shm_reserve("_odp_cls_global", sizeof(cls_global_t),
 			      ODP_CACHE_LINE_SIZE, 0);
+
 	if (shm == ODP_SHM_INVALID)
 		return -1;
 


### PR DESCRIPTION
Combine three SHM blocks into one. Modified sysinfo example to print out shm blocks, so that it's easy to see how many blocks ODP uses internally. This is how I found out inefficient SHM usage of CLS. 