### PR TITLE
[PATCH v1] linux-gen: socket_mmap: fix build with older clang versions

### DIFF
--- a/platform/linux-generic/pktio/socket_mmap.c
+++ b/platform/linux-generic/pktio/socket_mmap.c
@@ -103,9 +103,8 @@ static int set_pkt_sock_fanout_mmap(pkt_sock_mmap_t *const pkt_sock,
 union frame_map {
 	struct {
 		struct tpacket2_hdr ODP_ALIGNED(TPACKET_ALIGNMENT) tp_h;
-		struct sockaddr_ll
-			ODP_ALIGNED(TPACKET_ALIGN(sizeof(struct tpacket2_hdr)))
-			s_ll;
+		struct sockaddr_ll ODP_ALIGNED(TPACKET_ALIGN(sizeof(struct
+				tpacket2_hdr))) s_ll;
 	} *v2;
 
 	void *raw;


### PR DESCRIPTION
Olders clang versions (at least 3.4.2 used by CentOS) don't handle
frame_map.v2.s_ll definition properly and throw invalid error.

Signed-off-by: Matias Elo <matias.elo@nokia.com>