### PR TITLE
[PATCH v4] linux-gen: timer: add inline timer config options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,6 +155,19 @@ jobs:
                               -e ODPH_PROC_MODE=1
                               ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/check.sh
                 - stage: test
+                  env: TEST=inline_timer
+                  install:
+                          - true
+                  compiler: gcc
+                  script:
+                          - if [ -z "${DOCKER_NAMESPACE}" ] ; then export DOCKER_NAMESPACE="opendataplane"; fi
+                          - docker run --privileged -i -t
+                              -v `pwd`:/odp --shm-size 8g
+                              -e CC="${CC}"
+                              -e CONF=""
+                              -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/inline-timer.conf
+                              ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/check_inline_timer.sh
+                - stage: test
                   env: TEST=distcheck
                   compiler: gcc
                   script:

--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -140,4 +140,11 @@ timer: {
 	#
 	# Set to 1 to enable
 	inline = 0
+
+	# Inline timer poll interval
+	#
+	# When set to 1 inline timers are polled during every schedule round.
+	# Increasing the value reduces timer processing overhead while
+	# decreasing accuracy. Ignored when inline timer is not enabled.
+	inline_poll_interval = 10
 }

--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.4"
+config_file_version = "0.1.5"
 
 # Shared memory options
 shm: {
@@ -128,4 +128,16 @@ sched_basic: {
 		worker  = 1
 		control = 1
 	}
+}
+
+timer: {
+	# Use inline timer implementation
+	#
+	# By default, timer processing is done in background threads (thread per
+	# timer pool). With inline implementation timers are processed on worker
+	# cores instead. When using inline timers the application has to call
+	# odp_schedule() or odp_queue_deq() to actuate timer processing.
+	#
+	# Set to 1 to enable
+	inline = 0
 }

--- a/platform/linux-generic/include/odp_timer_internal.h
+++ b/platform/linux-generic/include/odp_timer_internal.h
@@ -36,12 +36,14 @@ typedef struct {
 	odp_timer_t timer;
 } odp_timeout_hdr_t;
 
-unsigned _timer_run(void);
+/* A larger decrement value should be used after receiving events compared to
+ * an 'empty' call. */
+unsigned int _timer_run(int dec);
 
 /* Static inline wrapper to minimize modification of schedulers. */
-static inline unsigned timer_run(void)
+static inline unsigned int timer_run(int dec)
 {
-	return odp_global_rw->inline_timers ? _timer_run() : 0;
+	return odp_global_rw->inline_timers ? _timer_run(dec) : 0;
 }
 
 #endif

--- a/platform/linux-generic/include/odp_timer_internal.h
+++ b/platform/linux-generic/include/odp_timer_internal.h
@@ -21,9 +21,6 @@
 #include <odp/api/timer.h>
 #include <odp_global_data.h>
 
