### PR TITLE
[PATCH v2] linux-gen: ishm: add config option for selecting huge page usage limit

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.4"
+config_file_version = "0.1.5"
 
 # Shared memory options
 shm: {
@@ -33,6 +33,11 @@ shm: {
 	# When using process mode threads, this value should be set to 0
 	# because the current implementation won't work properly otherwise.
 	num_cached_hp = 0
+
+	# Huge page usage limit in kilobytes. Memory reservations larger than
+	# this value are done using huge pages (if available). Smaller
+	# reservations are done using normal pages to conserve memory.
+	huge_page_limit_kb = 64
 
 	# Allocate internal shared memory using a single virtual address space.
 	# Set to 1 to enable using process mode.

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,6 +1,6 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.4"
+config_file_version = "0.1.5"
 
 # Shared memory options
 shm: {


### PR DESCRIPTION
Add configuration option for selecting huge page usage limit in kilobytes.
Memory reservations larger than this value are done using huge pages (if
available), whereas smaller reservations are done using normal pages to
conserve memory. The default value is still 64 kilobytes.

V2:
- Rebase