### PR TITLE
[PATCH API-NEXT v3] api: init: add new mem_model member to odp_init_t

### DIFF
--- a/config/odp-linux-generic.conf
+++ b/config/odp-linux-generic.conf
@@ -16,7 +16,7 @@
 
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.3"
+config_file_version = "0.1.4"
 
 # Shared memory options
 shm: {
@@ -33,10 +33,6 @@ shm: {
 	# When using process mode threads, this value should be set to 0
 	# because the current implementation won't work properly otherwise.
 	num_cached_hp = 0
-
-	# Allocate internal shared memory using a single virtual address space.
-	# Set to 1 to enable using process mode.
-	single_va = 0
 }
 
 # Pool options

--- a/example/classifier/odp_classifier.c
+++ b/example/classifier/odp_classifier.c
@@ -468,6 +468,7 @@ static void configure_cos(odp_cos_t default_cos, appl_args_t *args)
  */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	odp_pool_t pool;
 	int num_workers;
@@ -481,10 +482,21 @@ int main(int argc, char *argv[])
 	odp_shm_t shm;
 	int ret;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		EXAMPLE_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		EXAMPLE_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}
@@ -801,9 +813,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	};
 
 	static const char *shortopts = "+c:t:i:p:m:t:h";
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	appl_args->cpu_count = 1; /* Use one worker by default */
 

--- a/example/generator/odp_generator.c
+++ b/example/generator/odp_generator.c
@@ -1090,6 +1090,7 @@ static void print_global_stats(int num_workers)
  */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	odp_pool_t pool;
 	int num_workers;
@@ -1101,10 +1102,21 @@ int main(int argc, char *argv[])
 	odp_pool_param_t params;
 	interface_t *ifs;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		EXAMPLE_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		EXAMPLE_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}
@@ -1423,9 +1435,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 
 	static const char *shortopts = "+I:a:b:s:d:p:i:m:n:t:w:c:x:he:j:f:k"
 					":yr:z";
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	appl_args->mode = -1; /* Invalid, must be changed by parsing */
 	appl_args->number = -1;

--- a/example/ipsec/odp_ipsec.c
+++ b/example/ipsec/odp_ipsec.c
@@ -1186,6 +1186,7 @@ int pktio_thread(void *arg EXAMPLE_UNUSED)
 int
 main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	int num_workers;
 	int i;
@@ -1195,6 +1196,7 @@ main(int argc, char *argv[])
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 	odp_pool_param_t params;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 
 	/* create by default scheduled queues */
@@ -1207,8 +1209,18 @@ main(int argc, char *argv[])
 		schedule = polled_odp_schedule_cb;
 	}
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		EXAMPLE_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		EXAMPLE_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}
@@ -1401,9 +1413,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	};
 
 	static const char *shortopts = "+c:i:m:h:r:p:a:e:t:s:";
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	printf("\nParsing command line options\n");
 

--- a/example/ipsec_api/odp_ipsec.c
+++ b/example/ipsec_api/odp_ipsec.c
@@ -885,6 +885,7 @@ int pktio_thread(void *arg EXAMPLE_UNUSED)
 int
 main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	int num_workers;
 	int i;
@@ -894,6 +895,7 @@ main(int argc, char *argv[])
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 	odp_pool_param_t params;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 
 	/* create by default scheduled queues */
@@ -906,8 +908,18 @@ main(int argc, char *argv[])
 		schedule = polled_odp_schedule_cb;
 	}
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		EXAMPLE_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		EXAMPLE_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}
@@ -1102,9 +1114,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	};
 
 	static const char *shortopts = "+c:i:h:lm:r:p:a:e:t:s:";
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	appl_args->cpu_count = 1; /* use one worker by default */
 

