### PR TITLE
[PATCH v1] linux-gen: dpdk: add a fallback value for the number of numa nodes

### DIFF
--- a/platform/linux-generic/pktio/dpdk.c
+++ b/platform/linux-generic/pktio/dpdk.c
@@ -1197,7 +1197,11 @@ static int dpdk_pktio_init(void)
 	}
 
 	mem_str_len = snprintf(NULL, 0, "%d,", DPDK_MEMORY_MB);
+
+	/* numa_num_configured_nodes() may return 0 on some platforms */
 	numa_nodes = numa_num_configured_nodes();
+	if (numa_nodes <= 0)
+		numa_nodes = 1;
 
 	char mem_str[mem_str_len * numa_nodes];
 


### PR DESCRIPTION
numa_num_configured_nodes() may return 0 on some platforms. In that case
use 1 as a replacement value.

Signed-off-by: Matias Elo <matias.elo@nokia.com>