### PR TITLE
[PATCH v1] linux-gen: run without /proc mounted

### DIFF
--- a/platform/linux-generic/arch/aarch64/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/aarch64/odp_sysinfo_parse.c
@@ -12,7 +12,6 @@
 #include <odp_sysinfo_internal.h>
 #include <odp_debug_internal.h>
 
-#define DUMMY_MAX_MHZ 1000
 #define TMP_STR_LEN   64
 
 static void aarch64_impl_str(char *str, int maxlen, int implementer)

--- a/platform/linux-generic/arch/default/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/default/odp_sysinfo_parse.c
@@ -7,24 +7,10 @@
 #include "config.h"
 
 #include <odp_sysinfo_internal.h>
-#include <odp_debug_internal.h>
-#include <string.h>
-
-#define DUMMY_MAX_MHZ 1400
 
 int cpuinfo_parser(FILE *file ODP_UNUSED, system_info_t *sysinfo)
 {
-	int i;
-
-	ODP_DBG("Warning: use dummy values for freq and model string\n");
-	for (i = 0; i < CONFIG_NUM_CPU; i++) {
-		ODP_PRINT("WARN: cpu[%i] uses dummy max frequency %u MHz\n",
-			  i, DUMMY_MAX_MHZ);
-		sysinfo->cpu_hz_max[i] = DUMMY_MAX_MHZ * 1000000;
-		strcpy(sysinfo->model_str[i], "UNKNOWN");
-	}
-
-	return 0;
+	return _odp_dummy_cpuinfo(sysinfo);
 }
 
 void sys_info_print_arch(void)

--- a/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
+++ b/platform/linux-generic/arch/x86/odp_sysinfo_parse.c
@@ -83,6 +83,8 @@ uint64_t odp_cpu_arch_hz_current(int id)
 	double mhz = 0.0;
 
 	file = fopen("/proc/cpuinfo", "rt");
+	if (!file)
+		return 0;
 
 	/* find the correct processor instance */
 	while (fgets(str, sizeof(str), file) != NULL) {

--- a/platform/linux-generic/include/odp_sysinfo_internal.h
+++ b/platform/linux-generic/include/odp_sysinfo_internal.h
@@ -12,11 +12,30 @@ extern "C" {
 #endif
 
 #include <odp_global_data.h>
+#include <odp_debug_internal.h>
+#include <string.h>
+
+#define DUMMY_MAX_MHZ 1400
 
 int cpuinfo_parser(FILE *file, system_info_t *sysinfo);
 uint64_t odp_cpu_hz_current(int id);
 uint64_t odp_cpu_arch_hz_current(int id);
 void sys_info_print_arch(void);
+
+static inline int _odp_dummy_cpuinfo(system_info_t *sysinfo)
+{
+	int i;
+
+	ODP_DBG("Warning: use dummy values for freq and model string\n");
+	for (i = 0; i < CONFIG_NUM_CPU; i++) {
+		ODP_PRINT("WARN: cpu[%i] uses dummy max frequency %u MHz\n",
+			  i, DUMMY_MAX_MHZ);
+		sysinfo->cpu_hz_max[i] = DUMMY_MAX_MHZ * 1000000;
+		strcpy(sysinfo->model_str[i], "UNKNOWN");
+	}
+
+	return 0;
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Some systems may have /proc interface not mounted, let
odp linux generic run there with dummy values.
https://bugs.linaro.org/show_bug.cgi?id=3989

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>