--- a/example/l2fwd_simple/odp_l2fwd_simple.c
+++ b/example/l2fwd_simple/odp_l2fwd_simple.c
@@ -139,17 +139,29 @@ static int run_worker(void *arg ODP_UNUSED)
 
 int main(int argc, char **argv)
 {
+	odph_helper_options_t helper_options;
 	odp_pool_t pool;
 	odp_pool_param_t params;
 	odp_cpumask_t cpumask;
 	odph_odpthread_t thd[MAX_WORKERS];
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 	odph_ethaddr_t correct_src;
 	uint32_t mtu1, mtu2;
 	odp_shm_t shm;
 
-	if (odp_init_global(&instance, NULL, NULL)) {
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		printf("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		printf("Error: ODP global init failed.\n");
 		exit(1);
 	}
@@ -170,9 +182,6 @@ int main(int argc, char **argv)
 
 	memset(global, 0, sizeof(global_data_t));
 	global->shm = shm;
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	if (argc > 7 ||
 	    odph_eth_addr_parse(&global->dst, argv[3]) != 0 ||

--- a/example/packet/odp_pktio.c
+++ b/example/packet/odp_pktio.c
@@ -343,6 +343,7 @@ static int pktio_ifburst_thread(void *arg)
  */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	odp_pool_t pool;
 	int num_workers;
@@ -352,11 +353,22 @@ int main(int argc, char *argv[])
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 	odp_pool_param_t params;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 	odp_shm_t shm;
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		EXAMPLE_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		EXAMPLE_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}
@@ -581,9 +593,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 	};
 
 	static const char *shortopts = "+c:i:+m:t:h";
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	appl_args->cpu_count = 1; /* use one worker by default */
 	appl_args->mode = APPL_MODE_PKT_SCHED;

--- a/example/switch/odp_switch.c
+++ b/example/switch/odp_switch.c
@@ -758,9 +758,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 
 	static const char *shortopts = "+c:+t:+a:i:h";
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	appl_args->cpu_count = 1; /* use one worker by default */
 	appl_args->time = 0; /* loop forever if time to run is 0 */
 	appl_args->accuracy = 10; /* get and print pps stats second */
@@ -870,6 +867,7 @@ static void gbl_args_init(args_t *args)
 
 int main(int argc, char **argv)
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	int i, j;
 	int cpu;
@@ -882,10 +880,21 @@ int main(int argc, char **argv)
 	stats_t (*stats)[MAX_PKTIOS];
 	int if_count;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		printf("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		printf("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}

--- a/example/time/time_global_test.c
+++ b/example/time/time_global_test.c
@@ -254,16 +254,25 @@ int main(int argc, char *argv[])
 	odp_shm_t shm_glbls = ODP_SHM_INVALID;
 	odp_shm_t shm_log = ODP_SHM_INVALID;
 	int log_size, log_enries_num;
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	printf("\nODP global time test starts\n");
 
-	if (odp_init_global(&instance, NULL, NULL)) {
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		EXAMPLE_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		err = 1;
 		EXAMPLE_ERR("ODP global init failed.\n");
 		goto end;

--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -88,6 +88,11 @@ typedef struct {
 	};
 } odph_odpthread_t;
 
+/** Linux helper options */
+typedef struct {
+	odp_mem_model_t mem_model; /**< Process or thread */
+} odph_helper_options_t;
+
 /**
  * Creates and launches odpthreads (as linux threads or processes)
  *
@@ -152,6 +157,18 @@ int odph_odpthread_getaffinity(void);
  *         the number of removed helper options.
  */
 int odph_parse_options(int argc, char *argv[]);
+
+/**
+ * Get linux helper options
+ *
+ * Return used ODP helper options. odph_parse_options() must be called before
+ * using this function.
+ *
+ * @param[out] options  ODP helper options
+ *
+ * @return 0 on success, -1 on failure
+ */
+int odph_options(odph_helper_options_t *options);
 
 /**
  * @}

--- a/helper/include/odp/helper/threads.h
+++ b/helper/include/odp/helper/threads.h
@@ -54,13 +54,6 @@ typedef struct {
 	int   status;   /**< Process state change status */
 } odph_linux_process_t;
 
