### PR TITLE
[PATCH v2] travis: define compiler for clang test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -231,7 +231,8 @@ jobs:
                               -e CC="${CC}"
                               ${DOCKER_NAMESPACE}/travis-odp-lng-ubuntu_16.04 /odp/scripts/ci/build_${ARCH}.sh
                 - stage: "build only"
-                  env: ARCH=x86_64 CC=clang
+                  env: ARCH=x86_64
+                  compiler: clang
                   install:
                           - true
                   script:


### PR DESCRIPTION
without specifying compiler CC falls back to default gcc
after it was initialized to clang. Current change forces
test to use clang.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>