### PR TITLE
[PATCH v2] configure: disable -march=native for clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -200,7 +200,12 @@ AC_ARG_ENABLE([abi-compat],
 	abi_compat=no
 	#if there is no ABI compatibility the .so numbers are meaningless
 	ODP_LIBSO_VERSION=0:0:0
-	ODP_CHECK_CFLAG([-march=native])
+	# do not try -march=native for clang due to possible failures on
+	# clang optimizations
+	$CC --version | grep -q clang
+	if test $? -ne 0; then
+		ODP_CHECK_CFLAG([-march=native])
+	fi
     fi])
 AM_CONDITIONAL(ODP_ABI_COMPAT, [test "x$ODP_ABI_COMPAT" = "x1"])
 


### PR DESCRIPTION
for clang we see strange optimizations for TM code which breaks
code flow execution. There might be number of such places. For
now it's better to disable march=native until we completely
test and validate clang support for this.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>