-/** odpthread linux type: whether an ODP thread is a linux thread or process */
-typedef enum odph_odpthread_linuxtype_e {
-	ODPTHREAD_NOT_STARTED = 0,
-	ODPTHREAD_PROCESS,
-	ODPTHREAD_PTHREAD
-} odph_odpthread_linuxtype_t;
-
 /** odpthread parameters for odp threads (pthreads and processes) */
 typedef struct {
 	int (*start)(void *);       /**< Thread entry point function */
@@ -71,7 +64,7 @@ typedef struct {
 
 /** The odpthread starting arguments, used both in process or thread mode */
 typedef struct {
-	odph_odpthread_linuxtype_t linuxtype; /**< process or pthread */
+	odp_mem_model_t mem_model;          /**< process or thread */
 	odph_odpthread_params_t thr_params; /**< odpthread start parameters */
 } odph_odpthread_start_args_t;
 

--- a/helper/test/odpthreads.c
+++ b/helper/test/odpthreads.c
@@ -64,18 +64,27 @@ static int worker_fn(void *arg ODPH_UNUSED)
 /* Create additional dataplane opdthreads */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_params_t thr_params;
 	odph_odpthread_t thread_tbl[NUMBER_WORKERS];
 	odp_cpumask_t cpu_mask;
+	odp_init_t init_param;
 	int num_workers;
 	int cpu, affinity;
 	int ret;
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
 	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		ODPH_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
 
-	if (odp_init_global(&odp_instance, NULL, NULL)) {
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (odp_init_global(&odp_instance, &init_param, NULL)) {
 		ODPH_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}

--- a/include/odp/api/spec/init.h
+++ b/include/odp/api/spec/init.h
@@ -107,6 +107,32 @@ typedef int (*odp_log_func_t)(odp_log_level_t level, const char *fmt, ...);
 typedef void (*odp_abort_func_t)(void) ODP_NORETURN;
 
 /**
+ * Application memory model
+ */
+typedef enum {
+	/** Thread memory model: by default all memory is shareable between
+	 *  threads.
+	 *
+	 *  Within a single ODP instance all ODP handles and pointers to ODP
+	 *  allocated data may be shared amongst threads independent of data
+	 *  allocation time (e.g. before or after thread creation). */
+	ODP_MEM_MODEL_THREAD = 0,
+
+	/** Process memory model: by default all memory is not shareable between
+	 *  processes.
+	 *
+	 *  Within a single ODP instance all ODP handles and pointers to ODP
+	 *  allocated data (excluding non-single VA SHM blocks) may be shared
+	 *  amongst processes independent of data allocation time (e.g. before
+	 *  or after fork).
+	 *
+	 * @see ODP_SHM_SINGLE_VA
+	 */
+	ODP_MEM_MODEL_PROCESS
+
+} odp_mem_model_t;
+
+/**
  * Global initialization parameters
  *
  * These parameters may be used at global initialization time to configure and
@@ -171,6 +197,12 @@ typedef struct odp_init_t {
 	 * that a feature will not be used and it is used anyway.
 	 */
 	odp_feature_t not_used;
+
+	/** Application memory model. The main application thread has to call
+	 *  odp_init_global() and odp_init_local() before creating threads that
+	 *  share ODP data. The default value is ODP_MEM_MODEL_THREAD.
+	 */
+	odp_mem_model_t mem_model;
 
 	/** Shared memory parameters */
 	struct {

--- a/platform/linux-generic/odp_init.c
+++ b/platform/linux-generic/odp_init.c
@@ -274,6 +274,8 @@ int odp_init_global(odp_instance_t *instance,
 			odp_global_ro.log_fn = params->log_fn;
 		if (params->abort_fn != NULL)
 			odp_global_ro.abort_fn = params->abort_fn;
+		if (params->mem_model == ODP_MEM_MODEL_PROCESS)
+			odp_global_ro.shm_single_va = 1;
 	}
 
 	if (_odp_libconfig_init_global()) {

--- a/platform/linux-generic/odp_ishm.c
+++ b/platform/linux-generic/odp_ishm.c
@@ -301,14 +301,7 @@ static void hp_init(void)
 	char filename[ISHM_FILENAME_MAXLEN];
 	char dir[ISHM_FILENAME_MAXLEN];
 	int count;
-	int single_va = 0;
 	void *addr;
-
-	if (_odp_libconfig_lookup_ext_int("shm", NULL, "single_va",
-					  &single_va)) {
-		odp_global_ro.shm_single_va = single_va;
-		ODP_DBG("Shm single VA: %d\n", odp_global_ro.shm_single_va);
-	}
 
 	if (!_odp_libconfig_lookup_ext_int("shm", NULL, "num_cached_hp",
 					   &count)) {

--- a/platform/linux-generic/test/mmap_vlan_ins/mmap_vlan_ins.c
+++ b/platform/linux-generic/test/mmap_vlan_ins/mmap_vlan_ins.c
@@ -135,14 +135,20 @@ int main(int argc, char **argv)
 	odp_pool_t pool;
 	odp_pool_param_t params;
 	odp_cpumask_t cpumask;
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thd[MAX_WORKERS];
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 	odp_shm_t shm;
 	int ret;
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
 	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		printf("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
 
 	if (argc < 3) {
 		printf("Too few arguments (%i).\n"
@@ -150,7 +156,10 @@ int main(int argc, char **argv)
 		exit(0);
 	}
 
-	if (odp_init_global(&instance, NULL, NULL)) {
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		printf("Error: ODP global init failed.\n");
 		exit(1);
 	}

--- a/platform/linux-generic/test/process-mode.conf
+++ b/platform/linux-generic/test/process-mode.conf
@@ -1,10 +1,7 @@
 # Mandatory fields
 odp_implementation = "linux-generic"
-config_file_version = "0.1.3"
+config_file_version = "0.1.4"
 
 # Shared memory options
 shm: {
-	# Override default option and allocate internal shms using single
-	# virtual address space.
-	single_va = 1
 }

--- a/test/common/odp_cunit_common.c
+++ b/test/common/odp_cunit_common.c
@@ -79,7 +79,18 @@ int odp_cunit_thread_exit(pthrd_arg *arg)
 
 static int tests_global_init(odp_instance_t *inst)
 {
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
+
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/performance/odp_bench_packet.c
+++ b/test/performance/odp_bench_packet.c
@@ -1315,9 +1315,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 
 	static const char *shortopts =  "b:i:h";
 
-	/* Let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	appl_args->bench_idx = 0; /* Run all benchmarks */
 	appl_args->burst_size = TEST_DEF_BURST;
 
@@ -1511,6 +1508,7 @@ bench_info_t test_suite[] = {
  */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t worker_thread;
 	int cpu;
 	odp_shm_t shm;
@@ -1519,11 +1517,22 @@ int main(int argc, char *argv[])
 	odp_pool_capability_t capa;
 	odp_pool_param_t params;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	uint32_t pkt_num;
 	uint8_t ret;
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		LOG_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		LOG_ERR("Error: ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}

--- a/test/performance/odp_cpu_bench.c
+++ b/test/performance/odp_cpu_bench.c
@@ -382,9 +382,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 
 	static const char *shortopts = "+a:+c:+l:+t:h";
 
-	/* Let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	appl_args->accuracy = 1; /* Get and print pps stats second */
 	appl_args->cpu_count = 1;
 	appl_args->lookup_tbl_size = DEF_LOOKUP_TBL_SIZE;
@@ -524,6 +521,7 @@ static void gbl_args_init(args_t *args)
 int main(int argc, char *argv[])
 {
 	stats_t *stats[MAX_WORKERS];
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	odp_cpumask_t cpumask;
 	odp_pool_capability_t pool_capa;
@@ -546,6 +544,13 @@ int main(int argc, char *argv[])
 	int cpu;
 	int ret = 0;
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		LOG_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
 	odp_init_param_init(&init);
 
 	/* List features not to be used (may optimize performance) */
@@ -554,6 +559,8 @@ int main(int argc, char *argv[])
 	init.not_used.feat.ipsec  = 1;
 	init.not_used.feat.timer  = 1;
 	init.not_used.feat.tm     = 1;
+
+	init.mem_model = helper_options.mem_model;
 
 	/* Signal handler has to be registered before global init in case ODP
 	 * implementation creates internal threads/processes. */

--- a/test/performance/odp_crypto.c
+++ b/test/performance/odp_crypto.c
@@ -1033,12 +1033,24 @@ int main(int argc, char *argv[])
 	odp_cpumask_t cpumask;
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 	int num_workers = 1;
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thr[num_workers];
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odp_pool_capability_t pool_capa;
 	odp_crypto_capability_t crypto_capa;
 	uint32_t max_seg_len;
 	unsigned i;
+
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		app_err("Reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
 
 	memset(&cargs, 0, sizeof(cargs));
 
@@ -1046,7 +1058,7 @@ int main(int argc, char *argv[])
 	parse_args(argc, argv, &cargs);
 
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		app_err("ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}
@@ -1195,9 +1207,6 @@ static void parse_args(int argc, char *argv[], crypto_args_t *cargs)
 	};
 
 	static const char *shortopts = "+a:c:df:hi:m:nl:spr";
-
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
 
 	cargs->in_place = 0;
 	cargs->in_flight = 1;

--- a/test/performance/odp_ipsec.c
+++ b/test/performance/odp_ipsec.c
@@ -928,9 +928,6 @@ static void parse_args(int argc, char *argv[], ipsec_args_t *cargs)
 
 	static const char *shortopts = "+a:c:df:hi:m:nl:sptu";
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	cargs->in_place = 0;
 	cargs->in_flight = 1;
 	cargs->debug_packets = 0;
@@ -1012,12 +1009,24 @@ int main(int argc, char *argv[])
 	odp_cpumask_t cpumask;
 	char cpumaskstr[ODP_CPUMASK_STR_SIZE];
 	int num_workers = 1;
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thr[num_workers];
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odp_pool_capability_t capa;
 	odp_ipsec_config_t config;
 	uint32_t max_seg_len;
 	unsigned int i;
+
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		app_err("Reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
 
 	memset(&cargs, 0, sizeof(cargs));
 
@@ -1025,7 +1034,7 @@ int main(int argc, char *argv[])
 	parse_args(argc, argv, &cargs);
 
 	/* Init ODP before calling anything else */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		app_err("ODP global init failed.\n");
 		exit(EXIT_FAILURE);
 	}

--- a/test/performance/odp_l2fwd.c
+++ b/test/performance/odp_l2fwd.c
@@ -1184,9 +1184,6 @@ static void parse_args(int argc, char *argv[], appl_args_t *appl_args)
 
 	static const char *shortopts =  "+c:+t:+a:i:m:o:r:d:s:e:k:g:vh";
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	appl_args->time = 0; /* loop forever if time to run is 0 */
 	appl_args->accuracy = 1; /* get and print pps stats second */
 	appl_args->cpu_count = 1; /* use one worker by default */
@@ -1428,6 +1425,7 @@ static void create_groups(int num, odp_schedule_group_t *group)
  */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread_tbl[MAX_WORKERS];
 	odp_pool_t pool;
 	int i;
@@ -1449,6 +1447,13 @@ int main(int argc, char *argv[])
 	odp_pool_capability_t pool_capa;
 	uint32_t pkt_len, pkt_num;
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		LOG_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
 	odp_init_param_init(&init);
 
 	/* List features not to be used (may optimize performance) */
@@ -1457,6 +1462,8 @@ int main(int argc, char *argv[])
 	init.not_used.feat.ipsec  = 1;
 	init.not_used.feat.timer  = 1;
 	init.not_used.feat.tm     = 1;
+
+	init.mem_model = helper_options.mem_model;
 
 	/* Signal handler has to be registered before global init in case ODP
 	 * implementation creates internal threads/processes. */

--- a/test/performance/odp_pktio_perf.c
+++ b/test/performance/odp_pktio_perf.c
@@ -957,9 +957,6 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 
 	static const char *shortopts = "+c:t:b:pR:l:r:i:d:vh";
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	args->cpu_count      = 2;
 	args->num_tx_workers = 0; /* defaults to cpu_count+1/2 */
 	args->tx_batch_len   = BATCH_LEN_MAX;
@@ -1040,9 +1037,21 @@ int main(int argc, char **argv)
 	int ret;
 	odp_shm_t shm;
 	int max_thrs;
+	odph_helper_options_t helper_options;
 	odp_instance_t instance;
+	odp_init_t init_param;
 
-	if (odp_init_global(&instance, NULL, NULL) != 0)
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		LOG_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (odp_init_global(&instance, &init_param, NULL) != 0)
 		LOG_ABORT("Failed global init.\n");
 
 	if (odp_init_local(instance, ODP_THREAD_CONTROL) != 0)

--- a/test/performance/odp_sched_latency.c
+++ b/test/performance/odp_sched_latency.c
@@ -549,9 +549,6 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 
 	static const char *shortopts = "+c:s:l:t:m:n:o:p:rh";
 
-	/* Let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	args->cpu_count = 1;
 	args->sync_type = ODP_SCHED_SYNC_PARALLEL;
 	args->sample_per_prio = SAMPLE_EVENT_PER_PRIO;
@@ -637,6 +634,8 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 int main(int argc, char *argv[])
 {
 	odp_instance_t instance;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 	odph_odpthread_t *thread_tbl;
 	odph_odpthread_params_t thr_params;
 	odp_cpumask_t cpumask;
@@ -654,11 +653,21 @@ int main(int argc, char *argv[])
 
 	printf("\nODP scheduling latency benchmark starts\n\n");
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		LOG_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
 	memset(&args, 0, sizeof(args));
 	parse_args(argc, argv, &args);
 
 	/* ODP global init */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		LOG_ERR("ODP global init failed.\n");
 		return -1;
 	}

--- a/test/performance/odp_sched_pktio.c
+++ b/test/performance/odp_sched_pktio.c
@@ -578,9 +578,6 @@ static int parse_options(int argc, char *argv[], test_options_t *test_options)
 	test_options->burst_size = 32;
 	test_options->pipe_queue_size = 256;
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	while (1) {
 		opt = getopt_long(argc, argv, shortopts, longopts, &long_index);
 
@@ -1431,9 +1428,17 @@ int main(int argc, char *argv[])
 	odp_init_t init;
 	odp_shm_t shm;
 	odp_time_t t1, t2;
+	odph_helper_options_t helper_options;
 	odph_odpthread_t thread[MAX_WORKERS];
 	test_options_t test_options;
 	int ret = 0;
+
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		printf("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
 
 	signal(SIGINT, sig_handler);
 
@@ -1450,6 +1455,8 @@ int main(int argc, char *argv[])
 
 	if (test_options.timeout_us)
 		init.not_used.feat.timer = 0;
+
+	init.mem_model = helper_options.mem_model;
 
 	/* Init ODP before calling anything else */
 	if (odp_init_global(&instance, &init, NULL)) {

--- a/test/performance/odp_scheduling.c
+++ b/test/performance/odp_scheduling.c
@@ -762,9 +762,6 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
 
 	static const char *shortopts = "+c:fh";
 
-	/* let helper collect its own arguments (e.g. --odph_proc) */
-	argc = odph_parse_options(argc, argv);
-
 	args->cpu_count = 1; /* use one worker by default */
 
 	while (1) {
@@ -798,6 +795,7 @@ static void parse_args(int argc, char *argv[], test_args_t *args)
  */
 int main(int argc, char *argv[])
 {
+	odph_helper_options_t helper_options;
 	odph_odpthread_t *thread_tbl;
 	test_args_t args;
 	int num_workers;
@@ -811,6 +809,7 @@ int main(int argc, char *argv[])
 	odp_pool_param_t params;
 	int ret = 0;
 	odp_instance_t instance;
+	odp_init_t init_param;
 	odph_odpthread_params_t thr_params;
 	odp_queue_capability_t capa;
 	odp_pool_capability_t pool_capa;
@@ -818,11 +817,21 @@ int main(int argc, char *argv[])
 
 	printf("\nODP example starts\n\n");
 
+	/* Let helper collect its own arguments (e.g. --odph_proc) */
+	argc = odph_parse_options(argc, argv);
+	if (odph_options(&helper_options)) {
+		LOG_ERR("Error: reading ODP helper options failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
 	memset(&args, 0, sizeof(args));
 	parse_args(argc, argv, &args);
 
 	/* ODP global init */
-	if (odp_init_global(&instance, NULL, NULL)) {
+	if (odp_init_global(&instance, &init_param, NULL)) {
 		LOG_ERR("ODP global init failed.\n");
 		return -1;
 	}

--- a/test/validation/api/atomic/atomic.c
+++ b/test/validation/api/atomic/atomic.c
@@ -8,6 +8,7 @@
 
 #include <malloc.h>
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include <unistd.h>
@@ -554,8 +555,18 @@ static int atomic_init(odp_instance_t *inst)
 	uint32_t workers_count, max_threads;
 	int ret = 0;
 	odp_cpumask_t mask;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/barrier/barrier.c
+++ b/test/validation/api/barrier/barrier.c
@@ -8,6 +8,7 @@
 
 #include <malloc.h>
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include <unistd.h>
@@ -329,8 +330,18 @@ static int barrier_init(odp_instance_t *inst)
 	uint32_t workers_count, max_threads;
 	int ret = 0;
 	odp_cpumask_t mask;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/crypto/odp_crypto_test_inp.c
+++ b/test/validation/api/crypto/odp_crypto_test_inp.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include "test_vectors.h"
@@ -2029,8 +2030,18 @@ static int crypto_init(odp_instance_t *inst)
 	odp_pool_t pool;
 	odp_queue_t out_queue;
 	odp_pool_capability_t pool_capa;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/init/init_main_ok.c
+++ b/test/validation/api/init/init_main_ok.c
@@ -14,8 +14,12 @@ static void init_test_odp_init_global(void)
 {
 	int status;
 	odp_instance_t instance;
+	odp_init_t init_data;
 
-	status = odp_init_global(&instance, NULL, NULL);
+	odp_init_param_init(&init_data);
+	init_data.mem_model = ODP_MEM_MODEL_THREAD;
+
+	status = odp_init_global(&instance, &init_data, NULL);
 	CU_ASSERT_FATAL(status == 0);
 
 	status = odp_term_global(instance);

--- a/test/validation/api/ipsec/ipsec.c
+++ b/test/validation/api/ipsec/ipsec.c
@@ -906,8 +906,18 @@ int ipsec_init(odp_instance_t *inst)
 	odp_queue_t out_queue;
 	odp_pool_capability_t pool_capa;
 	odp_pktio_t pktio;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/lock/lock.c
+++ b/test/validation/api/lock/lock.c
@@ -8,6 +8,7 @@
 
 #include <malloc.h>
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <CUnit/Basic.h>
 #include <odp_cunit_common.h>
 #include <unistd.h>
@@ -1163,8 +1164,18 @@ static int lock_init(odp_instance_t *inst)
 	uint32_t workers_count, max_threads;
 	int ret = 0;
 	odp_cpumask_t mask;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/thread/thread.c
+++ b/test/validation/api/thread/thread.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include <odp_api.h>
+#include <odp/helper/odph_api.h>
 #include <odp_cunit_common.h>
 #include <mask_common.h>
 #include <test_debug.h>
@@ -24,8 +25,18 @@ static global_shared_mem_t *global_mem;
 static int thread_global_init(odp_instance_t *inst)
 {
 	odp_shm_t global_shm;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}

--- a/test/validation/api/timer/timer.c
+++ b/test/validation/api/timer/timer.c
@@ -61,8 +61,18 @@ static global_shared_mem_t *global_mem;
 static int timer_global_init(odp_instance_t *inst)
 {
 	odp_shm_t global_shm;
+	odp_init_t init_param;
+	odph_helper_options_t helper_options;
 
-	if (0 != odp_init_global(inst, NULL, NULL)) {
+	if (odph_options(&helper_options)) {
+		fprintf(stderr, "error: odph_options() failed.\n");
+		return -1;
+	}
+
+	odp_init_param_init(&init_param);
+	init_param.mem_model = helper_options.mem_model;
+
+	if (0 != odp_init_global(inst, &init_param, NULL)) {
 		fprintf(stderr, "error: odp_init_global() failed.\n");
 		return -1;
 	}


### PR DESCRIPTION
Enables an application to support process mode without the need to modify ODP configuration file.

New odph_options() helper function is added to enable an application to find out if ODP should be started in process mode.

V2:
- Clarify that handle/pointer sharing works only within an ODP instance (Bill)

V3:
- Add default value statement (Petri)
- Use odp_mem_model_t with helpers (Petri)