### PR TITLE
[PATCH v2] Update dpdk support to v18.11 level

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -164,7 +164,8 @@ Prerequisites for building the OpenDataPlane (ODP) API
 
 3.4 DPDK packet I/O support (optional)
 
-   Use DPDK for ODP packet I/O.
+   Use DPDK for ODP packet I/O. Currently supported DPDK versions are v17.11,
+   v18.02, v18.05 and v18.11.
 
    Note: only packet I/O is accelerated with DPDK. Use
         https://github.com/Linaro/odp-dpdk.git


### PR DESCRIPTION
I have build this with v17.11.4, v18.02.2, v18.05.1 and v18.11. Make check passed with v17.11 locally, v18.11 failed one validation/api/pktio/pktio_run_dpdk.sh test case. L2fwd worked with v17.11 and v18.11.

This should not be included into ODP v1.20 as more testing is needed (e.g. v17.11 and v18.11 with zero copy).

