### PR TITLE
[PATCH v1] linux-gen: netmap: update ring->head in netmap_recv_desc()

### DIFF
--- a/platform/linux-generic/pktio/netmap.c
+++ b/platform/linux-generic/pktio/netmap.c
@@ -842,8 +842,8 @@ static inline int netmap_recv_desc(pktio_entry_t *pktio_entry,
 					"B\n", ring->slot[slot_id].len);
 			}
 			ring->cur = nm_ring_next(ring, slot_id);
+			ring->head = ring->cur;
 		}
-		ring->head = ring->cur;
 		ring_id++;
 	}
 	desc->cur_rx_ring = ring_id;


### PR DESCRIPTION
Netmap function nm_ring_empty() implementation has been modified to use
ring->head instead of ring->cur.

Reported-by: Jari Mustajärvi <jari.mustajarvi@nokia-bell-labs.com>
Signed-off-by: Matias Elo <matias.elo@nokia.com>