-/* Minimum number of scheduling rounds between checking timer pools. */
-#define CONFIG_TIMER_RUN_RATELIMIT_ROUNDS 1
-
 /**
  * Internal Timeout header
  */

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -267,6 +267,7 @@ int odp_init_global(odp_instance_t *instance,
 	odp_global_ro.log_fn = odp_override_log;
 	odp_global_ro.abort_fn = odp_override_abort;
 
+	odp_init_param_init(&odp_global_ro.init_param);
 	if (params != NULL) {
 		odp_global_ro.init_param  = *params;
 

--- a/platform/linux-generic/odp_queue_scalable.c
+++ b/platform/linux-generic/odp_queue_scalable.c
@@ -837,30 +837,32 @@ static odp_buffer_hdr_t *_queue_deq(odp_queue_t handle)
 static int queue_deq_multi(odp_queue_t handle, odp_event_t ev[], int num)
 {
 	queue_entry_t *queue;
+	int ret;
 
 	if (num > QUEUE_MULTI_MAX)
 		num = QUEUE_MULTI_MAX;
 
 	queue = qentry_from_ext(handle);
 
+	ret = queue->s.dequeue_multi(handle, (odp_buffer_hdr_t **)ev, num);
+
 	if (odp_global_rw->inline_timers &&
 	    odp_atomic_load_u64(&queue->s.num_timers))
-		timer_run();
+		timer_run(ret ? 2 : 1);
 
-	return queue->s.dequeue_multi(handle, (odp_buffer_hdr_t **)ev, num);
+	return ret;
 }
 
 static odp_event_t queue_deq(odp_queue_t handle)
 {
-	queue_entry_t *queue;
-
-	queue = qentry_from_ext(handle);
+	queue_entry_t *queue = qentry_from_ext(handle);
+	odp_event_t ev = (odp_event_t)queue->s.dequeue(handle);
 
 	if (odp_global_rw->inline_timers &&
 	    odp_atomic_load_u64(&queue->s.num_timers))
-		timer_run();
+		timer_run(ev != ODP_EVENT_INVALID ? 2 : 1);
 
-	return (odp_event_t)queue->s.dequeue(handle);
+	return ev;
 }
 
 static void queue_param_init(odp_queue_param_t *params)

--- a/platform/linux-generic/odp_schedule_basic.c
+++ b/platform/linux-generic/odp_schedule_basic.c
@@ -1152,12 +1152,13 @@ static inline int schedule_loop(odp_queue_t *out_queue, uint64_t wait,
 	int ret;
 
 	while (1) {
-		timer_run();
 
 		ret = do_schedule(out_queue, out_ev, max_num);
-
-		if (ret)
+		if (ret) {
+			timer_run(2);
 			break;
+		}
+		timer_run(1);
 
 		if (wait == ODP_SCHED_WAIT)
 			continue;

--- a/platform/linux-generic/odp_schedule_scalable.c
+++ b/platform/linux-generic/odp_schedule_scalable.c
@@ -890,7 +890,7 @@ static int _schedule(odp_queue_t *from, odp_event_t ev[], int num_evts)
 	ts = sched_ts;
 	atomq = ts->atomq;
 
-	timer_run();
+	timer_run(1);
 
 	/* Once an atomic queue has been scheduled to a thread, it will stay
 	 * on that thread until empty or 'rotated' by WRR

--- a/platform/linux-generic/odp_schedule_sp.c
+++ b/platform/linux-generic/odp_schedule_sp.c
@@ -552,8 +552,6 @@ static int schedule_multi(odp_queue_t *from, uint64_t wait,
 		uint32_t qi;
 		int num;
 
-		timer_run();
-
 		cmd = sched_cmd();
 
 		if (cmd && cmd->s.type == CMD_PKTIO) {
@@ -593,6 +591,7 @@ static int schedule_multi(odp_queue_t *from, uint64_t wait,
 		}
 
 		if (cmd == NULL) {
+			timer_run(1);
 			/* All priority queues are empty */
 			if (wait == ODP_SCHED_NO_WAIT)
 				return 0;
@@ -617,12 +616,15 @@ static int schedule_multi(odp_queue_t *from, uint64_t wait,
 		num = sched_queue_deq(qi, events, 1, 1);
 
 		if (num <= 0) {
+			timer_run(1);
 			/* Destroyed or empty queue. Remove empty queue from
 			 * scheduling. A dequeue operation to on an already
 			 * empty queue moves it to NOTSCHED state and
 			 * sched_queue() will be called on next enqueue. */
 			continue;
 		}
+
+		timer_run(2);
 
 		sched_local.cmd = cmd;
 

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -869,10 +869,10 @@ static unsigned process_timer_pools(void)
 	return nexp;
 }
 
-unsigned _timer_run(void)
+unsigned int _timer_run(int dec)
 {
 	static __thread odp_time_t last_timer_run;
-	static __thread unsigned timer_run_cnt = 1;
+	static __thread int timer_run_cnt = 1;
 	odp_time_t now;
 
 	if (timer_global->num_timer_pools == 0)
@@ -881,7 +881,8 @@ unsigned _timer_run(void)
 	/* Rate limit how often this thread checks the timer pools. */
 
 	if (timer_global->inline_poll_interval > 1) {
-		if (--timer_run_cnt)
+		timer_run_cnt -= dec;
+		if (timer_run_cnt > 0)
 			return 0;
 		timer_run_cnt = timer_global->inline_poll_interval;
 	}

--- a/platform/linux-generic/odp_timer.c
+++ b/platform/linux-generic/odp_timer.c
@@ -55,6 +55,7 @@
 #include <odp/api/time.h>
 #include <odp/api/plat/time_inlines.h>
 #include <odp/api/timer.h>
+#include <odp_libconfig_internal.h>
 #include <odp_queue_if.h>
 #include <odp_timer_internal.h>
 #include <odp/api/plat/queue_inlines.h>
@@ -217,7 +218,7 @@ typedef struct timer_global_t {
 	/* Multiple locks per cache line! */
 	_odp_atomic_flag_t ODP_ALIGNED_CACHE locks[NUM_LOCKS];
 #endif
-
+	odp_bool_t use_inline_timers;
 } timer_global_t;
 
 static timer_global_t *timer_global;
@@ -339,22 +340,8 @@ static odp_timer_pool_t timer_pool_new(const char *name,
 	odp_ticketlock_lock(&timer_global->lock);
 	timer_global->timer_pool[tp_idx] = tp;
 
-	if (timer_global->num_timer_pools == 1) {
-		odp_bool_t inline_tim;
-
-		/*
-		 * Whether to run timer pool processing 'inline' (on worker
-		 * cores) or in background threads (thread-per-timerpool).
-		 *
-		 * If the application will use scheduler this flag is set to
-		 * true, otherwise false. This application conveys this
-		 * information via the 'not_used' bits in odp_init_t which are
-		 * passed to odp_global_init().
-		 */
-		inline_tim = !odp_global_ro.init_param.not_used.feat.schedule;
-
-		odp_global_rw->inline_timers = inline_tim;
-	}
+	if (timer_global->num_timer_pools == 1)
+		odp_global_rw->inline_timers = timer_global->use_inline_timers;
 
 	odp_ticketlock_unlock(&timer_global->lock);
 	if (!odp_global_rw->inline_timers) {
@@ -1333,7 +1320,8 @@ void odp_timeout_free(odp_timeout_t tmo)
 int odp_timer_init_global(const odp_init_t *params)
 {
 	odp_shm_t shm;
-	odp_bool_t inline_timers = false;
+	const char *conf_str;
+	int val = 0;
 
 	shm = odp_shm_reserve("_odp_timer", sizeof(timer_global_t),
 			      ODP_CACHE_LINE_SIZE, 0);
@@ -1358,16 +1346,21 @@ int odp_timer_init_global(const odp_init_t *params)
 #else
 	ODP_DBG("Using lock-less timer implementation\n");
 #endif
+	conf_str =  "timer.inline";
+	if (!_odp_libconfig_lookup_int(conf_str, &val)) {
+		ODP_ERR("Config option '%s' not found.\n", conf_str);
+		odp_shm_free(shm);
+		return -1;
+	}
+	timer_global->use_inline_timers = val;
 
-	if (params)
-		inline_timers =
-			!params->not_used.feat.schedule &&
-			!params->not_used.feat.timer;
+	if (params && params->not_used.feat.timer)
+		timer_global->use_inline_timers = false;
 
 	timer_global->time_per_ratelimit_period =
 		odp_time_global_from_ns(timer_global->min_res_ns / 2);
 
-	if (!inline_timers) {
+	if (!timer_global->use_inline_timers) {
 		timer_res_init();
 		block_sigalarm();
 	}

--- a/platform/linux-generic/test/inline-timer.conf
+++ b/platform/linux-generic/test/inline-timer.conf
@@ -1,0 +1,8 @@
+# Mandatory fields
+odp_implementation = "linux-generic"
+config_file_version = "0.1.5"
+
+timer: {
+	# Enable inline timer implementation
+	inline = 1
+}

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.4"
+config_file_version = "0.1.5"
 
 # Shared memory options
 shm: {

--- a/scripts/ci/check_inline_timer.sh
+++ b/scripts/ci/check_inline_timer.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+"`dirname "$0"`"/build_x86_64.sh
+
+cd "$(dirname "$0")"/../..
+
+echo 1000 | tee /proc/sys/vm/nr_hugepages
+mkdir -p /mnt/huge
+mount -t hugetlbfs nodev /mnt/huge
+
+ODP_SCHEDULER=basic    ./test/validation/api/timer/timer_main
+ODP_SCHEDULER=sp       ./test/validation/api/timer/timer_main
+ODP_SCHEDULER=scalable ./test/validation/api/timer/timer_main
+
+umount /mnt/huge


### PR DESCRIPTION
V2:
- Free shm block on failure (Bill)

V3:
- Fixed timer_pool_new() not initializing allocated shm memory

V4:
- Always init odp_global_ro.init_param